### PR TITLE
refactor: remove Speed option, soften error card colours

### DIFF
--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -6409,14 +6409,14 @@
   padding: 12px 16px;
   margin-top: 8px;
   border-radius: 10px;
-  background-color: #fff5f5;
-  border: 1px solid #fecaca;
+  background-color: #fdf5f1;
+  border: 1px solid #e6d3ca;
   animation: messageFadeIn 0.3s ease;
 }
 
 [data-theme='dark'] .errorCard {
-  background-color: rgba(239, 68, 68, 0.08);
-  border-color: rgba(239, 68, 68, 0.2);
+  background-color: rgba(180, 110, 90, 0.07);
+  border-color: rgba(180, 110, 90, 0.18);
 }
 
 .errorCardContent {
@@ -6429,12 +6429,12 @@
 
 .errorCardMessage {
   font-size: 13px;
-  color: #b91c1c;
+  color: #8b5c4e;
   line-height: 1.5;
 }
 
 [data-theme='dark'] .errorCardMessage {
-  color: #fca5a5;
+  color: #c9a097;
 }
 
 .errorSuggestedPlatforms {

--- a/src/components/ModelSelector/ModelSelector.jsx
+++ b/src/components/ModelSelector/ModelSelector.jsx
@@ -26,7 +26,6 @@ const FEATURED_MODEL_IDS_FREE = ['claude-haiku-4-5-20251001', 'gpt-5-mini', 'gem
 // Routing strategies shown as top-level options
 const ROUTING_OPTIONS = [
   { id: 'default', label: 'Auto', tagline: 'Best model for each task' },
-  { id: 'costEfficient', label: 'Speed', tagline: 'Fast and cost-efficient' },
   { id: 'taskBased', label: 'Balanced', tagline: 'Optimized for the task' },
   { id: 'humanFactors', label: 'Quality', tagline: 'Uses context, tone and mood' },
 ];

--- a/src/store/slices/chatSlice.js
+++ b/src/store/slices/chatSlice.js
@@ -25,7 +25,7 @@ const initialState = {
   webSearchEnabled: null, // null = Auto/let ADE decide, true = user toggled on, false = user toggled off
   tone: 'default', // 'default' | 'professional' | 'friendly' | 'candid' | 'quirky' | 'efficient' | 'cynical'
   mood: null, // null = not set, or: happy, neutral, stressed, frustrated, excited, tired, anxious, calm
-  autoStrategy: 'default', // 'default' | 'humanFactors' | 'costEfficient' | 'taskBased'
+  autoStrategy: 'default', // 'default' | 'taskBased' | 'humanFactors'
   currentChatId: null, // current conversationId from backend
   isProcessing: false,
   pendingAutoSubmit: false, // when true, MainContent auto-fires the inputValue on mount
@@ -96,7 +96,7 @@ const chatSlice = createSlice({
       state.mood = action.payload; // null | string
     },
     setAutoStrategy: (state, action) => {
-      state.autoStrategy = action.payload; // 'default' | 'humanFactors' | 'costEfficient' | 'taskBased'
+      state.autoStrategy = action.payload; // 'default' | 'taskBased' | 'humanFactors'
     },
     addMessage: (state, action) => {
       state.messages.push(action.payload);


### PR DESCRIPTION
- Remove Speed from ROUTING_OPTIONS — only Auto, Balanced, Quality remain
- Update chatSlice comments to reflect valid strategies
- Soften error card colours to warm terracotta tones that blend with Araviel's sand (light) and charcoal (dark) colour schemes instead of harsh bright red

https://claude.ai/code/session_01MuLXYBZbWLXWT5yJkGFYSH