### PR TITLE
fix: show actual model names and reason in provider retry notice

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -1304,7 +1304,13 @@ export default function MainContent() {
               if (data.code === 'PROVIDER_RETRY') {
                 // Non-fatal — show a brief notification but keep listening
                 if (assistantMsgAdded) {
-                  dispatch(updateLastMessage({ providerRetry: true }));
+                  dispatch(updateLastMessage({
+                    providerRetry: {
+                      fromModel: data.fromModel || 'Unknown',
+                      toModel: data.toModel || 'Unknown',
+                      reason: data.reason || 'Retrying with a different model',
+                    },
+                  }));
                 }
               } else if (data.code === 'MONTHLY_CREDITS_EXHAUSTED') {
                 dispatch(setIsProcessing(false));

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -2373,7 +2373,12 @@ function ErrorCard({ error, onRetry, onSessionExpired, userPrompt }) {
   if (!isFatal) {
     return (
       <div className={styles.providerRetryNotice}>
-        <span>Switching to backup model...</span>
+        <span className={styles.providerRetryLabel}>
+          {error.fromModel || 'Unknown'} → {error.toModel || 'Unknown'}
+        </span>
+        <span className={styles.providerRetryReason}>
+          {error.reason || 'Retrying with a different model'}
+        </span>
       </div>
     );
   }
@@ -5213,7 +5218,10 @@ function Message({
       {/* Provider retry notice */}
       {!isUser && message.providerRetry && isStreaming && (
         <div className={styles.providerRetryNotice}>
-          <span>Switching to backup model...</span>
+          <span className={styles.providerRetryLabel}>
+            {message.providerRetry.fromModel} → {message.providerRetry.toModel}
+          </span>
+          <span className={styles.providerRetryReason}>{message.providerRetry.reason}</span>
         </div>
       )}
 

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -6323,18 +6323,39 @@
 .providerRetryNotice {
   display: flex;
   align-items: center;
+  gap: 8px;
   padding: 6px 12px;
   margin-bottom: 8px;
-  border-radius: 8px;
-  background-color: #fef3cd;
+  border-radius: 6px;
+  border-left: 3px solid var(--accent-color, #d97706);
+  background-color: var(--bg-secondary, #f7f0e6);
   font-size: 12px;
-  color: #856404;
+  color: var(--text-secondary, #6e6354);
   animation: messageFadeIn 0.3s ease;
 }
 
 [data-theme='dark'] .providerRetryNotice {
-  background-color: rgba(255, 193, 7, 0.12);
-  color: #ffc107;
+  background-color: rgba(217, 119, 6, 0.06);
+  border-left-color: var(--accent-color, #d97706);
+  color: var(--text-secondary, #a8a4a0);
+}
+
+.providerRetryLabel {
+  font-weight: 600;
+  color: var(--text-primary, #3d3528);
+  white-space: nowrap;
+}
+
+[data-theme='dark'] .providerRetryLabel {
+  color: var(--text-primary, #e8e4dd);
+}
+
+.providerRetryReason {
+  color: var(--text-secondary, #6e6354);
+}
+
+[data-theme='dark'] .providerRetryReason {
+  color: var(--text-secondary, #a8a4a0);
 }
 
 /* ===== Error Card ===== */


### PR DESCRIPTION
- Pass fromModel, toModel, and reason from PROVIDER_RETRY event to the message state instead of just a boolean flag
- Display "Model A → Model B" with the reason in both inline notice and ErrorCard
- Restyle notice to use Araviel colour scheme (accent border, theme variables) instead of generic yellow/amber colours

https://claude.ai/code/session_017sbsHGj1s5u6X8WXo5wLWU