### PR TITLE
Add comprehensive frontend test suite (377 tests across 16 files)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint:fix": "eslint . --ext .js,.jsx --fix",
     "format": "prettier --write .",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -31,6 +33,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
@@ -42,9 +47,11 @@
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.11.0",
     "husky": "^8.0.3",
+    "jsdom": "^29.0.1",
     "lint-staged": "^13.3.0",
     "prettier": "^2.8.8",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "vitest": "^4.1.2"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/config/credits.test.js
+++ b/src/config/credits.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TIER_TEXT_CREDITS,
+  TIER_IMAGE_CREDITS,
+  IMAGE_QUALITY_COSTS,
+  IMAGE_QUALITY_OPTIONS,
+  IMAGE_PACKS,
+  PACK_EXPIRY_DAYS,
+  GUEST_TEXT_LIMIT,
+  GUEST_IMAGE_LIMIT,
+} from './credits';
+
+describe('credits config', () => {
+  describe('TIER_TEXT_CREDITS', () => {
+    it('defines credits for free, lite, and pro tiers', () => {
+      expect(TIER_TEXT_CREDITS.free).toBeDefined();
+      expect(TIER_TEXT_CREDITS.lite).toBeDefined();
+      expect(TIER_TEXT_CREDITS.pro).toBeDefined();
+    });
+
+    it('each tier has monthly, window, and firstMonthBonus', () => {
+      for (const tier of Object.values(TIER_TEXT_CREDITS)) {
+        expect(typeof tier.monthly).toBe('number');
+        expect(typeof tier.window).toBe('number');
+        expect(typeof tier.firstMonthBonus).toBe('number');
+      }
+    });
+
+    it('free tier has lower credits than lite, lite lower than pro', () => {
+      expect(TIER_TEXT_CREDITS.free.monthly).toBeLessThan(TIER_TEXT_CREDITS.lite.monthly);
+      expect(TIER_TEXT_CREDITS.lite.monthly).toBeLessThan(TIER_TEXT_CREDITS.pro.monthly);
+    });
+
+    it('free tier has no first month bonus', () => {
+      expect(TIER_TEXT_CREDITS.free.firstMonthBonus).toBe(0);
+    });
+  });
+
+  describe('TIER_IMAGE_CREDITS', () => {
+    it('scales with tier level', () => {
+      expect(TIER_IMAGE_CREDITS.free).toBeLessThan(TIER_IMAGE_CREDITS.lite);
+      expect(TIER_IMAGE_CREDITS.lite).toBeLessThan(TIER_IMAGE_CREDITS.pro);
+    });
+  });
+
+  describe('IMAGE_QUALITY_COSTS', () => {
+    it('standard costs 1 credit', () => {
+      expect(IMAGE_QUALITY_COSTS.standard).toBe(1);
+    });
+
+    it('hd costs more than standard', () => {
+      expect(IMAGE_QUALITY_COSTS.hd).toBeGreaterThan(IMAGE_QUALITY_COSTS.standard);
+    });
+
+    it('ultra costs more than hd', () => {
+      expect(IMAGE_QUALITY_COSTS.ultra).toBeGreaterThan(IMAGE_QUALITY_COSTS.hd);
+    });
+  });
+
+  describe('IMAGE_QUALITY_OPTIONS', () => {
+    it('has 3 quality options', () => {
+      expect(IMAGE_QUALITY_OPTIONS).toHaveLength(3);
+    });
+
+    it('each option has value, label, and cost', () => {
+      for (const option of IMAGE_QUALITY_OPTIONS) {
+        expect(option.value).toBeDefined();
+        expect(option.label).toBeDefined();
+        expect(typeof option.cost).toBe('number');
+      }
+    });
+
+    it('option costs match IMAGE_QUALITY_COSTS', () => {
+      for (const option of IMAGE_QUALITY_OPTIONS) {
+        expect(option.cost).toBe(IMAGE_QUALITY_COSTS[option.value]);
+      }
+    });
+  });
+
+  describe('IMAGE_PACKS', () => {
+    it('defines starter, creator, and studio packs', () => {
+      expect(IMAGE_PACKS.starter).toBeDefined();
+      expect(IMAGE_PACKS.creator).toBeDefined();
+      expect(IMAGE_PACKS.studio).toBeDefined();
+    });
+
+    it('each pack has credits, label, and price', () => {
+      for (const pack of Object.values(IMAGE_PACKS)) {
+        expect(typeof pack.credits).toBe('number');
+        expect(typeof pack.label).toBe('string');
+        expect(typeof pack.price).toBe('string');
+      }
+    });
+
+    it('pack credits scale up', () => {
+      expect(IMAGE_PACKS.starter.credits).toBeLessThan(IMAGE_PACKS.creator.credits);
+      expect(IMAGE_PACKS.creator.credits).toBeLessThan(IMAGE_PACKS.studio.credits);
+    });
+  });
+
+  describe('constants', () => {
+    it('PACK_EXPIRY_DAYS is 90', () => {
+      expect(PACK_EXPIRY_DAYS).toBe(90);
+    });
+
+    it('GUEST_TEXT_LIMIT is 3', () => {
+      expect(GUEST_TEXT_LIMIT).toBe(3);
+    });
+
+    it('GUEST_IMAGE_LIMIT is 0', () => {
+      expect(GUEST_IMAGE_LIMIT).toBe(0);
+    });
+  });
+});

--- a/src/config/subscription.test.js
+++ b/src/config/subscription.test.js
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SubscriptionTier,
+  FeatureCategory,
+  ModelAccessLevel,
+  SUBSCRIPTION_TIERS,
+  COMPARISON_FEATURES,
+  TIER_ORDER,
+  getAvailableTiers,
+  getTierById,
+  getDisplayPrice,
+  getAnnualSavings,
+  isUpgrade,
+  isDowngrade,
+  getProjectLimit,
+  getNextTier,
+} from './subscription';
+
+describe('subscription config', () => {
+  describe('SubscriptionTier enum', () => {
+    it('contains all 5 tiers', () => {
+      expect(SubscriptionTier.Free).toBe('free');
+      expect(SubscriptionTier.Lite).toBe('lite');
+      expect(SubscriptionTier.Pro).toBe('pro');
+      expect(SubscriptionTier.Ultra).toBe('ultra');
+      expect(SubscriptionTier.Apex).toBe('apex');
+    });
+  });
+
+  describe('FeatureCategory enum', () => {
+    it('has all categories', () => {
+      expect(FeatureCategory.Models).toBe('Models');
+      expect(FeatureCategory.Credits).toBe('Credits & Usage');
+      expect(FeatureCategory.ADE).toBe('ADE Routing');
+      expect(FeatureCategory.Features).toBe('Features');
+    });
+  });
+
+  describe('ModelAccessLevel enum', () => {
+    it('has all access levels', () => {
+      expect(ModelAccessLevel.Budget).toBe('budget');
+      expect(ModelAccessLevel.MidTier).toBe('mid_tier');
+      expect(ModelAccessLevel.Flagship).toBe('flagship');
+      expect(ModelAccessLevel.FlagshipPlus).toBe('flagship_plus');
+    });
+  });
+
+  describe('SUBSCRIPTION_TIERS', () => {
+    it('contains exactly 5 tiers', () => {
+      expect(SUBSCRIPTION_TIERS).toHaveLength(5);
+    });
+
+    it('each tier has required properties', () => {
+      for (const tier of SUBSCRIPTION_TIERS) {
+        expect(tier.id).toBeDefined();
+        expect(tier.name).toBeDefined();
+        expect(tier.tagline).toBeDefined();
+        expect(typeof tier.monthlyPrice).toBe('number');
+        expect(typeof tier.annualPricePerMonth).toBe('number');
+        expect(tier.currency).toBe('GBP');
+        expect(typeof tier.monthlyTextCredits).toBe('number');
+        expect(typeof tier.monthlyImageCredits).toBe('number');
+        expect(Array.isArray(tier.features)).toBe(true);
+        expect(tier.features.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('free tier has price of 0', () => {
+      const free = SUBSCRIPTION_TIERS.find((t) => t.id === 'free');
+      expect(free.monthlyPrice).toBe(0);
+      expect(free.annualPricePerMonth).toBe(0);
+    });
+
+    it('annual price is always less than or equal to monthly', () => {
+      for (const tier of SUBSCRIPTION_TIERS) {
+        expect(tier.annualPricePerMonth).toBeLessThanOrEqual(tier.monthlyPrice);
+      }
+    });
+  });
+
+  describe('TIER_ORDER', () => {
+    it('orders tiers from lowest to highest', () => {
+      expect(TIER_ORDER).toEqual(['free', 'lite', 'pro', 'ultra', 'apex']);
+    });
+  });
+
+  describe('COMPARISON_FEATURES', () => {
+    it('has features with name and category', () => {
+      for (const feature of COMPARISON_FEATURES) {
+        expect(typeof feature.name).toBe('string');
+        expect(typeof feature.category).toBe('string');
+      }
+    });
+  });
+
+  describe('getAvailableTiers', () => {
+    it('returns only tiers marked as available', () => {
+      const available = getAvailableTiers();
+      for (const tier of available) {
+        expect(tier.available).toBe(true);
+      }
+    });
+
+    it('includes free, lite, and pro', () => {
+      const ids = getAvailableTiers().map((t) => t.id);
+      expect(ids).toContain('free');
+      expect(ids).toContain('lite');
+      expect(ids).toContain('pro');
+    });
+
+    it('excludes ultra and apex', () => {
+      const ids = getAvailableTiers().map((t) => t.id);
+      expect(ids).not.toContain('ultra');
+      expect(ids).not.toContain('apex');
+    });
+  });
+
+  describe('getTierById', () => {
+    it('returns the correct tier for a valid id', () => {
+      const lite = getTierById('lite');
+      expect(lite.id).toBe('lite');
+      expect(lite.name).toBe('Lite');
+    });
+
+    it('returns undefined for an invalid id', () => {
+      expect(getTierById('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('getDisplayPrice', () => {
+    it('returns 0 for free tier', () => {
+      const free = getTierById('free');
+      expect(getDisplayPrice(free, 'monthly')).toBe(0);
+      expect(getDisplayPrice(free, 'annual')).toBe(0);
+    });
+
+    it('returns monthly price for monthly billing', () => {
+      const lite = getTierById('lite');
+      expect(getDisplayPrice(lite, 'monthly')).toBe(lite.monthlyPrice);
+    });
+
+    it('returns annual price per month for annual billing', () => {
+      const lite = getTierById('lite');
+      expect(getDisplayPrice(lite, 'annual')).toBe(lite.annualPricePerMonth);
+    });
+  });
+
+  describe('getAnnualSavings', () => {
+    it('returns 0 for free tier', () => {
+      const free = getTierById('free');
+      expect(getAnnualSavings(free)).toBe(0);
+    });
+
+    it('returns a positive savings percentage for paid tiers', () => {
+      const lite = getTierById('lite');
+      const savings = getAnnualSavings(lite);
+      expect(savings).toBeGreaterThan(0);
+      expect(savings).toBeLessThan(100);
+    });
+
+    it('returns a rounded integer', () => {
+      const pro = getTierById('pro');
+      const savings = getAnnualSavings(pro);
+      expect(Number.isInteger(savings)).toBe(true);
+    });
+  });
+
+  describe('isUpgrade', () => {
+    it('free to lite is an upgrade', () => {
+      expect(isUpgrade('free', 'lite')).toBe(true);
+    });
+
+    it('free to pro is an upgrade', () => {
+      expect(isUpgrade('free', 'pro')).toBe(true);
+    });
+
+    it('pro to free is not an upgrade', () => {
+      expect(isUpgrade('pro', 'free')).toBe(false);
+    });
+
+    it('same tier is not an upgrade', () => {
+      expect(isUpgrade('lite', 'lite')).toBe(false);
+    });
+  });
+
+  describe('isDowngrade', () => {
+    it('pro to free is a downgrade', () => {
+      expect(isDowngrade('pro', 'free')).toBe(true);
+    });
+
+    it('free to pro is not a downgrade', () => {
+      expect(isDowngrade('free', 'pro')).toBe(false);
+    });
+
+    it('same tier is not a downgrade', () => {
+      expect(isDowngrade('lite', 'lite')).toBe(false);
+    });
+  });
+
+  describe('getProjectLimit', () => {
+    it('free tier has limit of 1', () => {
+      expect(getProjectLimit('free')).toBe(1);
+    });
+
+    it('lite tier has limit of 4', () => {
+      expect(getProjectLimit('lite')).toBe(4);
+    });
+
+    it('pro tier has unlimited projects', () => {
+      expect(getProjectLimit('pro')).toBe(Infinity);
+    });
+
+    it('defaults to 1 for unknown tier', () => {
+      expect(getProjectLimit('nonexistent')).toBe(1);
+    });
+  });
+
+  describe('getNextTier', () => {
+    it('free upgrades to lite', () => {
+      expect(getNextTier('free')).toBe('lite');
+    });
+
+    it('lite upgrades to pro', () => {
+      expect(getNextTier('lite')).toBe('pro');
+    });
+
+    it('pro has no next tier', () => {
+      expect(getNextTier('pro')).toBeNull();
+    });
+
+    it('unknown tier returns null', () => {
+      expect(getNextTier('nonexistent')).toBeNull();
+    });
+  });
+});

--- a/src/data/models.test.js
+++ b/src/data/models.test.js
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MODELS,
+  PROVIDERS,
+  ACCESS_TIERS,
+  PROVIDER_ORDER,
+  SPEED_TIERS,
+  formatTokens,
+  formatPricePerM,
+  getModelsByProvider,
+  getModelsForTier,
+  isModelAccessible,
+  isImageGenerationModel,
+  getUpgradeModels,
+  getProOnlyModels,
+} from './models';
+
+describe('models data', () => {
+  describe('PROVIDERS', () => {
+    it('defines all 6 providers', () => {
+      expect(Object.keys(PROVIDERS)).toHaveLength(6);
+      expect(PROVIDERS.anthropic).toBeDefined();
+      expect(PROVIDERS.openai).toBeDefined();
+      expect(PROVIDERS.google).toBeDefined();
+      expect(PROVIDERS.xai).toBeDefined();
+      expect(PROVIDERS.perplexity).toBeDefined();
+      expect(PROVIDERS.elevenlabs).toBeDefined();
+    });
+
+    it('each provider has required properties', () => {
+      for (const provider of Object.values(PROVIDERS)) {
+        expect(provider.id).toBeDefined();
+        expect(provider.name).toBeDefined();
+        expect(provider.logoChar).toBeDefined();
+        expect(provider.accentColor).toBeDefined();
+      }
+    });
+  });
+
+  describe('ACCESS_TIERS', () => {
+    it('defines free, lite, and pro', () => {
+      expect(ACCESS_TIERS.free).toBe('free');
+      expect(ACCESS_TIERS.lite).toBe('lite');
+      expect(ACCESS_TIERS.pro).toBe('pro');
+    });
+  });
+
+  describe('MODELS', () => {
+    it('contains models', () => {
+      expect(MODELS.length).toBeGreaterThan(0);
+    });
+
+    it('each model has required properties', () => {
+      for (const model of MODELS) {
+        expect(model.id).toBeDefined();
+        expect(model.name).toBeDefined();
+        expect(model.provider).toBeDefined();
+        expect(PROVIDERS[model.provider]).toBeDefined();
+        expect(model.pricing).toBeDefined();
+        expect(model.accessTier).toBeDefined();
+        expect(typeof model.creditCost).toBe('number');
+      }
+    });
+
+    it('every model references a valid provider', () => {
+      for (const model of MODELS) {
+        expect(Object.keys(PROVIDERS)).toContain(model.provider);
+      }
+    });
+
+    it('every model has a valid access tier', () => {
+      const validTiers = Object.values(ACCESS_TIERS);
+      for (const model of MODELS) {
+        expect(validTiers).toContain(model.accessTier);
+      }
+    });
+
+    it('every model has a valid speed tier', () => {
+      const validSpeeds = Object.keys(SPEED_TIERS);
+      for (const model of MODELS) {
+        expect(validSpeeds).toContain(model.speedTier);
+      }
+    });
+  });
+
+  describe('PROVIDER_ORDER', () => {
+    it('lists all 6 providers', () => {
+      expect(PROVIDER_ORDER).toHaveLength(6);
+      for (const id of PROVIDER_ORDER) {
+        expect(PROVIDERS[id]).toBeDefined();
+      }
+    });
+  });
+
+  describe('formatTokens', () => {
+    it('formats millions', () => {
+      expect(formatTokens(1000000)).toBe('1M');
+      expect(formatTokens(2500000)).toBe('2.5M');
+    });
+
+    it('formats thousands', () => {
+      expect(formatTokens(1000)).toBe('1K');
+      expect(formatTokens(128000)).toBe('128K');
+      expect(formatTokens(200000)).toBe('200K');
+    });
+
+    it('formats small numbers directly', () => {
+      expect(formatTokens(500)).toBe('500');
+      expect(formatTokens(0)).toBe('0');
+    });
+  });
+
+  describe('formatPricePerM', () => {
+    it('formats very small prices with 4 decimals', () => {
+      expect(formatPricePerM(0.000005)).toBe('$0.0050');
+    });
+
+    it('formats sub-dollar prices with 3 decimals', () => {
+      expect(formatPricePerM(0.0003)).toBe('$0.300');
+    });
+
+    it('formats dollar+ prices with 2 decimals', () => {
+      expect(formatPricePerM(0.005)).toBe('$5.00');
+      expect(formatPricePerM(0.025)).toBe('$25.00');
+    });
+  });
+
+  describe('getModelsByProvider', () => {
+    it('groups models by provider', () => {
+      const grouped = getModelsByProvider();
+      for (const providerId of Object.keys(grouped)) {
+        expect(PROVIDER_ORDER).toContain(providerId);
+        for (const model of grouped[providerId]) {
+          expect(model.provider).toBe(providerId);
+        }
+      }
+    });
+
+    it('accepts a custom model list', () => {
+      const subset = MODELS.filter((m) => m.provider === 'anthropic');
+      const grouped = getModelsByProvider(subset);
+      expect(Object.keys(grouped)).toEqual(['anthropic']);
+    });
+
+    it('omits providers with no models', () => {
+      const grouped = getModelsByProvider([]);
+      expect(Object.keys(grouped)).toHaveLength(0);
+    });
+  });
+
+  describe('getModelsForTier', () => {
+    it('pro tier returns all models', () => {
+      const proModels = getModelsForTier('pro');
+      expect(proModels).toHaveLength(MODELS.length);
+    });
+
+    it('lite tier excludes pro-only models', () => {
+      const liteModels = getModelsForTier('lite');
+      for (const model of liteModels) {
+        expect(model.accessTier).not.toBe('pro');
+      }
+    });
+
+    it('free tier returns only free models', () => {
+      const freeModels = getModelsForTier('free');
+      for (const model of freeModels) {
+        expect(model.accessTier).toBe('free');
+      }
+    });
+
+    it('tier sizes are ordered: free <= lite <= pro', () => {
+      const freeCount = getModelsForTier('free').length;
+      const liteCount = getModelsForTier('lite').length;
+      const proCount = getModelsForTier('pro').length;
+      expect(freeCount).toBeLessThanOrEqual(liteCount);
+      expect(liteCount).toBeLessThanOrEqual(proCount);
+    });
+  });
+
+  describe('isModelAccessible', () => {
+    it('returns false for nonexistent model', () => {
+      expect(isModelAccessible('nonexistent', 'pro')).toBe(false);
+    });
+
+    it('pro tier can access any model', () => {
+      for (const model of MODELS) {
+        expect(isModelAccessible(model.id, 'pro')).toBe(true);
+      }
+    });
+
+    it('free tier can only access free models', () => {
+      for (const model of MODELS) {
+        if (model.accessTier === 'free') {
+          expect(isModelAccessible(model.id, 'free')).toBe(true);
+        } else {
+          expect(isModelAccessible(model.id, 'free')).toBe(false);
+        }
+      }
+    });
+
+    it('lite tier cannot access pro models', () => {
+      const proModels = MODELS.filter((m) => m.accessTier === 'pro');
+      for (const model of proModels) {
+        expect(isModelAccessible(model.id, 'lite')).toBe(false);
+      }
+    });
+  });
+
+  describe('isImageGenerationModel', () => {
+    it('returns false for nonexistent model', () => {
+      expect(isImageGenerationModel('nonexistent')).toBeFalsy();
+    });
+
+    it('returns false for text-only models', () => {
+      const textModel = MODELS.find((m) => !m.capabilities?.imageGeneration);
+      if (textModel) {
+        expect(isImageGenerationModel(textModel.id)).toBeFalsy();
+      }
+    });
+
+    it('returns true for image generation models', () => {
+      const imgModel = MODELS.find((m) => m.capabilities?.imageGeneration === true);
+      if (imgModel) {
+        expect(isImageGenerationModel(imgModel.id)).toBe(true);
+      }
+    });
+  });
+
+  describe('getUpgradeModels', () => {
+    it('pro tier has no upgrade models', () => {
+      expect(getUpgradeModels('pro')).toHaveLength(0);
+    });
+
+    it('free tier sees lite and pro models as upgrades', () => {
+      const upgrades = getUpgradeModels('free');
+      for (const model of upgrades) {
+        expect(model.accessTier).not.toBe('free');
+      }
+      expect(upgrades.length).toBeGreaterThan(0);
+    });
+
+    it('lite tier sees only pro models as upgrades', () => {
+      const upgrades = getUpgradeModels('lite');
+      for (const model of upgrades) {
+        expect(model.accessTier).toBe('pro');
+      }
+    });
+  });
+
+  describe('getProOnlyModels', () => {
+    it('is an alias for getUpgradeModels("free")', () => {
+      expect(getProOnlyModels()).toEqual(getUpgradeModels('free'));
+    });
+  });
+
+  describe('SPEED_TIERS', () => {
+    it('defines fast, balanced, and powerful', () => {
+      expect(SPEED_TIERS.fast).toBeDefined();
+      expect(SPEED_TIERS.balanced).toBeDefined();
+      expect(SPEED_TIERS.powerful).toBeDefined();
+    });
+
+    it('each speed tier has label and description', () => {
+      for (const tier of Object.values(SPEED_TIERS)) {
+        expect(typeof tier.label).toBe('string');
+        expect(typeof tier.description).toBe('string');
+      }
+    });
+  });
+});

--- a/src/services/analytics.test.js
+++ b/src/services/analytics.test.js
@@ -1,0 +1,398 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterByPeriod,
+  computeOverviewFromLifetime,
+  computeUsageTrend,
+  computeCostTrend,
+  computeModelBreakdown,
+  computeProviderBreakdown,
+  computeWeekdayFrequency,
+  computeHourlyActivity,
+  computeLatencyByModel,
+  computeTopicAnalysis,
+  getLevel,
+  computeBudgetStatus,
+  computePeriodCounts,
+  getMostActiveHour,
+  getTopModel,
+  getTopProvider,
+} from './analytics';
+
+// Helper: create a date key in YYYY-MM-DD format
+function dateKey(daysAgo = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+const sampleDailyUsage = {
+  [dateKey(0)]: { messages: 10, cost: 0.5, inputTokens: 1000, outputTokens: 2000 },
+  [dateKey(1)]: { messages: 5, cost: 0.3, inputTokens: 500, outputTokens: 1000 },
+  [dateKey(5)]: { messages: 8, cost: 0.4, inputTokens: 800, outputTokens: 1600 },
+  [dateKey(15)]: { messages: 3, cost: 0.1, inputTokens: 300, outputTokens: 600 },
+  [dateKey(40)]: { messages: 2, cost: 0.05, inputTokens: 200, outputTokens: 400 },
+};
+
+describe('analytics service', () => {
+  describe('filterByPeriod', () => {
+    it('filters for today only', () => {
+      const result = filterByPeriod(sampleDailyUsage, 'today');
+      const keys = Object.keys(result);
+      expect(keys).toHaveLength(1);
+      expect(keys[0]).toBe(dateKey(0));
+    });
+
+    it('filters for the past week', () => {
+      const result = filterByPeriod(sampleDailyUsage, 'week');
+      const keys = Object.keys(result);
+      // Should include today, 1 day ago, 5 days ago
+      expect(keys.length).toBeGreaterThanOrEqual(2);
+      expect(keys.length).toBeLessThanOrEqual(4);
+    });
+
+    it('filters for the past month', () => {
+      const result = filterByPeriod(sampleDailyUsage, 'month');
+      const keys = Object.keys(result);
+      expect(keys.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('returns all data for "all" period', () => {
+      const result = filterByPeriod(sampleDailyUsage, 'all');
+      expect(Object.keys(result)).toHaveLength(Object.keys(sampleDailyUsage).length);
+    });
+
+    it('returns empty object when today has no data', () => {
+      const result = filterByPeriod({}, 'today');
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+  });
+
+  describe('computeOverviewFromLifetime', () => {
+    const stats = {
+      dailyUsage: sampleDailyUsage,
+      modelUsage: { 'model-a': 10, 'model-b': 5 },
+      providerUsage: { anthropic: 8, openai: 7 },
+      latencySum: 5000,
+      latencyCount: 10,
+    };
+
+    it('computes totals for all periods', () => {
+      const overview = computeOverviewFromLifetime(stats, 'all');
+      expect(overview.totalMessages).toBe(28);
+      expect(overview.totalCost).toBeCloseTo(1.35, 2);
+      expect(overview.totalInputTokens).toBe(2800);
+      expect(overview.totalOutputTokens).toBe(5600);
+      expect(overview.totalTokens).toBe(8400);
+    });
+
+    it('computes average latency', () => {
+      const overview = computeOverviewFromLifetime(stats, 'all');
+      expect(overview.avgLatency).toBe(500);
+    });
+
+    it('counts unique models and providers', () => {
+      const overview = computeOverviewFromLifetime(stats, 'all');
+      expect(overview.uniqueModels).toBe(2);
+      expect(overview.uniqueProviders).toBe(2);
+    });
+
+    it('counts active days', () => {
+      const overview = computeOverviewFromLifetime(stats, 'all');
+      expect(overview.activeDays).toBe(5);
+    });
+
+    it('returns 0 latency when no latency data', () => {
+      const noLatency = { ...stats, latencySum: 0, latencyCount: 0 };
+      const overview = computeOverviewFromLifetime(noLatency, 'all');
+      expect(overview.avgLatency).toBe(0);
+    });
+  });
+
+  describe('computeUsageTrend', () => {
+    it('returns sorted trend data', () => {
+      const trend = computeUsageTrend(sampleDailyUsage, 'all');
+      expect(trend.length).toBe(5);
+      for (let i = 1; i < trend.length; i++) {
+        expect(trend[i].date >= trend[i - 1].date).toBe(true);
+      }
+    });
+
+    it('each entry has date, input, output', () => {
+      const trend = computeUsageTrend(sampleDailyUsage, 'all');
+      for (const entry of trend) {
+        expect(entry.date).toBeDefined();
+        expect(typeof entry.input).toBe('number');
+        expect(typeof entry.output).toBe('number');
+      }
+    });
+  });
+
+  describe('computeCostTrend', () => {
+    it('returns cumulative cost', () => {
+      const trend = computeCostTrend(sampleDailyUsage, 'all');
+      for (let i = 1; i < trend.length; i++) {
+        expect(trend[i].cost).toBeGreaterThanOrEqual(trend[i - 1].cost);
+      }
+    });
+
+    it('last entry has total cost', () => {
+      const trend = computeCostTrend(sampleDailyUsage, 'all');
+      const last = trend[trend.length - 1];
+      expect(last.cost).toBeCloseTo(1.35, 2);
+    });
+  });
+
+  describe('computeModelBreakdown', () => {
+    it('returns sorted breakdown by count', () => {
+      const breakdown = computeModelBreakdown({ 'claude-sonnet-4-6': 10, 'gpt-4o': 5 });
+      expect(breakdown[0].count).toBeGreaterThanOrEqual(breakdown[1].count);
+    });
+
+    it('handles empty usage', () => {
+      expect(computeModelBreakdown({})).toHaveLength(0);
+      expect(computeModelBreakdown(null)).toHaveLength(0);
+    });
+
+    it('entries have required fields', () => {
+      const breakdown = computeModelBreakdown({ 'claude-sonnet-4-6': 5 });
+      expect(breakdown[0].modelId).toBe('claude-sonnet-4-6');
+      expect(breakdown[0].count).toBe(5);
+      expect(breakdown[0].name).toBeDefined();
+    });
+  });
+
+  describe('computeProviderBreakdown', () => {
+    it('returns sorted breakdown by value', () => {
+      const breakdown = computeProviderBreakdown({ anthropic: 10, openai: 20 });
+      expect(breakdown[0].value).toBeGreaterThanOrEqual(breakdown[1].value);
+      expect(breakdown[0].providerId).toBe('openai');
+    });
+
+    it('handles empty usage', () => {
+      expect(computeProviderBreakdown({})).toHaveLength(0);
+      expect(computeProviderBreakdown(null)).toHaveLength(0);
+    });
+  });
+
+  describe('computeWeekdayFrequency', () => {
+    it('returns 7 entries for each day of the week', () => {
+      const freq = computeWeekdayFrequency(sampleDailyUsage);
+      expect(freq).toHaveLength(7);
+      expect(freq[0].day).toBe('Sun');
+      expect(freq[6].day).toBe('Sat');
+    });
+
+    it('handles empty usage', () => {
+      const freq = computeWeekdayFrequency({});
+      expect(freq).toHaveLength(7);
+      for (const entry of freq) {
+        expect(entry.messages).toBe(0);
+      }
+    });
+  });
+
+  describe('computeHourlyActivity', () => {
+    it('returns 24 entries', () => {
+      const activity = computeHourlyActivity({ '0': 5, '12': 10, '23': 3 });
+      expect(activity).toHaveLength(24);
+    });
+
+    it('maps hourly data correctly', () => {
+      const activity = computeHourlyActivity({ '12': 10 });
+      expect(activity[12].messages).toBe(10);
+      expect(activity[0].messages).toBe(0);
+    });
+
+    it('handles empty usage', () => {
+      const activity = computeHourlyActivity({});
+      expect(activity).toHaveLength(24);
+      for (const entry of activity) {
+        expect(entry.messages).toBe(0);
+      }
+    });
+  });
+
+  describe('computeLatencyByModel', () => {
+    it('computes average latency per model', () => {
+      const result = computeLatencyByModel({
+        'claude-sonnet-4-6': { sum: 3000, count: 3 },
+      });
+      expect(result[0].latency).toBe(1000);
+    });
+
+    it('sorts by latency descending', () => {
+      const result = computeLatencyByModel({
+        'model-a': { sum: 1000, count: 1 },
+        'model-b': { sum: 5000, count: 1 },
+      });
+      expect(result[0].latency).toBeGreaterThanOrEqual(result[1].latency);
+    });
+
+    it('limits to 10 entries', () => {
+      const data = {};
+      for (let i = 0; i < 15; i++) {
+        data[`model-${i}`] = { sum: 1000 * i, count: 1 };
+      }
+      const result = computeLatencyByModel(data);
+      expect(result.length).toBeLessThanOrEqual(10);
+    });
+
+    it('handles empty data', () => {
+      expect(computeLatencyByModel({})).toHaveLength(0);
+      expect(computeLatencyByModel(null)).toHaveLength(0);
+    });
+  });
+
+  describe('computeTopicAnalysis', () => {
+    it('extracts word frequencies from snippets', () => {
+      const topics = computeTopicAnalysis([
+        'React performance optimization',
+        'React hooks tutorial',
+        'React component testing',
+      ]);
+      const reactTopic = topics.find((t) => t.word === 'react');
+      expect(reactTopic).toBeDefined();
+      expect(reactTopic.count).toBe(3);
+    });
+
+    it('filters out stop words', () => {
+      const topics = computeTopicAnalysis(['the quick brown fox']);
+      const words = topics.map((t) => t.word);
+      expect(words).not.toContain('the');
+    });
+
+    it('filters out short words', () => {
+      const topics = computeTopicAnalysis(['go to me at']);
+      expect(topics).toHaveLength(0);
+    });
+
+    it('limits to 20 topics', () => {
+      const snippets = [];
+      for (let i = 0; i < 50; i++) {
+        snippets.push(`word${i} unique${i} special${i}`);
+      }
+      const topics = computeTopicAnalysis(snippets);
+      expect(topics.length).toBeLessThanOrEqual(20);
+    });
+
+    it('handles empty input', () => {
+      expect(computeTopicAnalysis([])).toHaveLength(0);
+      expect(computeTopicAnalysis(null)).toHaveLength(0);
+    });
+  });
+
+  describe('getLevel', () => {
+    it('returns Beginner for 0 points', () => {
+      expect(getLevel(0).name).toBe('Beginner');
+    });
+
+    it('returns Explorer for 100 points', () => {
+      expect(getLevel(100).name).toBe('Explorer');
+    });
+
+    it('returns Power User for 300 points', () => {
+      expect(getLevel(300).name).toBe('Power User');
+    });
+
+    it('returns Expert for 800 points', () => {
+      expect(getLevel(800).name).toBe('Expert');
+    });
+
+    it('returns Master for 2000 points', () => {
+      expect(getLevel(2000).name).toBe('Master');
+    });
+
+    it('includes progress field between 0 and 1', () => {
+      const level = getLevel(25);
+      expect(level.progress).toBeGreaterThanOrEqual(0);
+      expect(level.progress).toBeLessThanOrEqual(1);
+    });
+
+    it('Master level has progress of 1', () => {
+      expect(getLevel(5000).progress).toBe(1);
+    });
+  });
+
+  describe('computeBudgetStatus', () => {
+    it('returns null when no budget set', () => {
+      expect(computeBudgetStatus(sampleDailyUsage, null)).toBeNull();
+    });
+
+    it('computes budget status correctly', () => {
+      const status = computeBudgetStatus({ [dateKey(0)]: { cost: 5 } }, 10);
+      expect(status.spent).toBe(5);
+      expect(status.budget).toBe(10);
+      expect(status.percent).toBe(0.5);
+      expect(status.remaining).toBe(5);
+    });
+
+    it('remaining never goes negative', () => {
+      const status = computeBudgetStatus({ [dateKey(0)]: { cost: 15 } }, 10);
+      expect(status.remaining).toBe(0);
+    });
+  });
+
+  describe('computePeriodCounts', () => {
+    it('computes daily, weekly, monthly, yearly, and allTime', () => {
+      const counts = computePeriodCounts(sampleDailyUsage);
+      expect(typeof counts.daily).toBe('number');
+      expect(typeof counts.weekly).toBe('number');
+      expect(typeof counts.monthly).toBe('number');
+      expect(typeof counts.yearly).toBe('number');
+      expect(typeof counts.allTime).toBe('number');
+    });
+
+    it('daily count matches today', () => {
+      const counts = computePeriodCounts(sampleDailyUsage);
+      expect(counts.daily).toBe(10);
+    });
+
+    it('allTime includes everything', () => {
+      const counts = computePeriodCounts(sampleDailyUsage);
+      expect(counts.allTime).toBe(28);
+    });
+
+    it('handles empty usage', () => {
+      const counts = computePeriodCounts({});
+      expect(counts.allTime).toBe(0);
+    });
+  });
+
+  describe('getMostActiveHour', () => {
+    it('returns the hour with most messages', () => {
+      const result = getMostActiveHour({ '9': 5, '14': 20, '22': 10 });
+      expect(result.hour).toBe(14);
+      expect(result.count).toBe(20);
+    });
+
+    it('returns hour 0 for empty usage', () => {
+      const result = getMostActiveHour({});
+      expect(result.hour).toBe(0);
+      expect(result.count).toBe(0);
+    });
+  });
+
+  describe('getTopModel', () => {
+    it('returns the most used model', () => {
+      const result = getTopModel({ 'claude-sonnet-4-6': 20, 'gpt-4o': 5 });
+      expect(result.modelId).toBe('claude-sonnet-4-6');
+      expect(result.count).toBe(20);
+    });
+
+    it('returns null for empty usage', () => {
+      expect(getTopModel({})).toBeNull();
+    });
+  });
+
+  describe('getTopProvider', () => {
+    it('returns the most used provider', () => {
+      const result = getTopProvider({ anthropic: 30, openai: 10 });
+      expect(result.providerId).toBe('anthropic');
+      expect(result.count).toBe(30);
+    });
+
+    it('returns null for empty usage', () => {
+      expect(getTopProvider({})).toBeNull();
+    });
+  });
+});

--- a/src/services/conversationParsers.test.js
+++ b/src/services/conversationParsers.test.js
@@ -1,0 +1,325 @@
+import { describe, it, expect } from 'vitest';
+import { parseConversationsFile } from './conversationParsers';
+
+// Helper to create a mock File
+function createJsonFile(data, name = 'export.json') {
+  const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+  return new File([blob], name, { type: 'application/json' });
+}
+
+describe('conversationParsers', () => {
+  describe('Claude format', () => {
+    it('parses Claude conversations', async () => {
+      const data = [
+        {
+          uuid: 'conv-1',
+          name: 'Test Conversation',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T01:00:00Z',
+          chat_messages: [
+            {
+              uuid: 'msg-1',
+              sender: 'human',
+              content: [{ type: 'text', text: 'Hello' }],
+              created_at: '2024-01-01T00:00:00Z',
+            },
+            {
+              uuid: 'msg-2',
+              sender: 'assistant',
+              text: 'Hi there!',
+              created_at: '2024-01-01T00:01:00Z',
+            },
+          ],
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'claude', 'Claude');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe('Test Conversation');
+      expect(result[0].provider).toBe('claude');
+      expect(result[0].providerName).toBe('Claude');
+      expect(result[0].messages).toHaveLength(2);
+      expect(result[0].messages[0].role).toBe('user');
+      expect(result[0].messages[0].content).toBe('Hello');
+      expect(result[0].messages[1].role).toBe('assistant');
+      expect(result[0].messages[1].content).toBe('Hi there!');
+    });
+
+    it('filters out empty messages', async () => {
+      const data = [
+        {
+          uuid: 'conv-1',
+          name: 'Test',
+          chat_messages: [
+            { uuid: 'msg-1', sender: 'human', content: [{ type: 'text', text: '' }] },
+            { uuid: 'msg-2', sender: 'assistant', text: 'Response' },
+          ],
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'claude', 'Claude');
+
+      expect(result[0].messages).toHaveLength(1);
+      expect(result[0].messages[0].content).toBe('Response');
+    });
+
+    it('skips conversations with no valid messages', async () => {
+      const data = [
+        {
+          uuid: 'conv-1',
+          name: 'Empty',
+          chat_messages: [
+            { uuid: 'msg-1', sender: 'system', text: 'System message' },
+          ],
+        },
+        {
+          uuid: 'conv-2',
+          name: 'Valid',
+          chat_messages: [
+            { uuid: 'msg-2', sender: 'human', text: 'Hello' },
+          ],
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'claude', 'Claude');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe('Valid');
+    });
+
+    it('handles conversations wrapped in an object', async () => {
+      const data = {
+        conversations: [
+          {
+            uuid: 'conv-1',
+            name: 'Wrapped',
+            chat_messages: [{ uuid: 'msg-1', sender: 'human', text: 'Test' }],
+          },
+        ],
+      };
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'claude', 'Claude');
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('ChatGPT format', () => {
+    it('parses ChatGPT conversations', async () => {
+      const data = [
+        {
+          id: 'chatgpt-conv-1',
+          title: 'ChatGPT Chat',
+          create_time: 1704067200,
+          update_time: 1704070800,
+          mapping: {
+            node1: {
+              message: {
+                id: 'msg-1',
+                author: { role: 'user' },
+                content: { parts: ['Hello from ChatGPT'] },
+                create_time: 1704067200,
+              },
+            },
+            node2: {
+              message: {
+                id: 'msg-2',
+                author: { role: 'assistant' },
+                content: { parts: ['Hello!'] },
+                create_time: 1704067260,
+              },
+            },
+          },
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'chatgpt', 'ChatGPT');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('chatgpt');
+      expect(result[0].title).toBe('ChatGPT Chat');
+      expect(result[0].messages.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('ignores system messages in ChatGPT format', async () => {
+      const data = [
+        {
+          id: 'conv-1',
+          title: 'Test',
+          mapping: {
+            node1: {
+              message: {
+                id: 'msg-1',
+                author: { role: 'system' },
+                content: { parts: ['System prompt'] },
+              },
+            },
+            node2: {
+              message: {
+                id: 'msg-2',
+                author: { role: 'user' },
+                content: { parts: ['User message'] },
+              },
+            },
+          },
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'chatgpt', 'ChatGPT');
+
+      expect(result[0].messages).toHaveLength(1);
+      expect(result[0].messages[0].role).toBe('user');
+    });
+  });
+
+  describe('Generic format', () => {
+    it('parses generic conversations', async () => {
+      const data = [
+        {
+          id: 'gen-1',
+          title: 'Generic Chat',
+          messages: [
+            { id: 'msg-1', role: 'user', content: 'Hello' },
+            { id: 'msg-2', role: 'assistant', content: 'Hi' },
+          ],
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'gemini', 'Gemini');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('gemini');
+      expect(result[0].providerName).toBe('Gemini');
+      expect(result[0].messages).toHaveLength(2);
+    });
+
+    it('handles sender field mapped to bot as assistant', async () => {
+      const data = [
+        {
+          id: 'gen-1',
+          title: 'Bot Chat',
+          messages: [
+            { id: 'msg-1', sender: 'bot', content: 'I am a bot' },
+          ],
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'other', 'Other');
+
+      expect(result[0].messages[0].role).toBe('assistant');
+    });
+
+    it('uses text or message fields as fallback content', async () => {
+      const data = [
+        {
+          id: 'gen-1',
+          title: 'Fallback',
+          messages: [
+            { id: 'msg-1', role: 'user', text: 'Via text field' },
+            { id: 'msg-2', role: 'assistant', message: 'Via message field' },
+          ],
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'other', 'Other');
+
+      expect(result[0].messages[0].content).toBe('Via text field');
+      expect(result[0].messages[1].content).toBe('Via message field');
+    });
+  });
+
+  describe('Error handling', () => {
+    it('rejects with error for invalid JSON', async () => {
+      const file = new File(['not json'], 'bad.json', { type: 'application/json' });
+
+      await expect(parseConversationsFile(file, 'claude', 'Claude')).rejects.toThrow(
+        /valid JSON/
+      );
+    });
+
+    it('rejects when no conversations found', async () => {
+      const file = createJsonFile([]);
+
+      await expect(parseConversationsFile(file, 'claude', 'Claude')).rejects.toThrow(
+        /No conversations found/
+      );
+    });
+
+    it('rejects when file has conversations with no valid messages', async () => {
+      const data = [
+        {
+          uuid: 'conv-1',
+          name: 'Empty',
+          chat_messages: [],
+        },
+      ];
+
+      const file = createJsonFile(data);
+
+      await expect(parseConversationsFile(file, 'claude', 'Claude')).rejects.toThrow(
+        /No conversations found/
+      );
+    });
+  });
+
+  describe('messageCount', () => {
+    it('sets correct messageCount on parsed conversations', async () => {
+      const data = [
+        {
+          uuid: 'conv-1',
+          name: 'Count Test',
+          chat_messages: [
+            { uuid: 'msg-1', sender: 'human', text: 'One' },
+            { uuid: 'msg-2', sender: 'assistant', text: 'Two' },
+            { uuid: 'msg-3', sender: 'human', text: 'Three' },
+          ],
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'claude', 'Claude');
+
+      expect(result[0].messageCount).toBe(3);
+    });
+  });
+
+  describe('externalId and timestamps', () => {
+    it('preserves externalId from source', async () => {
+      const data = [
+        {
+          uuid: 'unique-ext-id',
+          name: 'ID Test',
+          chat_messages: [{ sender: 'human', text: 'Test' }],
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'claude', 'Claude');
+
+      expect(result[0].externalId).toBe('unique-ext-id');
+    });
+
+    it('uses default title when none provided', async () => {
+      const data = [
+        {
+          chat_messages: [{ sender: 'human', text: 'Test' }],
+        },
+      ];
+
+      const file = createJsonFile(data);
+      const result = await parseConversationsFile(file, 'claude', 'Claude');
+
+      expect(result[0].title).toBe('Untitled Conversation');
+    });
+  });
+});

--- a/src/services/credits.test.js
+++ b/src/services/credits.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { getCreditCost } from './credits';
+
+// Only test pure functions — async functions require network mocking
+
+describe('credits service', () => {
+  describe('getCreditCost', () => {
+    it('returns 1 for standard quality', () => {
+      expect(getCreditCost('standard')).toBe(1);
+    });
+
+    it('returns 2 for hd quality', () => {
+      expect(getCreditCost('hd')).toBe(2);
+    });
+
+    it('returns 4 for ultra quality', () => {
+      expect(getCreditCost('ultra')).toBe(4);
+    });
+
+    it('defaults to standard cost for unknown quality', () => {
+      expect(getCreditCost('unknown')).toBe(1);
+    });
+
+    it('defaults to standard cost when called with no argument', () => {
+      expect(getCreditCost()).toBe(1);
+    });
+  });
+});

--- a/src/services/settings.test.js
+++ b/src/services/settings.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_SETTINGS } from './settings';
+
+// We test the DEFAULT_SETTINGS shape and values.
+// The toSnakeCase/toCamelCase functions are not exported, but are tested
+// implicitly through the async functions. We test what we can without network.
+
+describe('settings service', () => {
+  describe('DEFAULT_SETTINGS', () => {
+    it('has all expected keys', () => {
+      const expectedKeys = [
+        'displayName',
+        'bio',
+        'preferredLanguage',
+        'responseTone',
+        'customInstructions',
+        'occupation',
+        'expertise',
+        'fontSize',
+        'answerFont',
+        'compactMode',
+        'sendWithEnter',
+        'showCodeLineNumbers',
+        'defaultModel',
+        'enableReasoning',
+        'showModelInfo',
+        'webSearchDefault',
+        'imageQualityDefault',
+        'enableFollowUps',
+        'saveHistory',
+        'enableAnalytics',
+        'aiDataRetention',
+        'locationMetadata',
+        'notifyNewFeatures',
+        'notifyUsageLimits',
+        'notifySounds',
+        'avatarUrl',
+        'fullName',
+        'phone',
+        'website',
+        'location',
+      ];
+
+      for (const key of expectedKeys) {
+        expect(DEFAULT_SETTINGS).toHaveProperty(key);
+      }
+    });
+
+    it('has sensible defaults', () => {
+      expect(DEFAULT_SETTINGS.displayName).toBe('User');
+      expect(DEFAULT_SETTINGS.preferredLanguage).toBe('English');
+      expect(DEFAULT_SETTINGS.responseTone).toBe('default');
+      expect(DEFAULT_SETTINGS.fontSize).toBe('medium');
+      expect(DEFAULT_SETTINGS.answerFont).toBe('sans-serif');
+      expect(DEFAULT_SETTINGS.defaultModel).toBe('auto');
+      expect(DEFAULT_SETTINGS.imageQualityDefault).toBe('standard');
+      expect(DEFAULT_SETTINGS.webSearchDefault).toBe('auto');
+    });
+
+    it('has boolean settings with correct defaults', () => {
+      expect(DEFAULT_SETTINGS.compactMode).toBe(false);
+      expect(DEFAULT_SETTINGS.sendWithEnter).toBe(true);
+      expect(DEFAULT_SETTINGS.showCodeLineNumbers).toBe(true);
+      expect(DEFAULT_SETTINGS.enableReasoning).toBe(true);
+      expect(DEFAULT_SETTINGS.showModelInfo).toBe(true);
+      expect(DEFAULT_SETTINGS.enableFollowUps).toBe(true);
+      expect(DEFAULT_SETTINGS.saveHistory).toBe(true);
+      expect(DEFAULT_SETTINGS.enableAnalytics).toBe(true);
+      expect(DEFAULT_SETTINGS.aiDataRetention).toBe(false);
+      expect(DEFAULT_SETTINGS.locationMetadata).toBe(false);
+      expect(DEFAULT_SETTINGS.notifyNewFeatures).toBe(true);
+      expect(DEFAULT_SETTINGS.notifyUsageLimits).toBe(true);
+      expect(DEFAULT_SETTINGS.notifySounds).toBe(true);
+    });
+
+    it('has empty string defaults for profile fields', () => {
+      expect(DEFAULT_SETTINGS.bio).toBe('');
+      expect(DEFAULT_SETTINGS.customInstructions).toBe('');
+      expect(DEFAULT_SETTINGS.occupation).toBe('');
+      expect(DEFAULT_SETTINGS.expertise).toBe('');
+      expect(DEFAULT_SETTINGS.avatarUrl).toBe('');
+      expect(DEFAULT_SETTINGS.fullName).toBe('');
+      expect(DEFAULT_SETTINGS.phone).toBe('');
+      expect(DEFAULT_SETTINGS.website).toBe('');
+      expect(DEFAULT_SETTINGS.location).toBe('');
+    });
+  });
+});

--- a/src/store/slices/analyticsSlice.test.js
+++ b/src/store/slices/analyticsSlice.test.js
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import analyticsReducer, {
+  recordMessage,
+  setMonthlyBudget,
+  setBudgetAlertThreshold,
+  resetStats,
+  selectLifetimeStats,
+  selectMonthlyBudget,
+  selectBudgetAlertThreshold,
+} from './analyticsSlice';
+
+describe('analyticsSlice', () => {
+  let defaultState;
+
+  beforeEach(() => {
+    localStorage.clear();
+    defaultState = analyticsReducer(undefined, resetStats());
+  });
+
+  describe('initial state', () => {
+    it('has zeroed lifetime stats', () => {
+      expect(defaultState.lifetimeStats.totalMessages).toBe(0);
+      expect(defaultState.lifetimeStats.totalCost).toBe(0);
+      expect(defaultState.lifetimeStats.totalInputTokens).toBe(0);
+      expect(defaultState.lifetimeStats.totalOutputTokens).toBe(0);
+      expect(defaultState.lifetimeStats.points).toBe(0);
+      expect(defaultState.lifetimeStats.currentStreak).toBe(0);
+      expect(defaultState.lifetimeStats.longestStreak).toBe(0);
+    });
+
+    it('has null monthly budget', () => {
+      expect(defaultState.monthlyBudget).toBeNull();
+    });
+
+    it('has default budget alert threshold', () => {
+      expect(defaultState.budgetAlertThreshold).toBe(0.8);
+    });
+  });
+
+  describe('recordMessage', () => {
+    const basePayload = {
+      modelId: 'claude-sonnet-4-6',
+      modelName: 'Claude Sonnet 4.6',
+      provider: 'anthropic',
+      costUsd: 0.01,
+      inputTokens: 100,
+      outputTokens: 200,
+      latencyMs: 500,
+      timestamp: new Date().toISOString(),
+      promptSnippet: 'Tell me about AI',
+    };
+
+    it('increments totalMessages', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      expect(state.lifetimeStats.totalMessages).toBe(1);
+    });
+
+    it('accumulates cost', () => {
+      let state = analyticsReducer(defaultState, recordMessage(basePayload));
+      state = analyticsReducer(state, recordMessage({ ...basePayload, costUsd: 0.02 }));
+      expect(state.lifetimeStats.totalCost).toBeCloseTo(0.03, 4);
+    });
+
+    it('accumulates tokens', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      expect(state.lifetimeStats.totalInputTokens).toBe(100);
+      expect(state.lifetimeStats.totalOutputTokens).toBe(200);
+    });
+
+    it('tracks model usage', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      expect(state.lifetimeStats.modelUsage['claude-sonnet-4-6']).toBe(1);
+    });
+
+    it('tracks provider usage', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      expect(state.lifetimeStats.providerUsage['anthropic']).toBe(1);
+    });
+
+    it('tracks daily usage', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      const dailyKeys = Object.keys(state.lifetimeStats.dailyUsage);
+      expect(dailyKeys.length).toBe(1);
+      const day = state.lifetimeStats.dailyUsage[dailyKeys[0]];
+      expect(day.messages).toBe(1);
+      expect(day.cost).toBe(0.01);
+    });
+
+    it('tracks hourly usage', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      const hourKeys = Object.keys(state.lifetimeStats.hourlyUsage);
+      expect(hourKeys.length).toBe(1);
+    });
+
+    it('tracks latency', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      expect(state.lifetimeStats.latencySum).toBe(500);
+      expect(state.lifetimeStats.latencyCount).toBe(1);
+    });
+
+    it('tracks latency by model', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      expect(state.lifetimeStats.latencyByModel['claude-sonnet-4-6'].sum).toBe(500);
+      expect(state.lifetimeStats.latencyByModel['claude-sonnet-4-6'].count).toBe(1);
+    });
+
+    it('stores prompt snippets', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      expect(state.lifetimeStats.promptSnippets).toContain('Tell me about AI');
+    });
+
+    it('limits prompt snippets to 200', () => {
+      let state = defaultState;
+      for (let i = 0; i < 210; i++) {
+        state = analyticsReducer(
+          state,
+          recordMessage({ ...basePayload, promptSnippet: `Snippet ${i}` })
+        );
+      }
+      expect(state.lifetimeStats.promptSnippets.length).toBeLessThanOrEqual(200);
+    });
+
+    it('sets firstUsedAt on first message', () => {
+      const state = analyticsReducer(defaultState, recordMessage(basePayload));
+      expect(state.lifetimeStats.firstUsedAt).toBe(basePayload.timestamp);
+    });
+
+    it('does not overwrite firstUsedAt on subsequent messages', () => {
+      let state = analyticsReducer(defaultState, recordMessage(basePayload));
+      const laterTimestamp = new Date(Date.now() + 10000).toISOString();
+      state = analyticsReducer(
+        state,
+        recordMessage({ ...basePayload, timestamp: laterTimestamp })
+      );
+      expect(state.lifetimeStats.firstUsedAt).toBe(basePayload.timestamp);
+    });
+
+    describe('points system', () => {
+      it('awards base point per message', () => {
+        const state = analyticsReducer(defaultState, recordMessage(basePayload));
+        expect(state.lifetimeStats.points).toBeGreaterThanOrEqual(1);
+      });
+
+      it('awards model discovery bonus for new models', () => {
+        const state = analyticsReducer(defaultState, recordMessage(basePayload));
+        // Base (1) + first streak day (0 since it's first active date, sets streak to 1) + model discovery (3)
+        expect(state.lifetimeStats.modelsDiscovered).toContain('claude-sonnet-4-6');
+      });
+
+      it('no duplicate model discovery bonus', () => {
+        let state = analyticsReducer(defaultState, recordMessage(basePayload));
+        const pointsAfterFirst = state.lifetimeStats.points;
+        state = analyticsReducer(state, recordMessage(basePayload));
+        // Second message: only base point (1), no model discovery
+        expect(state.lifetimeStats.points).toBe(pointsAfterFirst + 1);
+      });
+
+      it('tracks streak days', () => {
+        const state = analyticsReducer(defaultState, recordMessage(basePayload));
+        expect(state.lifetimeStats.currentStreak).toBe(1);
+      });
+    });
+
+    it('handles missing optional fields gracefully', () => {
+      const minimal = {
+        timestamp: new Date().toISOString(),
+      };
+      const state = analyticsReducer(defaultState, recordMessage(minimal));
+      expect(state.lifetimeStats.totalMessages).toBe(1);
+      expect(state.lifetimeStats.totalCost).toBe(0);
+    });
+
+    it('persists to localStorage', () => {
+      analyticsReducer(defaultState, recordMessage(basePayload));
+      expect(localStorage.setItem).toHaveBeenCalled();
+    });
+  });
+
+  describe('setMonthlyBudget', () => {
+    it('sets the budget', () => {
+      const state = analyticsReducer(defaultState, setMonthlyBudget(50));
+      expect(state.monthlyBudget).toBe(50);
+    });
+
+    it('persists to localStorage', () => {
+      analyticsReducer(defaultState, setMonthlyBudget(50));
+      expect(localStorage.setItem).toHaveBeenCalled();
+    });
+  });
+
+  describe('setBudgetAlertThreshold', () => {
+    it('sets the threshold', () => {
+      const state = analyticsReducer(defaultState, setBudgetAlertThreshold(0.9));
+      expect(state.budgetAlertThreshold).toBe(0.9);
+    });
+  });
+
+  describe('resetStats', () => {
+    it('resets all analytics to defaults', () => {
+      let state = analyticsReducer(
+        defaultState,
+        recordMessage({
+          modelId: 'test',
+          costUsd: 1,
+          timestamp: new Date().toISOString(),
+        })
+      );
+      state = analyticsReducer(state, setMonthlyBudget(100));
+      state = analyticsReducer(state, resetStats());
+
+      expect(state.lifetimeStats.totalMessages).toBe(0);
+      expect(state.monthlyBudget).toBeNull();
+      expect(state.budgetAlertThreshold).toBe(0.8);
+    });
+  });
+
+  describe('selectors', () => {
+    const rootState = {
+      analytics: {
+        lifetimeStats: { totalMessages: 42 },
+        monthlyBudget: 25,
+        budgetAlertThreshold: 0.9,
+      },
+    };
+
+    it('selectLifetimeStats', () => {
+      expect(selectLifetimeStats(rootState).totalMessages).toBe(42);
+    });
+
+    it('selectMonthlyBudget', () => {
+      expect(selectMonthlyBudget(rootState)).toBe(25);
+    });
+
+    it('selectBudgetAlertThreshold', () => {
+      expect(selectBudgetAlertThreshold(rootState)).toBe(0.9);
+    });
+  });
+});

--- a/src/store/slices/authSlice.test.js
+++ b/src/store/slices/authSlice.test.js
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest';
+import authReducer, {
+  setAuth,
+  clearAuth,
+  setAuthLoading,
+  setAuthError,
+  setUserAvatarUrl,
+  selectAuthUser,
+  selectAuthSession,
+  selectAuthLoading,
+  selectAuthError,
+  selectIsAuthenticated,
+  selectIsAnonymous,
+} from './authSlice';
+
+describe('authSlice', () => {
+  const initialState = {
+    user: null,
+    session: null,
+    isLoading: true,
+    error: null,
+  };
+
+  describe('initial state', () => {
+    it('starts with null user and session, loading true', () => {
+      const state = authReducer(undefined, { type: 'unknown' });
+      expect(state.user).toBeNull();
+      expect(state.session).toBeNull();
+      expect(state.isLoading).toBe(true);
+      expect(state.error).toBeNull();
+    });
+  });
+
+  describe('setAuth', () => {
+    it('sets user and session', () => {
+      const user = { id: 'u1', email: 'test@test.com', isAnonymous: false };
+      const session = { access_token: 'token' };
+      const state = authReducer(initialState, setAuth({ user, session }));
+      expect(state.user).toEqual(user);
+      expect(state.session).toEqual(session);
+      expect(state.error).toBeNull();
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('clearAuth', () => {
+    it('clears all auth state', () => {
+      const prev = {
+        user: { id: 'u1' },
+        session: { access_token: 'token' },
+        isLoading: true,
+        error: 'some error',
+      };
+      const state = authReducer(prev, clearAuth());
+      expect(state.user).toBeNull();
+      expect(state.session).toBeNull();
+      expect(state.error).toBeNull();
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('setAuthLoading', () => {
+    it('sets loading flag', () => {
+      const state = authReducer(initialState, setAuthLoading(false));
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('setAuthError', () => {
+    it('sets error message', () => {
+      const state = authReducer(initialState, setAuthError('Auth failed'));
+      expect(state.error).toBe('Auth failed');
+    });
+  });
+
+  describe('setUserAvatarUrl', () => {
+    it('updates avatar on existing user', () => {
+      const prev = {
+        ...initialState,
+        user: { id: 'u1', avatarUrl: null },
+      };
+      const state = authReducer(prev, setUserAvatarUrl('https://img.test/avatar.png'));
+      expect(state.user.avatarUrl).toBe('https://img.test/avatar.png');
+    });
+
+    it('does nothing when no user exists', () => {
+      const state = authReducer(initialState, setUserAvatarUrl('https://img.test/avatar.png'));
+      expect(state.user).toBeNull();
+    });
+  });
+
+  describe('async thunk reducers', () => {
+    it('handles initializeAuth.pending', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/initializeAuth/pending',
+      });
+      expect(state.isLoading).toBe(true);
+      expect(state.error).toBeNull();
+    });
+
+    it('handles initializeAuth.fulfilled', () => {
+      const user = { id: 'u1', email: 'test@test.com' };
+      const session = { access_token: 'tok' };
+      const state = authReducer(initialState, {
+        type: 'auth/initializeAuth/fulfilled',
+        payload: { user, session },
+      });
+      expect(state.user).toEqual(user);
+      expect(state.session).toEqual(session);
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('handles initializeAuth.rejected', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/initializeAuth/rejected',
+        payload: 'Init failed',
+      });
+      expect(state.isLoading).toBe(false);
+      expect(state.error).toBe('Init failed');
+    });
+
+    it('handles signInWithGoogle.pending', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/signInWithGoogle/pending',
+      });
+      expect(state.isLoading).toBe(true);
+    });
+
+    it('handles signInWithGoogle.rejected', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/signInWithGoogle/rejected',
+        payload: 'Google failed',
+      });
+      expect(state.error).toBe('Google failed');
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('handles signInWithEmail.fulfilled', () => {
+      const user = { id: 'u1' };
+      const session = { access_token: 'tok' };
+      const state = authReducer(initialState, {
+        type: 'auth/signInWithEmail/fulfilled',
+        payload: { user, session },
+      });
+      expect(state.user).toEqual(user);
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('handles signInWithEmail.rejected', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/signInWithEmail/rejected',
+        payload: 'Wrong password',
+      });
+      expect(state.error).toBe('Wrong password');
+    });
+
+    it('handles signUpWithEmail.fulfilled', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/signUpWithEmail/fulfilled',
+        payload: { user: { id: 'new' }, session: null },
+      });
+      expect(state.user.id).toBe('new');
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('handles signOut.fulfilled', () => {
+      const prev = {
+        user: { id: 'u1' },
+        session: { access_token: 'tok' },
+        isLoading: false,
+        error: null,
+      };
+      const state = authReducer(prev, { type: 'auth/signOut/fulfilled' });
+      expect(state.user).toBeNull();
+      expect(state.session).toBeNull();
+    });
+
+    it('handles signOut.rejected', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/signOut/rejected',
+        payload: 'Sign out failed',
+      });
+      expect(state.error).toBe('Sign out failed');
+    });
+
+    it('handles resetPassword.pending', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/resetPassword/pending',
+      });
+      expect(state.isLoading).toBe(true);
+    });
+
+    it('handles resetPassword.fulfilled', () => {
+      const state = authReducer(
+        { ...initialState, isLoading: true },
+        { type: 'auth/resetPassword/fulfilled' }
+      );
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('handles resetPassword.rejected', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/resetPassword/rejected',
+        payload: 'Reset failed',
+      });
+      expect(state.error).toBe('Reset failed');
+    });
+  });
+
+  describe('selectors', () => {
+    const authenticatedState = {
+      auth: {
+        user: { id: 'u1', email: 'test@test.com', isAnonymous: false },
+        session: { access_token: 'tok' },
+        isLoading: false,
+        error: null,
+      },
+    };
+
+    const anonymousState = {
+      auth: {
+        user: { id: 'anon-1', isAnonymous: true },
+        session: { access_token: 'anon-tok' },
+        isLoading: false,
+        error: null,
+      },
+    };
+
+    const emptyState = {
+      auth: { user: null, session: null, isLoading: true, error: 'err' },
+    };
+
+    it('selectAuthUser returns user', () => {
+      expect(selectAuthUser(authenticatedState).id).toBe('u1');
+    });
+
+    it('selectAuthSession returns session', () => {
+      expect(selectAuthSession(authenticatedState).access_token).toBe('tok');
+    });
+
+    it('selectAuthLoading returns loading state', () => {
+      expect(selectAuthLoading(emptyState)).toBe(true);
+    });
+
+    it('selectAuthError returns error', () => {
+      expect(selectAuthError(emptyState)).toBe('err');
+    });
+
+    it('selectIsAuthenticated returns true for non-anonymous user', () => {
+      expect(selectIsAuthenticated(authenticatedState)).toBe(true);
+    });
+
+    it('selectIsAuthenticated returns false for anonymous user', () => {
+      expect(selectIsAuthenticated(anonymousState)).toBe(false);
+    });
+
+    it('selectIsAuthenticated returns false for null user', () => {
+      expect(selectIsAuthenticated(emptyState)).toBe(false);
+    });
+
+    it('selectIsAnonymous returns true for anonymous user', () => {
+      expect(selectIsAnonymous(anonymousState)).toBe(true);
+    });
+
+    it('selectIsAnonymous returns false for authenticated user', () => {
+      expect(selectIsAnonymous(authenticatedState)).toBe(false);
+    });
+
+    it('selectIsAnonymous returns false for null user', () => {
+      expect(selectIsAnonymous(emptyState)).toBe(false);
+    });
+  });
+});

--- a/src/store/slices/chatSlice.test.js
+++ b/src/store/slices/chatSlice.test.js
@@ -1,0 +1,433 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import chatReducer, {
+  setInputValue,
+  setMode,
+  setSelectedModel,
+  setExtendedThinking,
+  setDeepResearch,
+  setGoogleThinking,
+  setWebSearchEnabled,
+  setTone,
+  setMood,
+  setAutoStrategy,
+  addMessage,
+  updateLastMessage,
+  setIsProcessing,
+  clearMessages,
+  setCurrentChat,
+  createNewChat,
+  removeLastAssistantMessage,
+  setPendingAutoSubmit,
+  setPendingModality,
+  setSelectedModality,
+  setImageQuality,
+  setCreditBalance,
+  setActiveProjectId,
+  setImportedContext,
+  setMessages,
+  setConversations,
+  appendConversations,
+  setConversationsLoading,
+  resetChatState,
+  selectInputValue,
+  selectMode,
+  selectSelectedModelId,
+  selectExtendedThinking,
+  selectDeepResearch,
+  selectGoogleThinking,
+  selectWebSearchEnabled,
+  selectTone,
+  selectMood,
+  selectAutoStrategy,
+  selectMessages,
+  selectIsProcessing,
+  selectCurrentChatId,
+  selectPendingAutoSubmit,
+  selectPendingModality,
+  selectSelectedModality,
+  selectImageQuality,
+  selectCreditBalance,
+  selectActiveProjectId,
+  selectConversations,
+  selectConversationsTotal,
+  selectConversationsLoading,
+  selectImportedContext,
+} from './chatSlice';
+
+// Mock isModelAccessible so getInitialSelectedModel works
+vi.mock('../../data/models', () => ({
+  isModelAccessible: vi.fn(() => true),
+}));
+
+describe('chatSlice', () => {
+  let defaultState;
+
+  beforeEach(() => {
+    localStorage.clear();
+    defaultState = chatReducer(undefined, { type: 'unknown' });
+  });
+
+  describe('initial state', () => {
+    it('has sensible defaults', () => {
+      expect(defaultState.messages).toEqual([]);
+      expect(defaultState.inputValue).toBe('');
+      expect(defaultState.mode).toBe('auto');
+      expect(defaultState.extendedThinking).toBe(false);
+      expect(defaultState.deepResearch).toBe(false);
+      expect(defaultState.googleThinking).toBe(false);
+      expect(defaultState.webSearchEnabled).toBeNull();
+      expect(defaultState.tone).toBe('default');
+      expect(defaultState.mood).toBeNull();
+      expect(defaultState.autoStrategy).toBe('default');
+      expect(defaultState.currentChatId).toBeNull();
+      expect(defaultState.isProcessing).toBe(false);
+      expect(defaultState.selectedModality).toBe('text');
+      expect(defaultState.imageQuality).toBe('standard');
+      expect(defaultState.creditBalance).toBeNull();
+      expect(defaultState.conversations).toEqual([]);
+    });
+  });
+
+  describe('setInputValue', () => {
+    it('sets the input value', () => {
+      const state = chatReducer(defaultState, setInputValue('Hello'));
+      expect(state.inputValue).toBe('Hello');
+    });
+  });
+
+  describe('setMode', () => {
+    it('sets the mode', () => {
+      const state = chatReducer(defaultState, setMode('code'));
+      expect(state.mode).toBe('code');
+    });
+  });
+
+  describe('setSelectedModel', () => {
+    it('sets the model id', () => {
+      const state = chatReducer(defaultState, setSelectedModel('claude-opus-4-6'));
+      expect(state.selectedModelId).toBe('claude-opus-4-6');
+    });
+
+    it('resets thinking toggles when switching models', () => {
+      let state = chatReducer(defaultState, setExtendedThinking(true));
+      state = chatReducer(state, setSelectedModel('gpt-4o'));
+      expect(state.extendedThinking).toBe(false);
+      expect(state.deepResearch).toBe(false);
+      expect(state.googleThinking).toBe(false);
+    });
+
+    it('persists to localStorage', () => {
+      chatReducer(defaultState, setSelectedModel('claude-opus-4-6'));
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'araviel-selected-model',
+        'claude-opus-4-6'
+      );
+    });
+
+    it('removes from localStorage when set to null', () => {
+      chatReducer(defaultState, setSelectedModel(null));
+      expect(localStorage.removeItem).toHaveBeenCalledWith('araviel-selected-model');
+    });
+  });
+
+  describe('thinking mode toggles', () => {
+    it('setExtendedThinking disables other thinking modes', () => {
+      let state = chatReducer(defaultState, setDeepResearch(true));
+      state = chatReducer(state, setExtendedThinking(true));
+      expect(state.extendedThinking).toBe(true);
+      expect(state.deepResearch).toBe(false);
+      expect(state.googleThinking).toBe(false);
+    });
+
+    it('setDeepResearch disables other thinking modes', () => {
+      let state = chatReducer(defaultState, setExtendedThinking(true));
+      state = chatReducer(state, setDeepResearch(true));
+      expect(state.deepResearch).toBe(true);
+      expect(state.extendedThinking).toBe(false);
+      expect(state.googleThinking).toBe(false);
+    });
+
+    it('setGoogleThinking disables other thinking modes', () => {
+      let state = chatReducer(defaultState, setExtendedThinking(true));
+      state = chatReducer(state, setGoogleThinking(true));
+      expect(state.googleThinking).toBe(true);
+      expect(state.extendedThinking).toBe(false);
+      expect(state.deepResearch).toBe(false);
+    });
+
+    it('turning off a thinking mode does not enable others', () => {
+      let state = chatReducer(defaultState, setExtendedThinking(true));
+      state = chatReducer(state, setExtendedThinking(false));
+      expect(state.extendedThinking).toBe(false);
+      expect(state.deepResearch).toBe(false);
+      expect(state.googleThinking).toBe(false);
+    });
+  });
+
+  describe('setWebSearchEnabled', () => {
+    it('sets to true, false, or null', () => {
+      let state = chatReducer(defaultState, setWebSearchEnabled(true));
+      expect(state.webSearchEnabled).toBe(true);
+
+      state = chatReducer(state, setWebSearchEnabled(false));
+      expect(state.webSearchEnabled).toBe(false);
+
+      state = chatReducer(state, setWebSearchEnabled(null));
+      expect(state.webSearchEnabled).toBeNull();
+    });
+  });
+
+  describe('setTone', () => {
+    it('sets the tone', () => {
+      const state = chatReducer(defaultState, setTone('professional'));
+      expect(state.tone).toBe('professional');
+    });
+  });
+
+  describe('setMood', () => {
+    it('sets the mood', () => {
+      const state = chatReducer(defaultState, setMood('happy'));
+      expect(state.mood).toBe('happy');
+    });
+  });
+
+  describe('setAutoStrategy', () => {
+    it('sets the auto strategy', () => {
+      const state = chatReducer(defaultState, setAutoStrategy('taskBased'));
+      expect(state.autoStrategy).toBe('taskBased');
+    });
+  });
+
+  describe('message management', () => {
+    it('addMessage appends a message', () => {
+      const msg = { role: 'user', content: 'Hello' };
+      const state = chatReducer(defaultState, addMessage(msg));
+      expect(state.messages).toHaveLength(1);
+      expect(state.messages[0]).toEqual(msg);
+    });
+
+    it('updateLastMessage updates the last message', () => {
+      let state = chatReducer(defaultState, addMessage({ role: 'user', content: 'Hello' }));
+      state = chatReducer(state, addMessage({ role: 'assistant', content: 'Hi' }));
+      state = chatReducer(state, updateLastMessage({ content: 'Hi there!' }));
+      expect(state.messages[1].content).toBe('Hi there!');
+    });
+
+    it('updateLastMessage does nothing on empty messages', () => {
+      const state = chatReducer(defaultState, updateLastMessage({ content: 'test' }));
+      expect(state.messages).toHaveLength(0);
+    });
+
+    it('clearMessages empties the messages array', () => {
+      let state = chatReducer(defaultState, addMessage({ role: 'user', content: 'Hello' }));
+      state = chatReducer(state, clearMessages());
+      expect(state.messages).toHaveLength(0);
+    });
+
+    it('setMessages replaces all messages', () => {
+      const msgs = [
+        { role: 'user', content: 'One' },
+        { role: 'assistant', content: 'Two' },
+      ];
+      const state = chatReducer(defaultState, setMessages(msgs));
+      expect(state.messages).toEqual(msgs);
+    });
+
+    it('removeLastAssistantMessage removes the last assistant message', () => {
+      let state = chatReducer(defaultState, addMessage({ role: 'user', content: 'Q1' }));
+      state = chatReducer(state, addMessage({ role: 'assistant', content: 'A1' }));
+      state = chatReducer(state, addMessage({ role: 'user', content: 'Q2' }));
+      state = chatReducer(state, addMessage({ role: 'assistant', content: 'A2' }));
+
+      state = chatReducer(state, removeLastAssistantMessage());
+      expect(state.messages).toHaveLength(3);
+      expect(state.messages[2].content).toBe('Q2');
+    });
+
+    it('removeLastAssistantMessage does nothing when no assistant messages', () => {
+      let state = chatReducer(defaultState, addMessage({ role: 'user', content: 'Q1' }));
+      state = chatReducer(state, removeLastAssistantMessage());
+      expect(state.messages).toHaveLength(1);
+    });
+  });
+
+  describe('setIsProcessing', () => {
+    it('sets processing state', () => {
+      const state = chatReducer(defaultState, setIsProcessing(true));
+      expect(state.isProcessing).toBe(true);
+    });
+  });
+
+  describe('setCurrentChat', () => {
+    it('sets the current chat id', () => {
+      const state = chatReducer(defaultState, setCurrentChat('chat-123'));
+      expect(state.currentChatId).toBe('chat-123');
+    });
+  });
+
+  describe('createNewChat', () => {
+    it('resets chat-related state', () => {
+      let state = chatReducer(defaultState, setCurrentChat('chat-123'));
+      state = chatReducer(state, addMessage({ role: 'user', content: 'Hello' }));
+      state = chatReducer(state, setInputValue('Draft'));
+      state = chatReducer(state, setIsProcessing(true));
+      state = chatReducer(state, setActiveProjectId('proj-1'));
+
+      state = chatReducer(state, createNewChat());
+      expect(state.currentChatId).toBeNull();
+      expect(state.messages).toEqual([]);
+      expect(state.inputValue).toBe('');
+      expect(state.isProcessing).toBe(false);
+      expect(state.activeProjectId).toBeNull();
+      expect(state.selectedModality).toBe('text');
+      expect(state.imageQuality).toBe('standard');
+      expect(state.importedContext).toBeNull();
+    });
+  });
+
+  describe('modality and image quality', () => {
+    it('setSelectedModality sets the modality', () => {
+      const state = chatReducer(defaultState, setSelectedModality('image'));
+      expect(state.selectedModality).toBe('image');
+    });
+
+    it('setImageQuality sets the quality', () => {
+      const state = chatReducer(defaultState, setImageQuality('hd'));
+      expect(state.imageQuality).toBe('hd');
+    });
+
+    it('setPendingModality sets pending modality', () => {
+      const state = chatReducer(defaultState, setPendingModality('image'));
+      expect(state.pendingModality).toBe('image');
+    });
+  });
+
+  describe('setCreditBalance', () => {
+    it('sets the credit balance', () => {
+      const balance = { monthly: 100, packs: 20 };
+      const state = chatReducer(defaultState, setCreditBalance(balance));
+      expect(state.creditBalance).toEqual(balance);
+    });
+  });
+
+  describe('setActiveProjectId', () => {
+    it('sets the active project id', () => {
+      const state = chatReducer(defaultState, setActiveProjectId('proj-1'));
+      expect(state.activeProjectId).toBe('proj-1');
+    });
+  });
+
+  describe('setImportedContext', () => {
+    it('sets imported context', () => {
+      const ctx = { importedConversationId: 'imp-1', provider: 'claude' };
+      const state = chatReducer(defaultState, setImportedContext(ctx));
+      expect(state.importedContext).toEqual(ctx);
+    });
+  });
+
+  describe('setPendingAutoSubmit', () => {
+    it('sets pending auto submit flag', () => {
+      const state = chatReducer(defaultState, setPendingAutoSubmit(true));
+      expect(state.pendingAutoSubmit).toBe(true);
+    });
+  });
+
+  describe('conversation management', () => {
+    it('setConversations sets conversations and total', () => {
+      const state = chatReducer(
+        defaultState,
+        setConversations({ conversations: [{ id: '1' }], total: 5 })
+      );
+      expect(state.conversations).toEqual([{ id: '1' }]);
+      expect(state.conversationsTotal).toBe(5);
+    });
+
+    it('appendConversations appends to existing', () => {
+      let state = chatReducer(
+        defaultState,
+        setConversations({ conversations: [{ id: '1' }], total: 3 })
+      );
+      state = chatReducer(
+        state,
+        appendConversations({ conversations: [{ id: '2' }], total: 3 })
+      );
+      expect(state.conversations).toHaveLength(2);
+      expect(state.conversationsTotal).toBe(3);
+    });
+
+    it('setConversationsLoading sets loading state', () => {
+      const state = chatReducer(defaultState, setConversationsLoading(true));
+      expect(state.conversationsLoading).toBe(true);
+    });
+  });
+
+  describe('resetChatState', () => {
+    it('resets to initial state but preserves selectedModelId', () => {
+      let state = chatReducer(defaultState, setSelectedModel('claude-opus-4-6'));
+      state = chatReducer(state, addMessage({ role: 'user', content: 'Hello' }));
+      state = chatReducer(state, setTone('professional'));
+
+      state = chatReducer(state, resetChatState());
+      expect(state.selectedModelId).toBe('claude-opus-4-6');
+      expect(state.messages).toEqual([]);
+      expect(state.tone).toBe('default');
+    });
+  });
+
+  describe('selectors', () => {
+    const rootState = {
+      chat: {
+        inputValue: 'test',
+        mode: 'code',
+        selectedModelId: 'gpt-4o',
+        extendedThinking: true,
+        deepResearch: false,
+        googleThinking: false,
+        webSearchEnabled: true,
+        tone: 'friendly',
+        mood: 'happy',
+        autoStrategy: 'taskBased',
+        messages: [{ role: 'user', content: 'hi' }],
+        isProcessing: true,
+        currentChatId: 'chat-1',
+        pendingAutoSubmit: false,
+        pendingModality: null,
+        selectedModality: 'image',
+        imageQuality: 'hd',
+        creditBalance: { monthly: 50 },
+        activeProjectId: 'proj-1',
+        conversations: [{ id: 'c1' }],
+        conversationsTotal: 10,
+        conversationsLoading: false,
+        importedContext: { provider: 'claude' },
+      },
+    };
+
+    it('selectInputValue', () => expect(selectInputValue(rootState)).toBe('test'));
+    it('selectMode', () => expect(selectMode(rootState)).toBe('code'));
+    it('selectSelectedModelId', () => expect(selectSelectedModelId(rootState)).toBe('gpt-4o'));
+    it('selectExtendedThinking', () => expect(selectExtendedThinking(rootState)).toBe(true));
+    it('selectDeepResearch', () => expect(selectDeepResearch(rootState)).toBe(false));
+    it('selectGoogleThinking', () => expect(selectGoogleThinking(rootState)).toBe(false));
+    it('selectWebSearchEnabled', () => expect(selectWebSearchEnabled(rootState)).toBe(true));
+    it('selectTone', () => expect(selectTone(rootState)).toBe('friendly'));
+    it('selectMood', () => expect(selectMood(rootState)).toBe('happy'));
+    it('selectAutoStrategy', () => expect(selectAutoStrategy(rootState)).toBe('taskBased'));
+    it('selectMessages', () => expect(selectMessages(rootState)).toHaveLength(1));
+    it('selectIsProcessing', () => expect(selectIsProcessing(rootState)).toBe(true));
+    it('selectCurrentChatId', () => expect(selectCurrentChatId(rootState)).toBe('chat-1'));
+    it('selectPendingAutoSubmit', () => expect(selectPendingAutoSubmit(rootState)).toBe(false));
+    it('selectPendingModality', () => expect(selectPendingModality(rootState)).toBeNull());
+    it('selectSelectedModality', () => expect(selectSelectedModality(rootState)).toBe('image'));
+    it('selectImageQuality', () => expect(selectImageQuality(rootState)).toBe('hd'));
+    it('selectCreditBalance', () =>
+      expect(selectCreditBalance(rootState)).toEqual({ monthly: 50 }));
+    it('selectActiveProjectId', () => expect(selectActiveProjectId(rootState)).toBe('proj-1'));
+    it('selectConversations', () => expect(selectConversations(rootState)).toHaveLength(1));
+    it('selectConversationsTotal', () => expect(selectConversationsTotal(rootState)).toBe(10));
+    it('selectConversationsLoading', () =>
+      expect(selectConversationsLoading(rootState)).toBe(false));
+    it('selectImportedContext', () =>
+      expect(selectImportedContext(rootState)).toEqual({ provider: 'claude' }));
+  });
+});

--- a/src/store/slices/projectsSlice.test.js
+++ b/src/store/slices/projectsSlice.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import projectsReducer, {
+  setProjects,
+  addProject,
+  updateProject,
+  removeProject,
+  setProjectsLoading,
+  setProjectsError,
+  resetProjectsState,
+  selectProjects,
+  selectProjectsLoading,
+  selectProjectsError,
+} from './projectsSlice';
+
+describe('projectsSlice', () => {
+  const initialState = { projects: [], loading: false, error: null };
+
+  describe('initial state', () => {
+    it('has empty projects, not loading, no error', () => {
+      const state = projectsReducer(undefined, { type: 'unknown' });
+      expect(state).toEqual(initialState);
+    });
+  });
+
+  describe('setProjects', () => {
+    it('sets the projects array', () => {
+      const projects = [
+        { id: '1', name: 'Project A' },
+        { id: '2', name: 'Project B' },
+      ];
+      const state = projectsReducer(initialState, setProjects(projects));
+      expect(state.projects).toEqual(projects);
+    });
+
+    it('replaces existing projects', () => {
+      const prev = { ...initialState, projects: [{ id: '1', name: 'Old' }] };
+      const state = projectsReducer(prev, setProjects([{ id: '2', name: 'New' }]));
+      expect(state.projects).toHaveLength(1);
+      expect(state.projects[0].name).toBe('New');
+    });
+  });
+
+  describe('addProject', () => {
+    it('adds a project to the beginning of the list', () => {
+      const prev = { ...initialState, projects: [{ id: '1', name: 'Existing' }] };
+      const state = projectsReducer(prev, addProject({ id: '2', name: 'New' }));
+      expect(state.projects).toHaveLength(2);
+      expect(state.projects[0].name).toBe('New');
+    });
+  });
+
+  describe('updateProject', () => {
+    it('updates the correct project', () => {
+      const prev = {
+        ...initialState,
+        projects: [
+          { id: '1', name: 'A', description: 'Old' },
+          { id: '2', name: 'B' },
+        ],
+      };
+      const state = projectsReducer(
+        prev,
+        updateProject({ id: '1', updates: { description: 'Updated' } })
+      );
+      expect(state.projects[0].description).toBe('Updated');
+      expect(state.projects[0].name).toBe('A');
+    });
+
+    it('does nothing for nonexistent project', () => {
+      const prev = { ...initialState, projects: [{ id: '1', name: 'A' }] };
+      const state = projectsReducer(
+        prev,
+        updateProject({ id: '999', updates: { name: 'X' } })
+      );
+      expect(state.projects).toHaveLength(1);
+      expect(state.projects[0].name).toBe('A');
+    });
+  });
+
+  describe('removeProject', () => {
+    it('removes the project by id', () => {
+      const prev = {
+        ...initialState,
+        projects: [
+          { id: '1', name: 'A' },
+          { id: '2', name: 'B' },
+        ],
+      };
+      const state = projectsReducer(prev, removeProject('1'));
+      expect(state.projects).toHaveLength(1);
+      expect(state.projects[0].id).toBe('2');
+    });
+
+    it('does nothing for nonexistent id', () => {
+      const prev = { ...initialState, projects: [{ id: '1', name: 'A' }] };
+      const state = projectsReducer(prev, removeProject('999'));
+      expect(state.projects).toHaveLength(1);
+    });
+  });
+
+  describe('setProjectsLoading', () => {
+    it('sets loading state', () => {
+      const state = projectsReducer(initialState, setProjectsLoading(true));
+      expect(state.loading).toBe(true);
+    });
+  });
+
+  describe('setProjectsError', () => {
+    it('sets error message', () => {
+      const state = projectsReducer(initialState, setProjectsError('Something went wrong'));
+      expect(state.error).toBe('Something went wrong');
+    });
+  });
+
+  describe('resetProjectsState', () => {
+    it('resets to initial state', () => {
+      const prev = {
+        projects: [{ id: '1' }],
+        loading: true,
+        error: 'err',
+      };
+      const state = projectsReducer(prev, resetProjectsState());
+      expect(state).toEqual(initialState);
+    });
+  });
+
+  describe('selectors', () => {
+    const rootState = {
+      projects: {
+        projects: [{ id: '1', name: 'Test' }],
+        loading: true,
+        error: 'err',
+      },
+    };
+
+    it('selectProjects returns the projects array', () => {
+      expect(selectProjects(rootState)).toEqual([{ id: '1', name: 'Test' }]);
+    });
+
+    it('selectProjectsLoading returns loading', () => {
+      expect(selectProjectsLoading(rootState)).toBe(true);
+    });
+
+    it('selectProjectsError returns error', () => {
+      expect(selectProjectsError(rootState)).toBe('err');
+    });
+  });
+});

--- a/src/store/slices/sidebarSlice.test.js
+++ b/src/store/slices/sidebarSlice.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import sidebarReducer, {
+  toggleSidebar,
+  setCollapsed,
+  setActiveItem,
+  selectSidebarCollapsed,
+  selectActiveItem,
+} from './sidebarSlice';
+
+describe('sidebarSlice', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('initial state', () => {
+    it('defaults to collapsed true', () => {
+      const state = sidebarReducer(undefined, { type: 'unknown' });
+      expect(state.collapsed).toBe(true);
+    });
+
+    it('defaults activeItem to home', () => {
+      const state = sidebarReducer(undefined, { type: 'unknown' });
+      expect(state.activeItem).toBe('home');
+    });
+  });
+
+  describe('toggleSidebar', () => {
+    it('toggles collapsed from true to false', () => {
+      const state = sidebarReducer({ collapsed: true, activeItem: 'home' }, toggleSidebar());
+      expect(state.collapsed).toBe(false);
+    });
+
+    it('toggles collapsed from false to true', () => {
+      const state = sidebarReducer({ collapsed: false, activeItem: 'home' }, toggleSidebar());
+      expect(state.collapsed).toBe(true);
+    });
+
+    it('persists to localStorage', () => {
+      sidebarReducer({ collapsed: true, activeItem: 'home' }, toggleSidebar());
+      expect(localStorage.setItem).toHaveBeenCalledWith('araviel-sidebar-collapsed', false);
+    });
+  });
+
+  describe('setCollapsed', () => {
+    it('sets collapsed to the given value', () => {
+      const state = sidebarReducer({ collapsed: true, activeItem: 'home' }, setCollapsed(false));
+      expect(state.collapsed).toBe(false);
+    });
+
+    it('persists to localStorage', () => {
+      sidebarReducer({ collapsed: true, activeItem: 'home' }, setCollapsed(false));
+      expect(localStorage.setItem).toHaveBeenCalledWith('araviel-sidebar-collapsed', false);
+    });
+  });
+
+  describe('setActiveItem', () => {
+    it('sets the active item', () => {
+      const state = sidebarReducer(
+        { collapsed: true, activeItem: 'home' },
+        setActiveItem('settings')
+      );
+      expect(state.activeItem).toBe('settings');
+    });
+
+    it('can set to any string', () => {
+      const state = sidebarReducer(
+        { collapsed: true, activeItem: 'home' },
+        setActiveItem('conversations')
+      );
+      expect(state.activeItem).toBe('conversations');
+    });
+  });
+
+  describe('selectors', () => {
+    it('selectSidebarCollapsed returns collapsed state', () => {
+      expect(selectSidebarCollapsed({ sidebar: { collapsed: true } })).toBe(true);
+      expect(selectSidebarCollapsed({ sidebar: { collapsed: false } })).toBe(false);
+    });
+
+    it('selectActiveItem returns active item', () => {
+      expect(selectActiveItem({ sidebar: { activeItem: 'models' } })).toBe('models');
+    });
+  });
+});

--- a/src/store/slices/subscriptionSlice.test.js
+++ b/src/store/slices/subscriptionSlice.test.js
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest';
+import subscriptionReducer, {
+  setCurrentTier,
+  setBillingCycle,
+  setIsFirstMonth,
+  setTextCredits,
+  setImageCredits,
+  setSubscriptionData,
+  showUpgradeModal,
+  hideUpgradeModal,
+  initiateUpgrade,
+  clearUpgradeLoading,
+  resetSubscriptionState,
+  selectCurrentTier,
+  selectBillingCycle,
+  selectIsFirstMonth,
+  selectPeriodEnd,
+  selectCancelAtPeriodEnd,
+  selectSubscriptionStatus,
+  selectTextCredits,
+  selectImageCredits,
+  selectShowUpgradeModal,
+  selectUpgradeContext,
+  selectUpgradeLoading,
+  selectCheckoutLoading,
+  selectPortalLoading,
+  selectSubscriptionError,
+} from './subscriptionSlice';
+
+describe('subscriptionSlice', () => {
+  let defaultState;
+
+  beforeEach(() => {
+    defaultState = subscriptionReducer(undefined, { type: 'unknown' });
+  });
+
+  describe('initial state', () => {
+    it('defaults to free tier', () => {
+      expect(defaultState.currentTier).toBe('free');
+    });
+
+    it('defaults to monthly billing', () => {
+      expect(defaultState.billingCycle).toBe('monthly');
+    });
+
+    it('defaults to idle subscription status', () => {
+      expect(defaultState.subscriptionStatus).toBe('idle');
+    });
+
+    it('has default text credits', () => {
+      expect(defaultState.textCredits.monthlyLimit).toBe(100);
+      expect(defaultState.textCredits.windowLimit).toBe(8);
+    });
+
+    it('has default image credits', () => {
+      expect(defaultState.imageCredits.limit).toBe(5);
+      expect(defaultState.imageCredits.remaining).toBe(5);
+    });
+  });
+
+  describe('setCurrentTier', () => {
+    it('sets the tier', () => {
+      const state = subscriptionReducer(defaultState, setCurrentTier('pro'));
+      expect(state.currentTier).toBe('pro');
+    });
+  });
+
+  describe('setBillingCycle', () => {
+    it('sets the billing cycle', () => {
+      const state = subscriptionReducer(defaultState, setBillingCycle('annual'));
+      expect(state.billingCycle).toBe('annual');
+    });
+  });
+
+  describe('setIsFirstMonth', () => {
+    it('sets first month flag', () => {
+      const state = subscriptionReducer(defaultState, setIsFirstMonth(true));
+      expect(state.isFirstMonth).toBe(true);
+    });
+  });
+
+  describe('setTextCredits', () => {
+    it('merges with existing text credits', () => {
+      const state = subscriptionReducer(
+        defaultState,
+        setTextCredits({ monthlyUsed: 50, monthlyLimit: 1500 })
+      );
+      expect(state.textCredits.monthlyUsed).toBe(50);
+      expect(state.textCredits.monthlyLimit).toBe(1500);
+      expect(state.textCredits.windowLimit).toBe(8); // preserved
+    });
+  });
+
+  describe('setImageCredits', () => {
+    it('merges with existing image credits', () => {
+      const state = subscriptionReducer(
+        defaultState,
+        setImageCredits({ used: 3, remaining: 47, limit: 50 })
+      );
+      expect(state.imageCredits.used).toBe(3);
+      expect(state.imageCredits.remaining).toBe(47);
+      expect(state.imageCredits.limit).toBe(50);
+    });
+  });
+
+  describe('setSubscriptionData', () => {
+    it('bulk-sets subscription data from API response', () => {
+      const state = subscriptionReducer(
+        defaultState,
+        setSubscriptionData({
+          tier: 'lite',
+          billingInterval: 'annual',
+          periodEnd: '2024-12-31',
+          cancelAtPeriodEnd: true,
+          firstMonth: true,
+          textCredits: {
+            monthlyUsed: 100,
+            monthlyLimit: 1500,
+            windowUsed: 10,
+            windowLimit: 60,
+            windowResetAt: '2024-01-01',
+          },
+          imageCredits: {
+            used: 5,
+            limit: 50,
+            remaining: 45,
+            packRemaining: 10,
+            cycleResetsAt: '2024-02-01',
+          },
+        })
+      );
+
+      expect(state.currentTier).toBe('lite');
+      expect(state.billingCycle).toBe('annual');
+      expect(state.periodEnd).toBe('2024-12-31');
+      expect(state.cancelAtPeriodEnd).toBe(true);
+      expect(state.isFirstMonth).toBe(true);
+      expect(state.textCredits.monthlyUsed).toBe(100);
+      expect(state.textCredits.monthlyLimit).toBe(1500);
+      expect(state.imageCredits.used).toBe(5);
+      expect(state.imageCredits.packRemaining).toBe(10);
+      expect(state.subscriptionStatus).toBe('succeeded');
+    });
+
+    it('handles partial data gracefully', () => {
+      const state = subscriptionReducer(
+        defaultState,
+        setSubscriptionData({ tier: 'pro' })
+      );
+      expect(state.currentTier).toBe('pro');
+      expect(state.billingCycle).toBe('monthly'); // unchanged
+    });
+  });
+
+  describe('upgrade modal', () => {
+    it('showUpgradeModal opens modal with context', () => {
+      const state = subscriptionReducer(defaultState, showUpgradeModal('credits_exhausted'));
+      expect(state.showUpgradeModal).toBe(true);
+      expect(state.upgradeContext).toBe('credits_exhausted');
+    });
+
+    it('showUpgradeModal works without context', () => {
+      const state = subscriptionReducer(defaultState, showUpgradeModal());
+      expect(state.showUpgradeModal).toBe(true);
+      expect(state.upgradeContext).toBeNull();
+    });
+
+    it('hideUpgradeModal closes modal and clears context', () => {
+      let state = subscriptionReducer(defaultState, showUpgradeModal('test'));
+      state = subscriptionReducer(state, hideUpgradeModal());
+      expect(state.showUpgradeModal).toBe(false);
+      expect(state.upgradeContext).toBeNull();
+    });
+  });
+
+  describe('upgrade loading', () => {
+    it('initiateUpgrade sets loading tier', () => {
+      const state = subscriptionReducer(defaultState, initiateUpgrade('pro'));
+      expect(state.upgradeLoading).toBe('pro');
+    });
+
+    it('clearUpgradeLoading clears loading', () => {
+      let state = subscriptionReducer(defaultState, initiateUpgrade('pro'));
+      state = subscriptionReducer(state, clearUpgradeLoading());
+      expect(state.upgradeLoading).toBeNull();
+    });
+  });
+
+  describe('resetSubscriptionState', () => {
+    it('resets to defaults', () => {
+      let state = subscriptionReducer(defaultState, setCurrentTier('pro'));
+      state = subscriptionReducer(state, setBillingCycle('annual'));
+      state = subscriptionReducer(state, resetSubscriptionState());
+      expect(state.currentTier).toBe('free');
+      expect(state.billingCycle).toBe('monthly');
+    });
+  });
+
+  describe('async thunk reducers', () => {
+    it('handles fetchSubscription.pending', () => {
+      const state = subscriptionReducer(defaultState, {
+        type: 'subscription/fetch/pending',
+      });
+      expect(state.subscriptionStatus).toBe('loading');
+    });
+
+    it('handles fetchSubscription.fulfilled', () => {
+      const state = subscriptionReducer(defaultState, {
+        type: 'subscription/fetch/fulfilled',
+        payload: {
+          tier: 'lite',
+          billingInterval: 'annual',
+          textCredits: { monthlyUsed: 50, monthlyLimit: 1500 },
+          imageCredits: { used: 2, limit: 50, remaining: 48 },
+        },
+      });
+      expect(state.currentTier).toBe('lite');
+      expect(state.subscriptionStatus).toBe('succeeded');
+    });
+
+    it('handles fetchSubscription.rejected', () => {
+      const state = subscriptionReducer(defaultState, {
+        type: 'subscription/fetch/rejected',
+      });
+      expect(state.subscriptionStatus).toBe('failed');
+    });
+
+    it('handles createCheckout.pending', () => {
+      const state = subscriptionReducer(defaultState, {
+        type: 'subscription/createCheckout/pending',
+      });
+      expect(state.checkoutLoading).toBe(true);
+      expect(state.error).toBeNull();
+    });
+
+    it('handles createCheckout.fulfilled', () => {
+      const prev = { ...defaultState, checkoutLoading: true };
+      const state = subscriptionReducer(prev, {
+        type: 'subscription/createCheckout/fulfilled',
+      });
+      expect(state.checkoutLoading).toBe(false);
+    });
+
+    it('handles createCheckout.rejected', () => {
+      const state = subscriptionReducer(defaultState, {
+        type: 'subscription/createCheckout/rejected',
+        payload: 'Checkout failed',
+      });
+      expect(state.checkoutLoading).toBe(false);
+      expect(state.error).toBe('Checkout failed');
+    });
+
+    it('handles createPortal.pending', () => {
+      const state = subscriptionReducer(defaultState, {
+        type: 'subscription/createPortal/pending',
+      });
+      expect(state.portalLoading).toBe(true);
+    });
+
+    it('handles createPortal.rejected', () => {
+      const state = subscriptionReducer(defaultState, {
+        type: 'subscription/createPortal/rejected',
+        payload: 'Portal failed',
+      });
+      expect(state.portalLoading).toBe(false);
+      expect(state.error).toBe('Portal failed');
+    });
+  });
+
+  describe('selectors', () => {
+    const rootState = {
+      subscription: {
+        currentTier: 'pro',
+        billingCycle: 'annual',
+        isFirstMonth: true,
+        periodEnd: '2024-12-31',
+        cancelAtPeriodEnd: false,
+        subscriptionStatus: 'succeeded',
+        textCredits: { monthlyUsed: 100, monthlyLimit: 4000 },
+        imageCredits: { used: 10, limit: 150, remaining: 140 },
+        showUpgradeModal: false,
+        upgradeContext: null,
+        upgradeLoading: null,
+        checkoutLoading: false,
+        portalLoading: false,
+        error: null,
+      },
+    };
+
+    it('selectCurrentTier', () => expect(selectCurrentTier(rootState)).toBe('pro'));
+    it('selectBillingCycle', () => expect(selectBillingCycle(rootState)).toBe('annual'));
+    it('selectIsFirstMonth', () => expect(selectIsFirstMonth(rootState)).toBe(true));
+    it('selectPeriodEnd', () => expect(selectPeriodEnd(rootState)).toBe('2024-12-31'));
+    it('selectCancelAtPeriodEnd', () => expect(selectCancelAtPeriodEnd(rootState)).toBe(false));
+    it('selectSubscriptionStatus', () =>
+      expect(selectSubscriptionStatus(rootState)).toBe('succeeded'));
+    it('selectTextCredits', () =>
+      expect(selectTextCredits(rootState).monthlyLimit).toBe(4000));
+    it('selectImageCredits', () =>
+      expect(selectImageCredits(rootState).remaining).toBe(140));
+    it('selectShowUpgradeModal', () =>
+      expect(selectShowUpgradeModal(rootState)).toBe(false));
+    it('selectUpgradeContext', () => expect(selectUpgradeContext(rootState)).toBeNull());
+    it('selectUpgradeLoading', () => expect(selectUpgradeLoading(rootState)).toBeNull());
+    it('selectCheckoutLoading', () => expect(selectCheckoutLoading(rootState)).toBe(false));
+    it('selectPortalLoading', () => expect(selectPortalLoading(rootState)).toBe(false));
+    it('selectSubscriptionError', () => expect(selectSubscriptionError(rootState)).toBeNull());
+  });
+});

--- a/src/store/slices/themeSlice.test.js
+++ b/src/store/slices/themeSlice.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import themeReducer, { setTheme, selectTheme, selectEffectiveTheme } from './themeSlice';
+
+describe('themeSlice', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('reducer', () => {
+    it('has "system" as default mode', () => {
+      const state = themeReducer(undefined, { type: 'unknown' });
+      expect(state.mode).toBe('system');
+    });
+
+    it('reads initial theme from localStorage', () => {
+      localStorage.setItem('araviel-theme', 'dark');
+      // Re-import would be needed for true init test; instead test setTheme
+      const state = themeReducer(undefined, setTheme('dark'));
+      expect(state.mode).toBe('dark');
+    });
+  });
+
+  describe('setTheme', () => {
+    it('sets mode to light', () => {
+      const state = themeReducer(undefined, setTheme('light'));
+      expect(state.mode).toBe('light');
+    });
+
+    it('sets mode to dark', () => {
+      const state = themeReducer(undefined, setTheme('dark'));
+      expect(state.mode).toBe('dark');
+    });
+
+    it('sets mode to system', () => {
+      const prev = themeReducer(undefined, setTheme('dark'));
+      const state = themeReducer(prev, setTheme('system'));
+      expect(state.mode).toBe('system');
+    });
+
+    it('persists to localStorage', () => {
+      themeReducer(undefined, setTheme('dark'));
+      expect(localStorage.setItem).toHaveBeenCalledWith('araviel-theme', 'dark');
+    });
+  });
+
+  describe('selectors', () => {
+    it('selectTheme returns the mode', () => {
+      const state = { theme: { mode: 'dark' } };
+      expect(selectTheme(state)).toBe('dark');
+    });
+
+    it('selectEffectiveTheme returns the mode for light/dark', () => {
+      expect(selectEffectiveTheme({ theme: { mode: 'light' } })).toBe('light');
+      expect(selectEffectiveTheme({ theme: { mode: 'dark' } })).toBe('dark');
+    });
+
+    it('selectEffectiveTheme resolves system to light/dark', () => {
+      const result = selectEffectiveTheme({ theme: { mode: 'system' } });
+      expect(['light', 'dark']).toContain(result);
+    });
+  });
+});

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom/vitest';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem: vi.fn((key) => store[key] ?? null),
+    setItem: vi.fn((key, value) => {
+      store[key] = String(value);
+    }),
+    removeItem: vi.fn((key) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((index) => Object.keys(store)[index] ?? null),
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+// Mock matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock crypto.randomUUID
+Object.defineProperty(globalThis, 'crypto', {
+  value: {
+    randomUUID: vi.fn(() => 'test-uuid-1234'),
+  },
+});
+
+// Environment variables are set via vitest.config.js env option
+
+// Clear localStorage between tests
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});

--- a/src/utils/guestSession.test.js
+++ b/src/utils/guestSession.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getGuestPromptCount,
+  incrementGuestPromptCount,
+  hasReachedGuestLimit,
+  getRemainingGuestPrompts,
+  getGuestImageCount,
+  incrementGuestImageCount,
+  hasReachedGuestImageLimit,
+  getRemainingGuestImages,
+  resetGuestPromptCount,
+  GUEST_PROMPT_LIMIT,
+  GUEST_IMAGE_LIMIT,
+} from './guestSession';
+
+describe('guestSession', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('text prompts', () => {
+    it('returns 0 when no prompts have been sent', () => {
+      expect(getGuestPromptCount()).toBe(0);
+    });
+
+    it('increments the prompt count', () => {
+      incrementGuestPromptCount();
+      expect(getGuestPromptCount()).toBe(1);
+
+      incrementGuestPromptCount();
+      expect(getGuestPromptCount()).toBe(2);
+    });
+
+    it('reports limit not reached when under limit', () => {
+      expect(hasReachedGuestLimit()).toBe(false);
+    });
+
+    it('reports limit reached when at the limit', () => {
+      for (let i = 0; i < GUEST_PROMPT_LIMIT; i++) {
+        incrementGuestPromptCount();
+      }
+      expect(hasReachedGuestLimit()).toBe(true);
+    });
+
+    it('reports limit reached when over the limit', () => {
+      for (let i = 0; i < GUEST_PROMPT_LIMIT + 1; i++) {
+        incrementGuestPromptCount();
+      }
+      expect(hasReachedGuestLimit()).toBe(true);
+    });
+
+    it('returns correct remaining prompts', () => {
+      expect(getRemainingGuestPrompts()).toBe(GUEST_PROMPT_LIMIT);
+
+      incrementGuestPromptCount();
+      expect(getRemainingGuestPrompts()).toBe(GUEST_PROMPT_LIMIT - 1);
+    });
+
+    it('never returns negative remaining prompts', () => {
+      for (let i = 0; i < GUEST_PROMPT_LIMIT + 5; i++) {
+        incrementGuestPromptCount();
+      }
+      expect(getRemainingGuestPrompts()).toBe(0);
+    });
+  });
+
+  describe('image prompts', () => {
+    it('returns 0 when no images have been generated', () => {
+      expect(getGuestImageCount()).toBe(0);
+    });
+
+    it('increments the image count', () => {
+      incrementGuestImageCount();
+      expect(getGuestImageCount()).toBe(1);
+    });
+
+    it('always reports image limit reached since limit is 0', () => {
+      expect(GUEST_IMAGE_LIMIT).toBe(0);
+      expect(hasReachedGuestImageLimit()).toBe(true);
+    });
+
+    it('returns 0 remaining images', () => {
+      expect(getRemainingGuestImages()).toBe(0);
+    });
+  });
+
+  describe('resetGuestPromptCount', () => {
+    it('resets both text and image counts', () => {
+      incrementGuestPromptCount();
+      incrementGuestPromptCount();
+      incrementGuestImageCount();
+
+      resetGuestPromptCount();
+
+      expect(getGuestPromptCount()).toBe(0);
+      expect(getGuestImageCount()).toBe(0);
+    });
+
+    it('removes the localStorage keys', () => {
+      incrementGuestPromptCount();
+      resetGuestPromptCount();
+      expect(localStorage.removeItem).toHaveBeenCalledWith('araviel-guest-prompt-count');
+      expect(localStorage.removeItem).toHaveBeenCalledWith('araviel-guest-image-count');
+    });
+  });
+
+  describe('constants', () => {
+    it('has GUEST_PROMPT_LIMIT of 3', () => {
+      expect(GUEST_PROMPT_LIMIT).toBe(3);
+    });
+
+    it('has GUEST_IMAGE_LIMIT of 0', () => {
+      expect(GUEST_IMAGE_LIMIT).toBe(0);
+    });
+  });
+});

--- a/src/utils/quickPromptsData.test.js
+++ b/src/utils/quickPromptsData.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { promptsData, quickPromptKeys } from './quickPromptsData';
+
+describe('quickPromptsData', () => {
+  it('exports exactly 6 prompt categories', () => {
+    expect(Object.keys(promptsData)).toHaveLength(6);
+  });
+
+  it('quickPromptKeys matches the keys in promptsData', () => {
+    expect(quickPromptKeys).toEqual(['code', 'write', 'research', 'analyze', 'create', 'learn']);
+    for (const key of quickPromptKeys) {
+      expect(promptsData[key]).toBeDefined();
+    }
+  });
+
+  it('each category has a title, icon, and items array', () => {
+    for (const key of quickPromptKeys) {
+      const category = promptsData[key];
+      expect(category.title).toBeDefined();
+      expect(typeof category.title).toBe('string');
+      expect(category.icon).toBeDefined();
+      expect(Array.isArray(category.items)).toBe(true);
+      expect(category.items.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('each item has text and icon properties', () => {
+    for (const key of quickPromptKeys) {
+      for (const item of promptsData[key].items) {
+        expect(typeof item.text).toBe('string');
+        expect(item.text.length).toBeGreaterThan(0);
+        expect(item.icon).toBeDefined();
+      }
+    }
+  });
+
+  it('each category has exactly 4 items', () => {
+    for (const key of quickPromptKeys) {
+      expect(promptsData[key].items).toHaveLength(4);
+    }
+  });
+
+  it('has the expected category titles', () => {
+    expect(promptsData.code.title).toBe('Code');
+    expect(promptsData.write.title).toBe('Write');
+    expect(promptsData.research.title).toBe('Research');
+    expect(promptsData.analyze.title).toBe('Analyse');
+    expect(promptsData.create.title).toBe('Create');
+    expect(promptsData.learn.title).toBe('Learn');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.js'],
+    css: false,
+    env: {
+      VITE_SUPABASE_URL: 'https://test.supabase.co',
+      VITE_SUPABASE_ANON_KEY: 'test-anon-key',
+    },
+  },
+});


### PR DESCRIPTION
Set up Vitest with jsdom, @testing-library/react, and @testing-library/jest-dom. Added tests covering all Redux slices (auth, chat, theme, sidebar, analytics, projects, subscription), utility functions (guestSession, quickPromptsData), config modules (credits, subscription helpers), data layer (models registry), and services (analytics, conversationParsers, credits, settings).

https://claude.ai/code/session_01Ng9EQTrtgRiekuUCbwSbZ1