### PR TITLE
fix(vision): preserve user image attachments when loading conversatio…

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -364,6 +364,9 @@ export default function Sidebar() {
             ...(generatedImages.length > 0 && { generatedImages }),
           });
         }
+        if (msg.role === 'user' && Array.isArray(msg.attachments) && msg.attachments.length > 0) {
+          base.attachments = msg.attachments;
+        }
         return base;
       });
       dispatch(setMessages(mappedMessages));


### PR DESCRIPTION
…n history

The Sidebar message mapper was stripping attachments from user messages, causing uploaded images to disappear on conversation reload. Carry the attachments field through so MessageList can render them.

https://claude.ai/code/session_01BamBWSrNo1XyLGttuwwcCR