### PR TITLE
feat: sources panel as third column, bigger model pill, remove cost

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -680,6 +680,7 @@ export default function MainContent() {
   const [isReporting, setIsReporting] = useState(false);
   const [isSubConvPanelOpen, setIsSubConvPanelOpen] = useState(false);
   const [isCodePanelOpen, setIsCodePanelOpen] = useState(false);
+  const [isSourcesPanelOpen, setIsSourcesPanelOpen] = useState(false);
   const [attachedFiles, setAttachedFiles] = useState([]);
   const [mobileFileSubmenu, setMobileFileSubmenu] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
@@ -1216,9 +1217,12 @@ export default function MainContent() {
               const statusMap = {
                 queued: 'Starting research...',
                 planning: 'Planning research...',
-                researching: data.sources > 0
-                  ? `Searching the web (${data.sources} source${data.sources !== 1 ? 's' : ''})...`
-                  : 'Searching the web...',
+                researching:
+                  data.sources > 0
+                    ? `Searching the web (${data.sources} source${
+                        data.sources !== 1 ? 's' : ''
+                      })...`
+                    : 'Searching the web...',
                 synthesizing: 'Synthesizing findings...',
               };
               const statusLabel = statusMap[data.status] || 'Researching...';
@@ -1372,13 +1376,15 @@ export default function MainContent() {
               if (data.code === 'PROVIDER_RETRY') {
                 // Non-fatal — show a brief notification but keep listening
                 if (assistantMsgAdded) {
-                  dispatch(updateLastMessage({
-                    providerRetry: {
-                      fromModel: data.fromModel || 'Unknown',
-                      toModel: data.toModel || 'Unknown',
-                      reason: data.reason || 'Retrying with a different model',
-                    },
-                  }));
+                  dispatch(
+                    updateLastMessage({
+                      providerRetry: {
+                        fromModel: data.fromModel || 'Unknown',
+                        toModel: data.toModel || 'Unknown',
+                        reason: data.reason || 'Retrying with a different model',
+                      },
+                    })
+                  );
                 }
               } else if (data.code === 'MONTHLY_CREDITS_EXHAUSTED') {
                 dispatch(setIsProcessing(false));
@@ -2047,14 +2053,21 @@ export default function MainContent() {
   // Build timeline stages
   const timelineStages =
     pipelineStatus !== 'idle'
-      ? createStages(pipelineStatus, routeResult ? routeResult.modelName : null, isManualRequest, researchProgress)
+      ? createStages(
+          pipelineStatus,
+          routeResult ? routeResult.modelName : null,
+          isManualRequest,
+          researchProgress
+        )
       : null;
 
   return (
     <main
       className={`${styles.main} ${hasMessages ? styles.hasMessages : ''} ${
         isSubConvPanelOpen ? styles.subConvPanelOpen : ''
-      } ${isCodePanelOpen ? styles.codePanelOpen : ''}`}
+      } ${isCodePanelOpen ? styles.codePanelOpen : ''} ${
+        isSourcesPanelOpen ? styles.sourcesPanelOpen : ''
+      }`}
     >
       {/* Top nav bar */}
       <div className={styles.topNav}>
@@ -2490,6 +2503,7 @@ export default function MainContent() {
           onAlternateModelRequest={handleAlternateModelRequest}
           onSubConvPanelToggle={setIsSubConvPanelOpen}
           onCodePanelToggle={setIsCodePanelOpen}
+          onSourcesPanelToggle={setIsSourcesPanelOpen}
           focusInput={focusInput}
           currentChatId={currentChatId}
           webSearchEnabled={webSearchEnabled}

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -30,6 +30,11 @@
   transition: margin-right 0.35s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+/* When sources panel is open, make room on the right (panel width + spacing) */
+.main.sourcesPanelOpen {
+  margin-right: 400px;
+}
+
 /* Top nav bar */
 .topNav {
   position: absolute;
@@ -2320,6 +2325,10 @@
   }
 
   .main.codePanelOpen {
+    margin-right: 0;
+  }
+
+  .main.sourcesPanelOpen {
     margin-right: 0;
   }
 

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -2065,9 +2065,6 @@ function UsageFooterInline({ message, isDark }) {
       });
     }
   }
-  if (message.costUsd != null) {
-    rows.push({ label: 'Cost', value: `$${message.costUsd.toFixed(4)}` });
-  }
   if (message.latencyMs != null) {
     const seconds = message.latencyMs / 1000;
     rows.push({
@@ -3720,30 +3717,9 @@ function SubConversationPills({ subConversations, onOpen, onDelete, activeSubCon
 
 /**
  * Inline sources pill — overlapping circular favicons + label.
- * Clicking opens a right-side floating panel matching the sub-conversation panel style.
+ * Clicking triggers the parent to open the sources panel.
  */
-function InlineSourcesDropdown({ citations }) {
-  const [isPanelOpen, setIsPanelOpen] = useState(false);
-  const panelRef = useRef(null);
-
-  useEffect(() => {
-    if (!isPanelOpen) return;
-    const handleClickOutside = (e) => {
-      if (panelRef.current && !panelRef.current.contains(e.target)) {
-        setIsPanelOpen(false);
-      }
-    };
-    const handleEsc = (e) => {
-      if (e.key === 'Escape') setIsPanelOpen(false);
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleEsc);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEsc);
-    };
-  }, [isPanelOpen]);
-
+function InlineSourcesDropdown({ citations, onOpen, isActive }) {
   if (!citations || citations.length === 0) return null;
 
   // Get unique favicons for the pill (max 3, deduplicated by domain)
@@ -3764,99 +3740,24 @@ function InlineSourcesDropdown({ citations }) {
   }
 
   return (
-    <>
-      <button
-        className={`${styles.sourcesPill} ${isPanelOpen ? styles.sourcesPillActive : ''}`}
-        onClick={() => setIsPanelOpen(!isPanelOpen)}
-        aria-expanded={isPanelOpen}
-      >
-        <span className={styles.sourcesPillFavicons}>
-          {pillFavicons.map((src, i) => (
-            <img
-              key={i}
-              src={src}
-              alt=""
-              className={styles.sourcesPillFavicon}
-              style={{ zIndex: pillFavicons.length - i }}
-            />
-          ))}
-        </span>
-        <span className={styles.sourcesPillLabel}>Sources</span>
-      </button>
-      {isPanelOpen &&
-        createPortal(
-          <div className={styles.sourcesPanel} ref={panelRef}>
-            <div className={styles.sourcesPanelHeader}>
-              <span className={styles.sourcesPanelTitle}>
-                {citations.length} source{citations.length !== 1 ? 's' : ''}
-              </span>
-              <button
-                className={styles.sourcesPanelClose}
-                onClick={() => setIsPanelOpen(false)}
-                aria-label="Close sources"
-              >
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
-                  <path
-                    d="M10.5 3.5L3.5 10.5M3.5 3.5l7 7"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div className={styles.sourcesPanelList}>
-              {citations.map((citation, idx) => {
-                let favicon = '';
-                let hostname = '';
-                let sourceName = '';
-                try {
-                  const url = new URL(citation.url);
-                  hostname = url.hostname.replace(/^www\./, '');
-                  favicon = `https://www.google.com/s2/favicons?domain=${url.hostname}&sz=32`;
-                  sourceName = hostname.split('.')[0];
-                  sourceName = sourceName.charAt(0).toUpperCase() + sourceName.slice(1);
-                } catch {
-                  // skip
-                }
-                return (
-                  <a
-                    key={idx}
-                    href={citation.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={styles.sourcesPanelItem}
-                  >
-                    <div className={styles.sourcesPanelItemIcon}>
-                      {favicon ? (
-                        <img src={favicon} alt="" className={styles.sourcesPanelFavicon} />
-                      ) : (
-                        <span className={styles.sourcesPanelItemNumber}>{idx + 1}</span>
-                      )}
-                    </div>
-                    <div className={styles.sourcesPanelItemContent}>
-                      <span className={styles.sourcesPanelItemSource}>
-                        {sourceName || hostname}
-                      </span>
-                      <span className={styles.sourcesPanelItemTitle}>
-                        {citation.title || citation.url}
-                      </span>
-                      {citation.snippet && (
-                        <span className={styles.sourcesPanelItemSnippet}>
-                          {citation.snippet.length > 150
-                            ? citation.snippet.slice(0, 150) + '...'
-                            : citation.snippet}
-                        </span>
-                      )}
-                    </div>
-                  </a>
-                );
-              })}
-            </div>
-          </div>,
-          document.body
-        )}
-    </>
+    <button
+      className={`${styles.sourcesPill} ${isActive ? styles.sourcesPillActive : ''}`}
+      onClick={() => onOpen(citations)}
+      aria-expanded={isActive}
+    >
+      <span className={styles.sourcesPillFavicons}>
+        {pillFavicons.map((src, i) => (
+          <img
+            key={i}
+            src={src}
+            alt=""
+            className={styles.sourcesPillFavicon}
+            style={{ zIndex: pillFavicons.length - i }}
+          />
+        ))}
+      </span>
+      <span className={styles.sourcesPillLabel}>Sources</span>
+    </button>
   );
 }
 
@@ -4093,6 +3994,8 @@ function ResponseActions({
   onSelectAlternate,
   assistantIndex,
   conversationId,
+  onOpenSourcesPanel,
+  isSourcesPanelOpen,
 }) {
   const [copied, setCopied] = useState(false);
   const [liked, setLiked] = useState(message.feedback === 'like');
@@ -4307,7 +4210,11 @@ function ResponseActions({
             )}
           </div>
         )}
-        <InlineSourcesDropdown citations={citations} />
+        <InlineSourcesDropdown
+          citations={citations}
+          onOpen={onOpenSourcesPanel}
+          isActive={isSourcesPanelOpen}
+        />
       </div>
 
       <div className={styles.responseActionsRight}>
@@ -5173,6 +5080,8 @@ function Message({
   onEditPrompt,
   onOpenCodePanel,
   webSearchEnabled,
+  onOpenSourcesPanel,
+  isSourcesPanelOpen,
 }) {
   const isUser = message.role === 'user';
   const displayText = isStreaming ? streamedText : message.content;
@@ -5765,6 +5674,8 @@ function Message({
           onSelectAlternate={(alt) => setPendingAlternate(alt)}
           assistantIndex={assistantIndex}
           conversationId={currentChatId}
+          onOpenSourcesPanel={onOpenSourcesPanel}
+          isSourcesPanelOpen={isSourcesPanelOpen}
         />
       )}
 
@@ -5818,6 +5729,87 @@ function Message({
 }
 
 /**
+ * Sources side panel — fixed right panel matching sub-conversation panel style.
+ * Renders as a third column alongside sidebar and conversation area.
+ */
+function SourcesSidePanel({ citations, onClose, panelRef }) {
+  useEffect(() => {
+    const handleEsc = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  return (
+    <div className={styles.sourcesPanel} ref={panelRef}>
+      <div className={styles.sourcesPanelHeader}>
+        <span className={styles.sourcesPanelTitle}>Sources</span>
+        <button className={styles.sourcesPanelClose} onClick={onClose} aria-label="Close sources">
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path
+              d="M10.5 3.5L3.5 10.5M3.5 3.5l7 7"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+      <div className={styles.sourcesPanelSubheader}>
+        {citations.length} source{citations.length !== 1 ? 's' : ''} found
+      </div>
+      <div className={styles.sourcesPanelList}>
+        {citations.map((citation, idx) => {
+          let favicon = '';
+          let hostname = '';
+          let sourceName = '';
+          try {
+            const url = new URL(citation.url);
+            hostname = url.hostname.replace(/^www\./, '');
+            favicon = `https://www.google.com/s2/favicons?domain=${url.hostname}&sz=32`;
+            sourceName = hostname.split('.')[0];
+            sourceName = sourceName.charAt(0).toUpperCase() + sourceName.slice(1);
+          } catch {
+            // skip
+          }
+          return (
+            <a
+              key={idx}
+              href={citation.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.sourcesPanelItem}
+            >
+              <div className={styles.sourcesPanelItemIcon}>
+                {favicon ? (
+                  <img src={favicon} alt="" className={styles.sourcesPanelFavicon} />
+                ) : (
+                  <span className={styles.sourcesPanelItemNumber}>{idx + 1}</span>
+                )}
+              </div>
+              <div className={styles.sourcesPanelItemContent}>
+                <span className={styles.sourcesPanelItemSource}>{sourceName || hostname}</span>
+                <span className={styles.sourcesPanelItemTitle}>
+                  {citation.title || citation.url}
+                </span>
+                {citation.snippet && (
+                  <span className={styles.sourcesPanelItemSnippet}>
+                    {citation.snippet.length > 150
+                      ? citation.snippet.slice(0, 150) + '...'
+                      : citation.snippet}
+                  </span>
+                )}
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
  * MessageList renders the full conversation including thinking timeline.
  */
 export default function MessageList({
@@ -5834,6 +5826,7 @@ export default function MessageList({
   onAlternateModelRequest,
   onSubConvPanelToggle,
   onCodePanelToggle,
+  onSourcesPanelToggle,
   focusInput,
   currentChatId,
   webSearchEnabled,
@@ -5852,6 +5845,9 @@ export default function MessageList({
 
   // Code side panel state (lifted up so it persists across messages)
   const [codePanelBlocks, setCodePanelBlocks] = useState(null);
+  // Sources panel state (lifted up so it renders as a third column)
+  const [sourcesPanelCitations, setSourcesPanelCitations] = useState(null);
+  const sourcesPanelRef = useRef(null);
   const prevChatIdRef = useRef(currentChatId);
 
   // Close code panel and sub-conversation panel when switching chats
@@ -5859,8 +5855,10 @@ export default function MessageList({
     if (prevChatIdRef.current !== currentChatId) {
       setCodePanelBlocks(null);
       setSubConvPanelOwnerId(null);
+      setSourcesPanelCitations(null);
       if (onCodePanelToggle) onCodePanelToggle(false);
       if (onSubConvPanelToggle) onSubConvPanelToggle(false);
+      if (onSourcesPanelToggle) onSourcesPanelToggle(false);
       document.documentElement.style.removeProperty('--code-panel-width');
       prevChatIdRef.current = currentChatId;
     }
@@ -5884,6 +5882,23 @@ export default function MessageList({
   const handleCodePanelWidthChange = useCallback((width) => {
     document.documentElement.style.setProperty('--code-panel-width', `${width}px`);
   }, []);
+
+  const handleOpenSourcesPanel = useCallback(
+    (citations) => {
+      // Toggle: if already open with same citations, close it
+      setSourcesPanelCitations((prev) => {
+        const shouldOpen = !prev;
+        if (onSourcesPanelToggle) onSourcesPanelToggle(shouldOpen);
+        return shouldOpen ? citations : null;
+      });
+    },
+    [onSourcesPanelToggle]
+  );
+
+  const handleCloseSourcesPanel = useCallback(() => {
+    setSourcesPanelCitations(null);
+    if (onSourcesPanelToggle) onSourcesPanelToggle(false);
+  }, [onSourcesPanelToggle]);
 
   // Track scroll position → show/hide scroll-to-bottom button.
   // Detect user-initiated scrolling during streaming via wheel/touch events only
@@ -6071,6 +6086,8 @@ export default function MessageList({
                 onEditPrompt={handleEditPrompt}
                 onOpenCodePanel={handleOpenCodePanel}
                 webSearchEnabled={webSearchEnabled}
+                onOpenSourcesPanel={handleOpenSourcesPanel}
+                isSourcesPanelOpen={!!sourcesPanelCitations}
               />
             </div>
           );
@@ -6111,6 +6128,15 @@ export default function MessageList({
           codeBlocks={codePanelBlocks}
           onClose={handleCloseCodePanel}
           onWidthChange={handleCodePanelWidthChange}
+        />
+      )}
+
+      {/* Sources side panel — third column */}
+      {sourcesPanelCitations && sourcesPanelCitations.length > 0 && (
+        <SourcesSidePanel
+          citations={sourcesPanelCitations}
+          onClose={handleCloseSourcesPanel}
+          panelRef={sourcesPanelRef}
         />
       )}
     </div>

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1370,14 +1370,14 @@
   cursor: pointer;
 }
 
-/* Small model pill in action bar */
+/* Model pill in action bar */
 .modelPillSmall {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  border-radius: 6px;
-  font-size: 11px;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: 8px;
+  font-size: 12.5px;
   font-weight: 600;
   line-height: 1.3;
   cursor: pointer;
@@ -1732,15 +1732,22 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 22px 22px 16px;
-  border-bottom: 1px solid var(--border-color);
+  padding: 22px 22px 8px;
   flex-shrink: 0;
 }
 
 .sourcesPanelTitle {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
   color: var(--text-primary);
+}
+
+.sourcesPanelSubheader {
+  padding: 0 22px 14px;
+  font-size: 12px;
+  font-weight: 450;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .sourcesPanelClose {
@@ -1852,7 +1859,7 @@
   margin-top: 1px;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .sourcesPanel {
     width: calc(100vw - 24px);
     max-width: calc(100vw - 24px);


### PR DESCRIPTION
- Sources panel now renders as a third column alongside sidebar and conversation area. When open, main content shifts left (margin-right: 400px) so users can still scroll and read responses. On mobile, panel overlays instead.
- Sources panel state lifted to MessageList level and toggled via onSourcesPanelToggle callback flowing up to MainContent, matching the sub-conversation panel pattern.
- Model pill made more prominent (12.5px font, 5px/10px padding, 8px radius) to visually align with the sources pill.
- Removed cost row from the info icon popup (UsageFooterInline).

https://claude.ai/code/session_01K93PCzKkR9WZBrpgRBeJdq