### PR TITLE
feat(vision): add image upload compression, submission, and display i…

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -117,6 +117,7 @@ import {
 } from '../../store/slices/subscriptionSlice';
 import { getNextTier } from '../../config/subscription';
 import { PROVIDERS, isImageGenerationModel } from '../../data/models';
+import { compressImage, isAcceptedImageType } from '../../utils/imageCompression';
 import {
   canGenerateImage,
   recordGeneration,
@@ -557,8 +558,9 @@ function ImageLimitPrompt({ onClose, onBuyCredits, onUpgrade }) {
   const isFree = !currentTier || currentTier === 'free';
 
   // Use real credit data from server when available, fall back to tier defaults
-  const monthlyLimit = creditBalance?.monthly?.total
-    ?? (currentTier === 'pro' ? 150 : currentTier === 'lite' ? 50 : 5);
+  const monthlyLimit =
+    creditBalance?.monthly?.total ??
+    (currentTier === 'pro' ? 150 : currentTier === 'lite' ? 50 : 5);
   const cycleResetsAt = creditBalance?.cycleResetsAt;
   const resetTime = cycleResetsAt
     ? new Date(cycleResetsAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
@@ -592,8 +594,12 @@ function ImageLimitPrompt({ onClose, onBuyCredits, onUpgrade }) {
 
         <p className={styles.imageLimitDesc}>
           {isFree
-            ? `You’ve used all ${monthlyLimit} free image generation${monthlyLimit !== 1 ? 's' : ''} for this month.`
-            : `You’ve used all ${monthlyLimit} image generation${monthlyLimit !== 1 ? 's' : ''} included with your ${currentTier === 'lite' ? 'Lite' : 'Pro'} plan this month.`}
+            ? `You’ve used all ${monthlyLimit} free image generation${
+                monthlyLimit !== 1 ? 's' : ''
+              } for this month.`
+            : `You’ve used all ${monthlyLimit} image generation${
+                monthlyLimit !== 1 ? 's' : ''
+              } included with your ${currentTier === 'lite' ? 'Lite' : 'Pro'} plan this month.`}
           {resetTime && <> Your monthly credits reset at {resetTime}.</>}
         </p>
 
@@ -621,7 +627,9 @@ function ImageLimitPrompt({ onClose, onBuyCredits, onUpgrade }) {
         <p className={styles.imageLimitFooter}>
           {isFree
             ? `Free plan: ${monthlyLimit} image credit${monthlyLimit !== 1 ? 's' : ''} / month`
-            : `${currentTier === 'lite' ? 'Lite' : 'Pro'} plan: ${monthlyLimit} image credit${monthlyLimit !== 1 ? 's' : ''} / month`}
+            : `${currentTier === 'lite' ? 'Lite' : 'Pro'} plan: ${monthlyLimit} image credit${
+                monthlyLimit !== 1 ? 's' : ''
+              } / month`}
         </p>
       </div>
     </div>
@@ -747,13 +755,15 @@ export default function MainContent() {
         .then((data) => {
           if (data.balance) {
             dispatch(setCreditBalance(data.balance));
-            dispatch(setImageCredits({
-              used: data.balance.monthly?.used ?? 0,
-              limit: data.balance.monthly?.total ?? 5,
-              remaining: data.balance.monthly?.remaining ?? 0,
-              packRemaining: data.balance.packs?.remaining ?? 0,
-              cycleResetsAt: data.balance.cycleResetsAt ?? null,
-            }));
+            dispatch(
+              setImageCredits({
+                used: data.balance.monthly?.used ?? 0,
+                limit: data.balance.monthly?.total ?? 5,
+                remaining: data.balance.monthly?.remaining ?? 0,
+                packRemaining: data.balance.packs?.remaining ?? 0,
+                cycleResetsAt: data.balance.cycleResetsAt ?? null,
+              })
+            );
           }
         })
         .catch(() => {});
@@ -1078,6 +1088,7 @@ export default function MainContent() {
           role: 'user',
           content: prompt,
           timestamp: Date.now(),
+          ...(options.images ? { images: options.images } : {}),
         };
         dispatch(addMessage(userMsg));
       }
@@ -1137,6 +1148,7 @@ export default function MainContent() {
           importedConversationId: importedContext?.importedConversationId || undefined,
           projectId: activeProjectId || undefined,
           userTier: currentTier,
+          images: options.images || undefined,
         });
 
         if (abortController.signal.aborted || requestIdRef.current !== myRequestId) return;
@@ -1359,13 +1371,15 @@ export default function MainContent() {
               // in the done event. No extra round-trip to /api/credits needed.
               if (data.imageBalance) {
                 dispatch(setCreditBalance(data.imageBalance));
-                dispatch(setImageCredits({
-                  used: data.imageBalance.monthly?.used ?? 0,
-                  limit: data.imageBalance.monthly?.total ?? 5,
-                  remaining: data.imageBalance.monthly?.remaining ?? 0,
-                  packRemaining: data.imageBalance.packs?.remaining ?? 0,
-                  cycleResetsAt: data.imageBalance.cycleResetsAt ?? null,
-                }));
+                dispatch(
+                  setImageCredits({
+                    used: data.imageBalance.monthly?.used ?? 0,
+                    limit: data.imageBalance.monthly?.total ?? 5,
+                    remaining: data.imageBalance.monthly?.remaining ?? 0,
+                    packRemaining: data.imageBalance.packs?.remaining ?? 0,
+                    cycleResetsAt: data.imageBalance.cycleResetsAt ?? null,
+                  })
+                );
                 // Signal SettingsView (and any component with local credit state) to re-fetch
                 window.dispatchEvent(new CustomEvent('araviel-credits-updated'));
               }
@@ -1586,27 +1600,34 @@ export default function MainContent() {
         const cost = getCreditCost(imageQuality);
         const monthlyDelta = Math.min(cost, creditBalance.monthly?.remaining ?? 0);
         const packDelta = cost - monthlyDelta;
-        dispatch(setCreditBalance({
-          ...creditBalance,
-          monthly: {
-            ...creditBalance.monthly,
+        dispatch(
+          setCreditBalance({
+            ...creditBalance,
+            monthly: {
+              ...creditBalance.monthly,
+              remaining: Math.max(0, (creditBalance.monthly?.remaining ?? 0) - monthlyDelta),
+              used: (creditBalance.monthly?.used ?? 0) + monthlyDelta,
+            },
+            packs: {
+              ...creditBalance.packs,
+              remaining: Math.max(0, (creditBalance.packs?.remaining ?? 0) - packDelta),
+              used: (creditBalance.packs?.used ?? 0) + packDelta,
+            },
+            combined: Math.max(0, (creditBalance.combined ?? 0) - cost),
+          })
+        );
+        dispatch(
+          setImageCredits({
             remaining: Math.max(0, (creditBalance.monthly?.remaining ?? 0) - monthlyDelta),
             used: (creditBalance.monthly?.used ?? 0) + monthlyDelta,
-          },
-          packs: {
-            ...creditBalance.packs,
-            remaining: Math.max(0, (creditBalance.packs?.remaining ?? 0) - packDelta),
-            used: (creditBalance.packs?.used ?? 0) + packDelta,
-          },
-          combined: Math.max(0, (creditBalance.combined ?? 0) - cost),
-        }));
-        dispatch(setImageCredits({
-          remaining: Math.max(0, (creditBalance.monthly?.remaining ?? 0) - monthlyDelta),
-          used: (creditBalance.monthly?.used ?? 0) + monthlyDelta,
-          packRemaining: Math.max(0, (creditBalance.packs?.remaining ?? 0) - packDelta),
-        }));
+            packRemaining: Math.max(0, (creditBalance.packs?.remaining ?? 0) - packDelta),
+          })
+        );
       }
     }
+
+    // Capture image files before clearing state
+    const imageFiles = attachedFiles.filter((f) => f.file && isAcceptedImageType(f.file));
 
     dispatch(setInputValue(''));
     if (textareaRef.current) {
@@ -1616,10 +1637,25 @@ export default function MainContent() {
     setShowAttachDropdown(false);
     clearAttachedFiles();
 
+    // Compress images in parallel
+    let compressedImages = [];
+    if (imageFiles.length > 0) {
+      try {
+        compressedImages = await Promise.all(imageFiles.map((f) => compressImage(f.file)));
+      } catch (err) {
+        console.error('[handleSubmit] Image compression failed:', err);
+        // Continue without images — don't block the message
+        compressedImages = [];
+      }
+    }
+
     // Let the backend router know if this conversation already has generated
-    // images so it can factor that into model selection (without forcing modality)
+    // or uploaded images so it can factor that into model selection
     const conversationHasImages = messages.some(
-      (m) => m.generatedImages && m.generatedImages.length > 0
+      (m) =>
+        (m.generatedImages && m.generatedImages.length > 0) ||
+        (m.images && m.images.length > 0) ||
+        (m.attachments && m.attachments.length > 0)
     );
 
     // Set modality to 'image' when an image generation model is explicitly selected or ModalityBar
@@ -1644,9 +1680,10 @@ export default function MainContent() {
       selectedModelId: selectedModelId || undefined,
       addUserMessage: true,
       webSearch: webSearchEnabled,
-      conversationHasImages: conversationHasImages || undefined,
+      conversationHasImages: conversationHasImages || compressedImages.length > 0 || undefined,
       modality,
       imageQuality: willGenerateImage ? imageQuality : undefined,
+      images: compressedImages.length > 0 ? compressedImages : undefined,
     });
   };
 
@@ -1679,7 +1716,12 @@ export default function MainContent() {
     }
 
     // Authenticated user image rate limit: if balance has loaded and is zero, show modal
-    if (isAuthenticated && willGenImage && creditBalance && creditBalance.combined < getCreditCost(imageQuality)) {
+    if (
+      isAuthenticated &&
+      willGenImage &&
+      creditBalance &&
+      creditBalance.combined < getCreditCost(imageQuality)
+    ) {
       dispatch(setPendingAutoSubmit(false));
       dispatch(setPendingModality(null));
       setShowBuyPacksModal(true);
@@ -1800,7 +1842,15 @@ export default function MainContent() {
         imageQuality: imageQuality || undefined,
       });
     },
-    [dispatch, isProcessing, selectedModelId, currentChatId, runSSEPipeline, webSearchEnabled, imageQuality]
+    [
+      dispatch,
+      isProcessing,
+      selectedModelId,
+      currentChatId,
+      runSSEPipeline,
+      webSearchEnabled,
+      imageQuality,
+    ]
   );
 
   /**
@@ -1844,7 +1894,7 @@ export default function MainContent() {
     },
   ];
 
-  const maxAttachments = currentTier === 'pro' ? 15 : 5;
+  const maxAttachments = currentTier === 'pro' ? 10 : currentTier === 'lite' ? 5 : 1;
 
   const getFileExtension = (name) => {
     const parts = name.split('.');

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -4979,12 +4979,18 @@ function ThinkingBlock({
  * User prompt component with distinctive styling and collapse/expand for long messages.
  * Includes hover actions: copy and edit (sends content back to input).
  */
-function UserPrompt({ content, onEdit, createdAt, onRetry }) {
+function UserPrompt({ content, images, onEdit, createdAt, onRetry }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [lightboxIdx, setLightboxIdx] = useState(-1);
   const contentRef = useRef(null);
   const [isLong, setIsLong] = useState(false);
   const LINE_LIMIT = 10;
+
+  const imageList = useMemo(() => {
+    if (!images || !Array.isArray(images) || images.length === 0) return null;
+    return images;
+  }, [images]);
 
   useEffect(() => {
     const lineCount = (content || '').split('\n').length;
@@ -5024,15 +5030,35 @@ function UserPrompt({ content, onEdit, createdAt, onRetry }) {
   return (
     <div className={styles.userPromptWrapper}>
       <div className={styles.userPromptCard}>
-        <div
-          ref={contentRef}
-          className={`${styles.userPromptText} ${
-            !isExpanded && isLong ? styles.userPromptCollapsed : ''
-          }`}
-          style={collapsedStyle}
-        >
-          {content}
-        </div>
+        {imageList && (
+          <div className={styles.userPromptImages}>
+            {imageList.map((img, idx) => (
+              <button
+                key={idx}
+                className={styles.userPromptImageThumb}
+                onClick={() => setLightboxIdx(idx)}
+                aria-label={img.fileName || `Attached image ${idx + 1}`}
+              >
+                <img
+                  src={img.dataUri}
+                  alt={img.fileName || `Attached image ${idx + 1}`}
+                  loading="lazy"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+        {content && (
+          <div
+            ref={contentRef}
+            className={`${styles.userPromptText} ${
+              !isExpanded && isLong ? styles.userPromptCollapsed : ''
+            }`}
+            style={collapsedStyle}
+          >
+            {content}
+          </div>
+        )}
         {isLong && (
           <button
             className={styles.userPromptToggle}
@@ -5043,6 +5069,21 @@ function UserPrompt({ content, onEdit, createdAt, onRetry }) {
           </button>
         )}
       </div>
+      {lightboxIdx >= 0 && imageList && (
+        <div
+          className={styles.imageLightbox}
+          onClick={() => setLightboxIdx(-1)}
+          role="dialog"
+          aria-label="Image preview"
+        >
+          <img
+            src={imageList[lightboxIdx]?.dataUri}
+            alt={imageList[lightboxIdx]?.fileName || 'Full size image'}
+            className={styles.imageLightboxImg}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
       <div className={styles.userPromptActions}>
         {timeStr && <span className={styles.userPromptTime}>{timeStr}</span>}
         <button
@@ -5599,6 +5640,7 @@ function Message({
         {isUser ? (
           <UserPrompt
             content={message.content}
+            images={message.images || message.attachments}
             onEdit={onEditPrompt}
             createdAt={message.createdAt}
             onRetry={onRetry}

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -77,6 +77,54 @@
   background-color: #2a2a2a;
 }
 
+.userPromptImages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.userPromptImageThumb {
+  all: unset;
+  cursor: pointer;
+  width: 120px;
+  height: 120px;
+  border-radius: 8px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.userPromptImageThumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.15s ease;
+}
+
+.userPromptImageThumb:hover img {
+  transform: scale(1.04);
+}
+
+.imageLightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.8);
+  cursor: zoom-out;
+}
+
+.imageLightboxImg {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 8px;
+  cursor: default;
+}
+
 .userPromptActions {
   display: flex;
   align-items: center;

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -78,6 +78,7 @@ export async function sendMessage(payload) {
   if (payload.conversationHasImages) body.conversationHasImages = true;
   if (payload.importedConversationId) body.importedConversationId = payload.importedConversationId;
   if (payload.projectId) body.projectId = payload.projectId;
+  if (payload.images && payload.images.length > 0) body.images = payload.images;
 
   const res = await fetch(`${API_BASE}/api/chat`, {
     method: 'POST',

--- a/src/utils/imageCompression.js
+++ b/src/utils/imageCompression.js
@@ -1,0 +1,72 @@
+const MAX_DIMENSION = 1568;
+const JPEG_QUALITY = 0.8;
+const MAX_COMPRESSED_BYTES = 2 * 1024 * 1024; // 2 MB
+const ACCEPTED_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+/**
+ * Compress an image File using canvas-based resize + JPEG encoding.
+ * Returns a lightweight object ready to send to the API.
+ *
+ * @param {File} file — browser File from <input type="file">
+ * @returns {Promise<{ dataUri: string, mimeType: string, fileName: string }>}
+ */
+export async function compressImage(file) {
+  if (!ACCEPTED_TYPES.has(file.type)) {
+    throw new Error(`Unsupported image type: ${file.type}`);
+  }
+
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = getScaledDimensions(bitmap.width, bitmap.height);
+
+  const canvas = new OffscreenCanvas(width, height);
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(bitmap, 0, 0, width, height);
+  bitmap.close();
+
+  // Encode as JPEG (smaller output, good quality).
+  // For PNGs with transparency, JPEG will flatten to white — acceptable trade-off
+  // for vision analysis where transparency is irrelevant.
+  const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: JPEG_QUALITY });
+
+  if (blob.size > MAX_COMPRESSED_BYTES) {
+    throw new Error('Image exceeds 2 MB after compression');
+  }
+
+  const dataUri = await blobToDataUri(blob);
+  return {
+    dataUri,
+    mimeType: 'image/jpeg',
+    fileName: file.name,
+  };
+}
+
+/**
+ * Check whether a file is an image type we accept for vision analysis.
+ */
+export function isAcceptedImageType(file) {
+  return ACCEPTED_TYPES.has(file.type);
+}
+
+/**
+ * Scale dimensions so neither exceeds MAX_DIMENSION, preserving aspect ratio.
+ */
+function getScaledDimensions(w, h) {
+  if (w <= MAX_DIMENSION && h <= MAX_DIMENSION) return { width: w, height: h };
+  const scale = Math.min(MAX_DIMENSION / w, MAX_DIMENSION / h);
+  return {
+    width: Math.round(w * scale),
+    height: Math.round(h * scale),
+  };
+}
+
+/**
+ * Convert a Blob to a data URI string.
+ */
+function blobToDataUri(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}


### PR DESCRIPTION
…n chat

Add canvas-based image compression utility (max 1568px, JPEG quality 0.8). Update MainContent to compress attached images on submit, enforce tier-based limits (Free=1, Lite=5, Pro=10), pass images through SSE pipeline, and track user-uploaded images in conversationHasImages. Render image thumbnails with lightbox overlay on user messages in MessageList. Include images in API request body via api.js sendMessage.

https://claude.ai/code/session_01BamBWSrNo1XyLGttuwwcCR