### PR TITLE
fix(credits): preserve user's image quality selection when firing fro…

### DIFF
--- a/src/components/ImageGalleryView/ImageGalleryView.jsx
+++ b/src/components/ImageGalleryView/ImageGalleryView.jsx
@@ -300,7 +300,10 @@ export default function ImageGalleryView() {
     if (!isAuthenticated) {
       incrementGuestImageCount();
     }
+    // Capture quality before createNewChat resets it to 'standard'
+    const qualityToUse = imageQuality;
     dispatch(createNewChat());
+    dispatch(setImageQuality(qualityToUse));
     dispatch(setInputValue(prompt));
     dispatch(setPendingModality('image'));
     dispatch(setPendingAutoSubmit(true));


### PR DESCRIPTION
…m Images page

createNewChat() resets imageQuality to 'standard' in Redux. In ImageGalleryView.firePromptInChat this meant any HD/Ultra selection was silently wiped before the auto-submit fired in MainContent, so the API always received quality='standard' and charged only 1 credit.

Fix: capture the selected quality before dispatching createNewChat, then restore it immediately after so the auto-submit sends the correct value (SD=1, HD=2, Ultra=4).

https://claude.ai/code/session_01LbHiuh8zL4R45vxb1n2Jg8