### PR TITLE
fix(image-viewer): centre footer under image, add gap, make prompt sc…

### DIFF
--- a/src/components/ImageGalleryView/ImageGalleryView.jsx
+++ b/src/components/ImageGalleryView/ImageGalleryView.jsx
@@ -887,7 +887,7 @@ function ImageDetailView({ images, startIndex, onClose, onDownload, onDelete }) 
           </div>
         </div>
 
-        {/* Main area: sidebar + image */}
+        {/* Main area: sidebar + image + footer (footer is inside the image column so it centres against the image, not the full container) */}
         <div className={styles.detailMain}>
           {/* Thumbnail sidebar — only shown when multiple images */}
           {images.length > 1 && (
@@ -915,40 +915,46 @@ function ImageDetailView({ images, startIndex, onClose, onDownload, onDelete }) 
             </div>
           )}
 
-          {/* Main image */}
-          <div className={styles.detailBody}>
-            <img
-              key={activeIndex}
-              src={img.url}
-              alt={img.prompt || 'Generated image'}
-              className={styles.detailImage}
-              onError={(e) => {
-                e.target.style.opacity = '0.2';
-              }}
-            />
-          </div>
-        </div>
+          {/* Image column: image + footer stacked so footer aligns under the image */}
+          <div className={styles.detailContent}>
+            <div className={styles.detailBody}>
+              <img
+                key={activeIndex}
+                src={img.url}
+                alt={img.prompt || 'Generated image'}
+                className={styles.detailImage}
+                onError={(e) => {
+                  e.target.style.opacity = '0.2';
+                }}
+              />
+            </div>
 
-        {/* Footer: prompt + meta */}
-        <div className={styles.detailFooter}>
-          {img.prompt && <p className={styles.detailPromptText}>{img.prompt}</p>}
-          <div className={styles.detailMetaRow}>
-            {img.provider && (
-              <span className={styles.detailMetaChip}>{providerData?.name || img.provider}</span>
-            )}
-            {img.size && <span className={styles.detailMetaChip}>{img.size}</span>}
-            {images.length > 1 && (
-              <span className={styles.detailMetaChip}>
-                {activeIndex + 1} of {images.length}
-              </span>
-            )}
-            <span className={styles.detailMetaChip}>
-              {new Date(img.createdAt).toLocaleDateString(undefined, {
-                month: 'short',
-                day: 'numeric',
-                year: 'numeric',
-              })}
-            </span>
+            {/* Footer: prompt (scrollable) + meta */}
+            <div className={styles.detailFooter}>
+              {img.prompt && (
+                <div className={styles.detailPromptScroll}>
+                  <p className={styles.detailPromptText}>{img.prompt}</p>
+                </div>
+              )}
+              <div className={styles.detailMetaRow}>
+                {img.provider && (
+                  <span className={styles.detailMetaChip}>{providerData?.name || img.provider}</span>
+                )}
+                {img.size && <span className={styles.detailMetaChip}>{img.size}</span>}
+                {images.length > 1 && (
+                  <span className={styles.detailMetaChip}>
+                    {activeIndex + 1} of {images.length}
+                  </span>
+                )}
+                <span className={styles.detailMetaChip}>
+                  {new Date(img.createdAt).toLocaleDateString(undefined, {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                </span>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/src/components/ImageGalleryView/ImageGalleryView.module.css
+++ b/src/components/ImageGalleryView/ImageGalleryView.module.css
@@ -953,7 +953,15 @@
 }
 
 :global([data-theme='light']) .detailPromptText {
-  color: rgba(0, 0, 0, 0.45);
+  color: rgba(0, 0, 0, 0.5);
+}
+
+:global([data-theme='light']) .detailPromptScroll {
+  scrollbar-color: rgba(0, 0, 0, 0.14) transparent;
+}
+
+:global([data-theme='light']) .detailPromptScroll::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.14);
 }
 
 :global([data-theme='light']) .detailMetaChip {
@@ -1174,6 +1182,15 @@
   transform: scale(1);
 }
 
+/* Image column: image + footer stacked */
+.detailContent {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+}
+
 /* Main image body */
 .detailBody {
   flex: 1;
@@ -1187,7 +1204,7 @@
 
 .detailImage {
   max-width: 80vw;
-  max-height: calc(100vh - 220px);
+  max-height: calc(100vh - 260px);
   border-radius: 14px;
   object-fit: contain;
   box-shadow: 0 16px 56px rgba(0, 0, 0, 0.5);
@@ -1206,21 +1223,43 @@
   }
 }
 
-/* Footer */
+/* Footer: sits below the image within the same column */
 .detailFooter {
   flex-shrink: 0;
-  padding: 16px 24px 24px;
+  padding: 20px 24px 28px;
   text-align: center;
-  max-width: 640px;
+  max-width: 600px;
   margin: 0 auto;
   width: 100%;
+}
+
+/* Scrollable prompt container — shows ~4 lines, scrolls beyond that */
+.detailPromptScroll {
+  max-height: 84px; /* 4 lines × 13px × 1.6 line-height */
+  overflow-y: auto;
+  margin-bottom: 12px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.14) transparent;
+}
+
+.detailPromptScroll::-webkit-scrollbar {
+  width: 3px;
+}
+
+.detailPromptScroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.detailPromptScroll::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 2px;
 }
 
 .detailPromptText {
   font-size: 13px;
   line-height: 1.6;
   color: rgba(255, 255, 255, 0.55);
-  margin: 0 0 8px;
+  margin: 0;
 }
 
 .detailMetaRow {
@@ -1319,7 +1358,7 @@
 
   .detailImage {
     max-width: 95vw;
-    max-height: calc(100vh - 180px);
+    max-height: calc(100vh - 240px);
   }
 
   .detailTopBar {


### PR DESCRIPTION
…rollable

- Wraps the image body and footer in a shared flex column (.detailContent) so the footer centres against the image column rather than the full container width — fixes the off-centre alignment when thumbnails are shown
- Increases top padding on the footer (16px → 20px) for a clean gap between image and prompt text
- Wraps the prompt in a scrollable container capped at 4 lines (84px); overflow scrolls with a 3px subtle scrollbar, hidden until needed
- Reduces image max-height slightly (220px → 260px offset) to always leave room for the footer within the column
- Light and dark scrollbar colour overrides included

https://claude.ai/code/session_01PHh5jXWzPq9mejz3Q3uUKS