### PR TITLE
feat: add URL-based routing with react-router-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^9.1.0",
+    "react-router-dom": "^6.30.3",
     "recharts": "^3.7.0"
   },
   "devDependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { Outlet, useNavigate } from 'react-router-dom';
 import { selectEffectiveTheme } from './store/slices/themeSlice';
-import { selectActiveItem, setActiveItem } from './store/slices/sidebarSlice';
 import { selectAuthLoading, selectAuthUser } from './store/slices/authSlice';
 import { fetchSubscriptionThunk, setImageCredits } from './store/slices/subscriptionSlice';
 import { setCreditBalance } from './store/slices/chatSlice';
@@ -9,26 +9,18 @@ import { subscribeToCreditPackChanges, fetchCreditBalance } from './services/cre
 import { SpeedInsights } from '@vercel/speed-insights/react';
 import useAuthListener from './hooks/useAuthListener';
 import Sidebar from './components/Sidebar';
-import MainContent from './components/MainContent';
-import ModelsView from './components/ModelsView';
-import ImageGalleryView from './components/ImageGalleryView';
-import ConversationsView from './components/ConversationsView';
-import ProjectsView from './components/ProjectsView';
-import SettingsView from './components/SettingsView';
-import PricingView from './components/PricingView/PricingView';
-import SubscriptionView from './components/SubscriptionView/SubscriptionView';
 import UpgradeModal from './components/UpgradeModal/UpgradeModal';
 import styles from './components/Auth/AuthModal.module.css';
 import './App.css';
 
 export default function App() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   // Initialize auth listener — subscribes to Supabase auth state changes
   useAuthListener();
 
   const effectiveTheme = useSelector(selectEffectiveTheme);
-  const activeItem = useSelector(selectActiveItem);
   const authLoading = useSelector(selectAuthLoading);
   const user = useSelector(selectAuthUser);
   const unsubPackRef = useRef(null);
@@ -58,10 +50,6 @@ export default function App() {
     // Post-checkout: /?checkout=success (for subscriptions and packs)
     if (params.get('checkout') === 'success') {
       const checkoutType = params.get('type');
-      const url = new URL(window.location.href);
-      url.searchParams.delete('checkout');
-      url.searchParams.delete('type');
-      window.history.replaceState({}, '', url.pathname + (url.search || ''));
 
       // Refresh both subscription slice and image credit balance after pack purchase
       const refreshAllCredits = () => {
@@ -85,7 +73,7 @@ export default function App() {
       // For pack purchases: subscribe to Realtime changes on credit_packs table
       // so balance updates as soon as the Stripe webhook inserts the new pack
       if (checkoutType === 'pack' && user?.id) {
-        dispatch(setActiveItem('usage'));
+        navigate('/settings/usage', { replace: true });
         unsubPackRef.current?.();
         unsubPackRef.current = subscribeToCreditPackChanges(user.id, () => {
           refreshAllCredits();
@@ -96,32 +84,30 @@ export default function App() {
         // No user id available — fall back to a delayed fetch
         setTimeout(() => {
           refreshAllCredits();
-          dispatch(setActiveItem('usage'));
+          navigate('/settings/usage', { replace: true });
         }, 3000);
       } else {
         // For subscriptions, refresh immediately
         refreshAllCredits();
+        navigate('/', { replace: true });
       }
     }
 
     // Portal/cancel return: /?view=settings, /?view=pricing, or /?view=usage
     const view = params.get('view');
-    if (view === 'settings' || view === 'pricing' || view === 'usage') {
-      dispatch(setActiveItem(view));
-      const url = new URL(window.location.href);
-      url.searchParams.delete('view');
-      window.history.replaceState({}, '', url.pathname + (url.search || ''));
-
-      // Refresh subscription after portal return
-      if (view === 'settings') {
-        dispatch(fetchSubscriptionThunk());
-      }
+    if (view === 'settings') {
+      navigate('/settings', { replace: true });
+      dispatch(fetchSubscriptionThunk());
+    } else if (view === 'pricing') {
+      navigate('/plans', { replace: true });
+    } else if (view === 'usage') {
+      navigate('/settings/usage', { replace: true });
     }
     return () => {
       unsubPackRef.current?.();
       unsubPackRef.current = null;
     };
-  }, [dispatch, user?.id]);
+  }, [dispatch, navigate, user?.id]);
 
   // Show loading screen while checking initial auth session
   if (authLoading) {
@@ -136,27 +122,7 @@ export default function App() {
   return (
     <div className="app">
       <Sidebar />
-      {activeItem === 'conversations' ? (
-        <ConversationsView />
-      ) : activeItem === 'projects' ? (
-        <ProjectsView />
-      ) : activeItem === 'models' ? (
-        <ModelsView />
-      ) : activeItem === 'gallery' ? (
-        <ImageGalleryView />
-      ) : activeItem === 'usage' ? (
-        <SettingsView initialSection="usage" />
-      ) : activeItem === 'personalisation' ? (
-        <SettingsView initialSection="personalization" />
-      ) : activeItem === 'settings' ? (
-        <SettingsView />
-      ) : activeItem === 'pricing' ? (
-        <PricingView />
-      ) : activeItem === 'subscription' ? (
-        <SubscriptionView />
-      ) : (
-        <MainContent />
-      )}
+      <Outlet />
       <UpgradeModal />
       <SpeedInsights />
     </div>

--- a/src/components/ConversationRoute.jsx
+++ b/src/components/ConversationRoute.jsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { selectCurrentChatId } from '../store/slices/chatSlice';
+import useLoadConversation from '../hooks/useLoadConversation';
+import MainContent from './MainContent';
+
+/**
+ * Wrapper that loads a conversation by URL param and renders MainContent.
+ * Used for /conversations/:id and /chat/:id routes.
+ */
+export default function ConversationRoute() {
+  const { id } = useParams();
+  const currentChatId = useSelector(selectCurrentChatId);
+  const loadConversation = useLoadConversation();
+
+  useEffect(() => {
+    if (id && id !== currentChatId) {
+      loadConversation(id);
+    }
+  }, [id, currentChatId, loadConversation]);
+
+  return <MainContent />;
+}

--- a/src/components/ConversationsView/ConversationsView.jsx
+++ b/src/components/ConversationsView/ConversationsView.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import {
   selectConversations,
   selectConversationsTotal,
@@ -13,7 +14,6 @@ import {
   setImportedContext,
   createNewChat,
 } from '../../store/slices/chatSlice';
-import { setActiveItem } from '../../store/slices/sidebarSlice';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import { GuestGate } from '../GuestGate';
 import {
@@ -296,6 +296,7 @@ function getImportedProviders(conversations) {
 
 export default function ConversationsView() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const { showError, showSuccess } = useToast();
   const conversations = useSelector(selectConversations);
   const conversationsTotal = useSelector(selectConversationsTotal);
@@ -635,7 +636,7 @@ export default function ConversationsView() {
     }
     dispatch(setCurrentChat(chatId));
     dispatch(setImportedContext(null));
-    dispatch(setActiveItem('home'));
+    navigate(`/conversations/${chatId}`);
     try {
       const data = await fetchConversationMessages(chatId);
       const storedImages = getGeneratedImages();
@@ -842,7 +843,7 @@ export default function ConversationsView() {
     }
     // Clear the native conversation ID so the backend creates a new one on first send
     dispatch(setCurrentChat(null));
-    dispatch(setActiveItem('home'));
+    navigate('/');
     dispatch(setMessages([]));
     try {
       const data = await fetchImportedConversationMessages(chat.id);
@@ -1178,7 +1179,7 @@ export default function ConversationsView() {
               className={styles.newChatBtn}
               onClick={() => {
                 dispatch(createNewChat());
-                dispatch(setActiveItem('home'));
+                navigate('/');
               }}
             >
               <PlusIcon />
@@ -1415,7 +1416,7 @@ export default function ConversationsView() {
                       className={styles.emptyAction}
                       onClick={() => {
                         dispatch(createNewChat());
-                        dispatch(setActiveItem('home'));
+                        navigate('/');
                       }}
                     >
                       <PlusIcon />

--- a/src/components/ImageGalleryView/ImageGalleryView.jsx
+++ b/src/components/ImageGalleryView/ImageGalleryView.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { setActiveItem } from '../../store/slices/sidebarSlice';
+import { useNavigate, useParams } from 'react-router-dom';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import {
   setInputValue,
@@ -99,6 +99,8 @@ const QUICK_PROMPTS = [
  */
 export default function ImageGalleryView() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { id: routeImageId } = useParams();
   const creditBalance = useSelector(selectCreditBalance);
   const imageQuality = useSelector(selectImageQuality);
   const [images, setImages] = useState([]);
@@ -221,6 +223,16 @@ export default function ImageGalleryView() {
     };
   }, [loadImages, isAuthenticated, dispatch]);
 
+  // Handle deep link to specific image via route param
+  useEffect(() => {
+    if (routeImageId && images.length > 0) {
+      const idx = images.findIndex((img) => img.id === routeImageId);
+      if (idx !== -1) {
+        setLightboxIdx(idx);
+      }
+    }
+  }, [routeImageId, images]);
+
   useEffect(() => {
     const handleClick = (e) => {
       if (filterRef.current && !filterRef.current.contains(e.target)) {
@@ -307,7 +319,7 @@ export default function ImageGalleryView() {
     dispatch(setInputValue(prompt));
     dispatch(setPendingModality('image'));
     dispatch(setPendingAutoSubmit(true));
-    dispatch(setActiveItem('home'));
+    navigate('/');
   };
 
   const handlePromptInputChange = (e) => {

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   selectInputValue,
@@ -108,7 +109,6 @@ import {
 } from '../../services/api';
 import { useToast } from '../Toast/Toast';
 import { selectProjects, addProject } from '../../store/slices/projectsSlice';
-import { setActiveItem, selectActiveItem } from '../../store/slices/sidebarSlice';
 import {
   showUpgradeModal,
   setTextCredits,
@@ -638,6 +638,7 @@ function ImageLimitPrompt({ onClose, onBuyCredits, onUpgrade }) {
 
 export default function MainContent() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const inputValue = useSelector(selectInputValue);
   const mode = useSelector(selectMode);
   const messages = useSelector(selectMessages);
@@ -920,9 +921,7 @@ export default function MainContent() {
 
   const handleNavigateToProject = () => {
     if (!conversationProject) return;
-    // Store the project ID so ProjectsView can pick it up
-    window.__aravielNavigateToProject = conversationProject.id;
-    dispatch(setActiveItem('projects'));
+    navigate(`/projects/${conversationProject.id}`);
   };
 
   // Close project dropdown on outside click
@@ -2578,7 +2577,7 @@ export default function MainContent() {
           }}
           onUpgrade={() => {
             setShowImageLimitPrompt(false);
-            dispatch(setActiveItem('pricing'));
+            navigate('/plans');
           }}
         />
       )}

--- a/src/components/PricingView/PricingView.jsx
+++ b/src/components/PricingView/PricingView.jsx
@@ -1,5 +1,6 @@
 import { useSelector, useDispatch } from 'react-redux';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   selectCurrentTier,
   selectBillingCycle,
@@ -9,7 +10,6 @@ import {
   createCheckoutThunk,
   createPortalThunk,
 } from '../../store/slices/subscriptionSlice';
-import { setActiveItem } from '../../store/slices/sidebarSlice';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import { getAvailableTiers, SubscriptionTier } from '../../config/subscription';
 import BillingToggle from './BillingToggle';
@@ -20,6 +20,7 @@ import styles from './PricingView.module.css';
 
 export default function PricingView() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const { showError } = useToast();
   const currentTier = useSelector(selectCurrentTier);
   const billingCycle = useSelector(selectBillingCycle);
@@ -62,7 +63,7 @@ export default function PricingView() {
         <div className={styles.header}>
           <button
             className={styles.backBtn}
-            onClick={() => dispatch(setActiveItem('home'))}
+            onClick={() => navigate('/')}
             aria-label="Back to chat"
           >
             <svg

--- a/src/components/ProjectsView/ProjectsView.jsx
+++ b/src/components/ProjectsView/ProjectsView.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
 import {
   selectProjects,
   selectProjectsLoading,
@@ -9,7 +10,6 @@ import {
   removeProject,
   setProjectsLoading,
 } from '../../store/slices/projectsSlice';
-import { setActiveItem } from '../../store/slices/sidebarSlice';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import { showUpgradeModal } from '../../store/slices/subscriptionSlice';
 import { GuestGate } from '../GuestGate';
@@ -294,7 +294,7 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
     dispatch(setActiveProjectId(project.id));
     dispatch(setInputValue(text));
     dispatch(setPendingAutoSubmit(true));
-    dispatch(setActiveItem('home'));
+    navigate('/');
   };
 
   const handleKeyDown = (e) => {
@@ -306,7 +306,7 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
 
   const handleConvClick = async (conv) => {
     dispatch(setCurrentChat(conv.id));
-    dispatch(setActiveItem('home'));
+    navigate(`/conversations/${conv.id}`);
     try {
       const data = await fetchConversationMessages(conv.id);
       const storedImages = getGeneratedImages();
@@ -779,6 +779,8 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
 
 export default function ProjectsView() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { id: routeProjectId } = useParams();
   const projects = useSelector(selectProjects);
   const loading = useSelector(selectProjectsLoading);
   const isAuthenticated = useSelector(selectIsAuthenticated);
@@ -817,17 +819,15 @@ export default function ProjectsView() {
     }
   }, [loadProjects, isAuthenticated]);
 
-  // Handle navigation from MainContent project header
+  // Handle deep link to specific project via route param
   useEffect(() => {
-    if (window.__aravielNavigateToProject) {
-      const targetId = window.__aravielNavigateToProject;
-      delete window.__aravielNavigateToProject;
-      const proj = projects.find((p) => p.id === targetId);
+    if (routeProjectId) {
+      const proj = projects.find((p) => p.id === routeProjectId);
       if (proj) {
         setSelectedProject(proj);
       }
     }
-  }, [projects]);
+  }, [projects, routeProjectId]);
 
   // Close dropdowns on outside click
   useEffect(() => {

--- a/src/components/SearchModal/SearchModal.jsx
+++ b/src/components/SearchModal/SearchModal.jsx
@@ -1,12 +1,12 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import {
   selectConversations,
   selectConversationsTotal,
   setCurrentChat,
   setMessages,
 } from '../../store/slices/chatSlice';
-import { setActiveItem } from '../../store/slices/sidebarSlice';
 import { selectProjects } from '../../store/slices/projectsSlice';
 import { searchConversations, searchProjects, searchImages } from '../../services/api';
 import { getGeneratedImages } from '../../services/imageGeneration';
@@ -76,6 +76,7 @@ function formatRelativeDate(dateStr) {
 
 export default function SearchModal({ onClose }) {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const conversations = useSelector(selectConversations);
   const conversationsTotal = useSelector(selectConversationsTotal);
   const projects = useSelector(selectProjects);
@@ -256,15 +257,15 @@ export default function SearchModal({ onClose }) {
       if (item.type === 'conversation') {
         dispatch(setCurrentChat(item.data.id));
         dispatch(setMessages([]));
-        dispatch(setActiveItem('home'));
+        navigate(`/conversations/${item.data.id}`);
       } else if (item.type === 'project') {
-        dispatch(setActiveItem('projects'));
+        navigate('/projects');
       } else if (item.type === 'image') {
-        dispatch(setActiveItem('gallery'));
+        navigate('/images');
       }
       onClose();
     },
-    [dispatch, onClose]
+    [dispatch, navigate, onClose]
   );
 
   // Keyboard navigation

--- a/src/components/SettingsView/SettingsView.jsx
+++ b/src/components/SettingsView/SettingsView.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
 import { selectTheme, setTheme } from '../../store/slices/themeSlice';
-import { setActiveItem } from '../../store/slices/sidebarSlice';
 import {
   selectCurrentTier,
   selectTextCredits,
@@ -105,8 +105,10 @@ const SHORTCUTS = [
 const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.userAgent);
 const modKey = isMac ? '⌘' : 'Ctrl';
 
-export default function SettingsView({ initialSection }) {
+export default function SettingsView() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { section } = useParams();
   const themeMode = useSelector(selectTheme);
   const isAuthenticated = useSelector(selectIsAuthenticated);
   const authUser = useSelector(selectAuthUser);
@@ -116,10 +118,7 @@ export default function SettingsView({ initialSection }) {
   const periodEnd = useSelector(selectPeriodEnd);
   const cancelAtPeriodEnd = useSelector(selectCancelAtPeriodEnd);
   const portalLoading = useSelector(selectPortalLoading);
-  const [activeSection, setActiveSection] = useState(initialSection || 'profile');
-  useEffect(() => {
-    if (initialSection) setActiveSection(initialSection);
-  }, [initialSection]);
+  const activeSection = section || 'profile';
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -215,7 +214,7 @@ export default function SettingsView({ initialSection }) {
   };
 
   const handleBack = () => {
-    dispatch(setActiveItem('home'));
+    navigate('/');
   };
 
   const handleAvatarChange = async (e) => {
@@ -322,7 +321,7 @@ export default function SettingsView({ initialSection }) {
                   className={`${styles.navItem} ${
                     activeSection === section.id ? styles.navItemActive : ''
                   }`}
-                  onClick={() => setActiveSection(section.id)}
+                  onClick={() => navigate(`/settings/${section.id}`)}
                 >
                   {section.label}
                 </button>
@@ -1029,7 +1028,7 @@ export default function SettingsView({ initialSection }) {
                           <div className={styles.subscriptionActions}>
                             <button
                               className={styles.upgradeBtn}
-                              onClick={() => dispatch(setActiveItem('pricing'))}
+                              onClick={() => navigate('/plans')}
                             >
                               Upgrade Plan
                             </button>
@@ -1074,7 +1073,7 @@ export default function SettingsView({ initialSection }) {
                               className={styles.planUpgradeBtn}
                               onClick={() =>
                                 tier === 'free'
-                                  ? dispatch(setActiveItem('pricing'))
+                                  ? navigate('/plans')
                                   : dispatch(createPortalThunk())
                               }
                               disabled={tier !== 'free' && portalLoading}

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,16 +1,13 @@
 import { useSelector, useDispatch } from 'react-redux';
 import { useState, useEffect, useLayoutEffect, useCallback, useRef, useMemo } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   selectSidebarCollapsed,
   toggleSidebar,
   setCollapsed,
-  selectActiveItem,
-  setActiveItem,
 } from '../../store/slices/sidebarSlice';
 import {
   createNewChat,
-  setCurrentChat,
-  setMessages,
   selectConversations,
   selectConversationsTotal,
   selectConversationsLoading,
@@ -23,7 +20,6 @@ import { selectTheme, setTheme } from '../../store/slices/themeSlice';
 import { selectAuthUser, selectIsAuthenticated, signOut } from '../../store/slices/authSlice';
 import {
   fetchConversations,
-  fetchConversationMessages,
   updateConversation,
   deleteConversation,
   fetchProjects as fetchProjectsApi,
@@ -31,7 +27,6 @@ import {
 import { useToast } from '../Toast/Toast';
 import { selectProjects, setProjects } from '../../store/slices/projectsSlice';
 import { selectCurrentTier } from '../../store/slices/subscriptionSlice';
-import { getGeneratedImages } from '../../services/imageGeneration';
 import { AuthModal } from '../Auth';
 import {
   PlusIcon,
@@ -154,6 +149,8 @@ function useDropdownPosition(menuOpenId) {
 
 export default function Sidebar() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
   const { showError, showSuccess } = useToast();
   const collapsed = useSelector(selectSidebarCollapsed);
   const conversations = useSelector(selectConversations);
@@ -161,7 +158,6 @@ export default function Sidebar() {
   const conversationsLoading = useSelector(selectConversationsLoading);
   const currentChatId = useSelector(selectCurrentChatId);
   const themeMode = useSelector(selectTheme);
-  const activeItem = useSelector(selectActiveItem);
   const projects = useSelector(selectProjects);
   const [isMobile, setIsMobile] = useState(false);
   const [projectPickerFor, setProjectPickerFor] = useState(null); // chatId to assign to project
@@ -280,98 +276,16 @@ export default function Sidebar() {
 
   const handleNewChat = () => {
     dispatch(createNewChat());
-    dispatch(setActiveItem('home'));
+    navigate('/');
     if (isMobile) {
       dispatch(setCollapsed(true));
     }
   };
 
-  const handleChatClick = async (chatId) => {
-    dispatch(setCurrentChat(chatId));
-    dispatch(setActiveItem('home'));
+  const handleChatClick = (chatId) => {
+    navigate(`/conversations/${chatId}`);
     if (isMobile) {
       dispatch(setCollapsed(true));
-    }
-    // Load messages for this conversation
-    try {
-      const data = await fetchConversationMessages(chatId);
-      // Get locally stored generated images to re-attach to messages
-      const storedImages = getGeneratedImages();
-      // Map backend messages to the shape the frontend expects
-      const mappedMessages = (data.messages || []).map((msg) => {
-        const base = {
-          id: msg.id,
-          role: msg.role,
-          content: msg.content,
-          timestamp: new Date(msg.createdAt).getTime(),
-        };
-        if (msg.role === 'assistant') {
-          // Restore generatedImages from backend or localStorage
-          let generatedImages = msg.generatedImages || [];
-          if (generatedImages.length === 0) {
-            // Primary: match by messageId (deterministic)
-            let matched = storedImages.filter((img) => img.messageId && img.messageId === msg.id);
-            // Fallback: timestamp proximity
-            if (matched.length === 0) {
-              const msgTime = new Date(msg.createdAt).getTime();
-              matched = storedImages.filter((img) => Math.abs(img.createdAt - msgTime) < 30000);
-            }
-            if (matched.length > 0) {
-              generatedImages = matched.map((img) => ({
-                url: img.url,
-                prompt: img.prompt,
-                model: img.model,
-                provider: img.provider,
-                id: img.id,
-              }));
-            }
-          }
-          // Last resort: extract images from message content markdown
-          if (generatedImages.length === 0 && msg.content) {
-            const imgRe = /!\[Generated image[^\]]*\]\(([^)]+)\)/g;
-            let m;
-            while ((m = imgRe.exec(msg.content)) !== null) {
-              generatedImages.push({
-                url: m[1],
-                prompt: msg.content.match(/!\[Generated image:?\s*([^\]]*)\]/)?.[1] || '',
-                model: msg.model?.name || 'unknown',
-                provider: msg.model?.provider || 'unknown',
-                id: `content-${msg.id}-${generatedImages.length}`,
-              });
-            }
-          }
-          Object.assign(base, {
-            modelId: msg.model?.id,
-            modelName: msg.model?.name,
-            provider: msg.model?.provider,
-            score: msg.model?.score,
-            reasoning: msg.model?.reasoning,
-            alternateModels: (msg.alternateModels || []).map((m) => ({
-              modelId: m.id,
-              modelName: m.name,
-              provider: m.provider,
-              score: m.score,
-              reasoning: m.reasoning,
-            })),
-            thinkingContent: msg.thinkingContent,
-            citations: msg.citations,
-            usage: msg.usage,
-            costUsd: msg.costUsd,
-            latencyMs: msg.latencyMs,
-            adeLatencyMs: msg.adeLatencyMs,
-            followUps: msg.followUps || [],
-            questions: msg.questions || [],
-            ...(generatedImages.length > 0 && { generatedImages }),
-          });
-        }
-        if (msg.role === 'user' && Array.isArray(msg.attachments) && msg.attachments.length > 0) {
-          base.attachments = msg.attachments;
-        }
-        return base;
-      });
-      dispatch(setMessages(mappedMessages));
-    } catch {
-      // Fail silently — conversation will appear empty
     }
   };
 
@@ -382,28 +296,28 @@ export default function Sidebar() {
   };
 
   const handleConversationsClick = () => {
-    dispatch(setActiveItem(activeItem === 'conversations' ? 'home' : 'conversations'));
+    navigate(location.pathname === '/conversations' ? '/' : '/conversations');
     if (isMobile) {
       dispatch(setCollapsed(true));
     }
   };
 
   const handleProjectsClick = () => {
-    dispatch(setActiveItem(activeItem === 'projects' ? 'home' : 'projects'));
+    navigate(location.pathname.startsWith('/projects') ? '/' : '/projects');
     if (isMobile) {
       dispatch(setCollapsed(true));
     }
   };
 
   const handleModelsClick = () => {
-    dispatch(setActiveItem(activeItem === 'models' ? 'home' : 'models'));
+    navigate(location.pathname === '/models' ? '/' : '/models');
     if (isMobile) {
       dispatch(setCollapsed(true));
     }
   };
 
   const handleGalleryClick = () => {
-    dispatch(setActiveItem(activeItem === 'gallery' ? 'home' : 'gallery'));
+    navigate(location.pathname.startsWith('/images') ? '/' : '/images');
     if (isMobile) {
       dispatch(setCollapsed(true));
     }
@@ -734,7 +648,7 @@ export default function Sidebar() {
 
         <nav className={styles.nav}>
           <button
-            className={`${styles.navItem} ${activeItem === 'conversations' ? styles.active : ''}`}
+            className={`${styles.navItem} ${location.pathname === '/conversations' ? styles.active : ''}`}
             onClick={handleConversationsClick}
             title="Conversations"
             aria-label="Conversations"
@@ -743,7 +657,7 @@ export default function Sidebar() {
             {showFullContent && <span>Conversations</span>}
           </button>
           <button
-            className={`${styles.navItem} ${activeItem === 'projects' ? styles.active : ''}`}
+            className={`${styles.navItem} ${location.pathname.startsWith('/projects') ? styles.active : ''}`}
             onClick={handleProjectsClick}
             title="Projects"
             aria-label="Projects"
@@ -752,7 +666,7 @@ export default function Sidebar() {
             {showFullContent && <span>Projects</span>}
           </button>
           <button
-            className={`${styles.navItem} ${activeItem === 'gallery' ? styles.active : ''}`}
+            className={`${styles.navItem} ${location.pathname.startsWith('/images') ? styles.active : ''}`}
             onClick={handleGalleryClick}
             title="Image Gallery"
             aria-label="Image Gallery"
@@ -761,7 +675,7 @@ export default function Sidebar() {
             {showFullContent && <span>Images</span>}
           </button>
           <button
-            className={`${styles.navItem} ${activeItem === 'models' ? styles.active : ''}`}
+            className={`${styles.navItem} ${location.pathname === '/models' ? styles.active : ''}`}
             onClick={handleModelsClick}
             title="Models"
             aria-label="Models"
@@ -1033,7 +947,7 @@ export default function Sidebar() {
                     if (!isAuthenticated) {
                       setAuthModalOpen(true);
                     } else {
-                      dispatch(setActiveItem('settings'));
+                      navigate('/settings');
                     }
                   }}
                 >
@@ -1044,7 +958,7 @@ export default function Sidebar() {
                   className={styles.userDropdownItem}
                   onClick={() => {
                     setUserMenuOpen(false);
-                    dispatch(setActiveItem('pricing'));
+                    navigate('/plans');
                   }}
                 >
                   <UpgradePlanIcon />
@@ -1055,7 +969,7 @@ export default function Sidebar() {
                     className={styles.userDropdownItem}
                     onClick={() => {
                       setUserMenuOpen(false);
-                      dispatch(setActiveItem('subscription'));
+                      navigate('/subscription');
                     }}
                   >
                     <CreditCardIcon />
@@ -1066,7 +980,7 @@ export default function Sidebar() {
                   className={styles.userDropdownItem}
                   onClick={() => {
                     setUserMenuOpen(false);
-                    dispatch(setActiveItem('usage'));
+                    navigate('/settings/usage');
                   }}
                 >
                   <ZapIcon />
@@ -1076,7 +990,7 @@ export default function Sidebar() {
                   className={styles.userDropdownItem}
                   onClick={() => {
                     setUserMenuOpen(false);
-                    dispatch(setActiveItem('personalisation'));
+                    navigate('/settings/personalisation');
                   }}
                 >
                   <EditIcon />

--- a/src/components/SubscriptionView/SubscriptionView.jsx
+++ b/src/components/SubscriptionView/SubscriptionView.jsx
@@ -1,5 +1,6 @@
 import { useSelector, useDispatch } from 'react-redux';
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   selectCurrentTier,
   selectBillingCycle,
@@ -13,7 +14,6 @@ import {
   fetchSubscriptionThunk,
   createPortalThunk,
 } from '../../store/slices/subscriptionSlice';
-import { setActiveItem } from '../../store/slices/sidebarSlice';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import { getTierById, getDisplayPrice, SubscriptionTier } from '../../config/subscription';
 import GuestGate from '../GuestGate/GuestGate';
@@ -61,6 +61,7 @@ function formatTime(dateStr) {
 
 export default function SubscriptionView() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const isAuthenticated = useSelector(selectIsAuthenticated);
   const currentTier = useSelector(selectCurrentTier);
   const billingCycle = useSelector(selectBillingCycle);
@@ -131,7 +132,7 @@ export default function SubscriptionView() {
         <div className={styles.header}>
           <button
             className={styles.backBtn}
-            onClick={() => dispatch(setActiveItem('home'))}
+            onClick={() => navigate('/')}
             aria-label="Back to chat"
           >
             <svg
@@ -237,14 +238,14 @@ export default function SubscriptionView() {
                 {(isFree || currentTier === SubscriptionTier.Lite) && (
                   <button
                     className={isFree ? styles.primaryBtn : styles.secondaryBtn}
-                    onClick={() => dispatch(setActiveItem('pricing'))}
+                    onClick={() => navigate('/plans')}
                   >
                     Upgrade Plan
                   </button>
                 )}
                 <button
                   className={styles.secondaryBtn}
-                  onClick={() => dispatch(setActiveItem('usage'))}
+                  onClick={() => navigate('/settings/usage')}
                 >
                   View Detailed Usage
                 </button>

--- a/src/components/UpgradeModal/UpgradeModal.jsx
+++ b/src/components/UpgradeModal/UpgradeModal.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import {
   selectShowUpgradeModal,
   selectUpgradeContext,
@@ -10,7 +11,6 @@ import {
   createCheckoutThunk,
 } from '../../store/slices/subscriptionSlice';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
-import { setActiveItem } from '../../store/slices/sidebarSlice';
 import { getTierById, getDisplayPrice, SubscriptionTier } from '../../config/subscription';
 import styles from './UpgradeModal.module.css';
 
@@ -46,6 +46,7 @@ function CheckIcon() {
 
 export default function UpgradeModal() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const show = useSelector(selectShowUpgradeModal);
   const context = useSelector(selectUpgradeContext);
   const currentTier = useSelector(selectCurrentTier);
@@ -79,7 +80,7 @@ export default function UpgradeModal() {
 
   const handleViewPlans = () => {
     dispatch(hideUpgradeModal());
-    dispatch(setActiveItem('pricing'));
+    navigate('/plans');
   };
 
   return (

--- a/src/hooks/useLoadConversation.js
+++ b/src/hooks/useLoadConversation.js
@@ -1,0 +1,118 @@
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { setCurrentChat, setMessages } from '../store/slices/chatSlice';
+import { fetchConversationMessages } from '../services/api';
+import { getGeneratedImages } from '../services/imageGeneration';
+
+/**
+ * Maps raw backend messages to the shape the frontend expects,
+ * including restoring generatedImages from backend data, localStorage, or content markdown.
+ */
+function mapMessages(rawMessages, storedImages) {
+  return (rawMessages || []).map((msg) => {
+    const base = {
+      id: msg.id,
+      role: msg.role,
+      content: msg.content,
+      timestamp: new Date(msg.createdAt).getTime(),
+    };
+
+    if (msg.role === 'assistant') {
+      let generatedImages = msg.generatedImages || [];
+
+      if (generatedImages.length === 0) {
+        // Primary: match by messageId (deterministic)
+        let matched = storedImages.filter(
+          (img) => img.messageId && img.messageId === msg.id
+        );
+        // Fallback: timestamp proximity
+        if (matched.length === 0) {
+          const msgTime = new Date(msg.createdAt).getTime();
+          matched = storedImages.filter(
+            (img) => Math.abs(img.createdAt - msgTime) < 30000
+          );
+        }
+        if (matched.length > 0) {
+          generatedImages = matched.map((img) => ({
+            url: img.url,
+            prompt: img.prompt,
+            model: img.model,
+            provider: img.provider,
+            id: img.id,
+          }));
+        }
+      }
+
+      // Last resort: extract images from message content markdown
+      if (generatedImages.length === 0 && msg.content) {
+        const imgRe = /!\[Generated image[^\]]*\]\(([^)]+)\)/g;
+        let m;
+        while ((m = imgRe.exec(msg.content)) !== null) {
+          generatedImages.push({
+            url: m[1],
+            prompt: msg.content.match(/!\[Generated image:?\s*([^\]]*)\]/)?.[1] || '',
+            model: msg.model?.name || 'unknown',
+            provider: msg.model?.provider || 'unknown',
+            id: `content-${msg.id}-${generatedImages.length}`,
+          });
+        }
+      }
+
+      Object.assign(base, {
+        modelId: msg.model?.id,
+        modelName: msg.model?.name,
+        provider: msg.model?.provider,
+        score: msg.model?.score,
+        reasoning: msg.model?.reasoning,
+        alternateModels: (msg.alternateModels || []).map((m) => ({
+          modelId: m.id,
+          modelName: m.name,
+          provider: m.provider,
+          score: m.score,
+          reasoning: m.reasoning,
+        })),
+        thinkingContent: msg.thinkingContent,
+        citations: msg.citations,
+        usage: msg.usage,
+        costUsd: msg.costUsd,
+        latencyMs: msg.latencyMs,
+        adeLatencyMs: msg.adeLatencyMs,
+        followUps: msg.followUps || [],
+        questions: msg.questions || [],
+        feedback: msg.feedback || null,
+        ...(generatedImages.length > 0 && { generatedImages }),
+      });
+    }
+
+    if (msg.role === 'user' && Array.isArray(msg.attachments) && msg.attachments.length > 0) {
+      base.attachments = msg.attachments;
+    }
+
+    return base;
+  });
+}
+
+/**
+ * Hook that provides a function to load a conversation by ID.
+ * Sets currentChatId in Redux and fetches + maps messages from the API.
+ */
+export default function useLoadConversation() {
+  const dispatch = useDispatch();
+
+  const loadConversation = useCallback(
+    async (chatId) => {
+      dispatch(setCurrentChat(chatId));
+      try {
+        const data = await fetchConversationMessages(chatId);
+        const storedImages = getGeneratedImages();
+        const mapped = mapMessages(data.messages, storedImages);
+        dispatch(setMessages(mapped));
+      } catch {
+        // Fail silently — conversation will appear empty
+      }
+    },
+    [dispatch]
+  );
+
+  return loadConversation;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
+import { RouterProvider } from 'react-router-dom';
 import { store } from './store';
 import { ToastProvider } from './components/Toast/Toast';
-import App from './App';
+import router from './router';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <Provider store={store}>
       <ToastProvider>
-        <App />
+        <RouterProvider router={router} />
       </ToastProvider>
     </Provider>
   </React.StrictMode>

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,0 +1,36 @@
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+import App from './App';
+import MainContent from './components/MainContent';
+import ConversationsView from './components/ConversationsView';
+import ConversationRoute from './components/ConversationRoute';
+import ProjectsView from './components/ProjectsView';
+import ImageGalleryView from './components/ImageGalleryView';
+import ModelsView from './components/ModelsView';
+import SettingsView from './components/SettingsView';
+import PricingView from './components/PricingView/PricingView';
+import SubscriptionView from './components/SubscriptionView/SubscriptionView';
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <App />,
+    children: [
+      { index: true, element: <MainContent /> },
+      { path: 'conversations', element: <ConversationsView /> },
+      { path: 'conversations/:id', element: <ConversationRoute /> },
+      { path: 'chat/:id', element: <ConversationRoute /> },
+      { path: 'projects', element: <ProjectsView /> },
+      { path: 'projects/:id', element: <ProjectsView /> },
+      { path: 'images', element: <ImageGalleryView /> },
+      { path: 'images/:id', element: <ImageGalleryView /> },
+      { path: 'models', element: <ModelsView /> },
+      { path: 'settings', element: <SettingsView /> },
+      { path: 'settings/:section', element: <SettingsView /> },
+      { path: 'plans', element: <PricingView /> },
+      { path: 'subscription', element: <SubscriptionView /> },
+      { path: '*', element: <Navigate to="/" replace /> },
+    ],
+  },
+]);
+
+export default router;

--- a/src/store/slices/sidebarSlice.js
+++ b/src/store/slices/sidebarSlice.js
@@ -8,7 +8,6 @@ const getInitialCollapsed = () => {
 
 const initialState = {
   collapsed: getInitialCollapsed(),
-  activeItem: 'home',
 }
 
 const sidebarSlice = createSlice({
@@ -23,15 +22,11 @@ const sidebarSlice = createSlice({
       state.collapsed = action.payload
       localStorage.setItem('araviel-sidebar-collapsed', action.payload)
     },
-    setActiveItem: (state, action) => {
-      state.activeItem = action.payload
-    },
   },
 })
 
-export const { toggleSidebar, setCollapsed, setActiveItem } = sidebarSlice.actions
+export const { toggleSidebar, setCollapsed } = sidebarSlice.actions
 
 export const selectSidebarCollapsed = (state) => state.sidebar.collapsed
-export const selectActiveItem = (state) => state.sidebar.activeItem
 
 export default sidebarSlice.reducer

--- a/src/store/slices/sidebarSlice.test.js
+++ b/src/store/slices/sidebarSlice.test.js
@@ -2,9 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import sidebarReducer, {
   toggleSidebar,
   setCollapsed,
-  setActiveItem,
   selectSidebarCollapsed,
-  selectActiveItem,
 } from './sidebarSlice';
 
 describe('sidebarSlice', () => {
@@ -17,57 +15,34 @@ describe('sidebarSlice', () => {
       const state = sidebarReducer(undefined, { type: 'unknown' });
       expect(state.collapsed).toBe(true);
     });
-
-    it('defaults activeItem to home', () => {
-      const state = sidebarReducer(undefined, { type: 'unknown' });
-      expect(state.activeItem).toBe('home');
-    });
   });
 
   describe('toggleSidebar', () => {
     it('toggles collapsed from true to false', () => {
-      const state = sidebarReducer({ collapsed: true, activeItem: 'home' }, toggleSidebar());
+      const state = sidebarReducer({ collapsed: true }, toggleSidebar());
       expect(state.collapsed).toBe(false);
     });
 
     it('toggles collapsed from false to true', () => {
-      const state = sidebarReducer({ collapsed: false, activeItem: 'home' }, toggleSidebar());
+      const state = sidebarReducer({ collapsed: false }, toggleSidebar());
       expect(state.collapsed).toBe(true);
     });
 
     it('persists to localStorage', () => {
-      sidebarReducer({ collapsed: true, activeItem: 'home' }, toggleSidebar());
+      sidebarReducer({ collapsed: true }, toggleSidebar());
       expect(localStorage.setItem).toHaveBeenCalledWith('araviel-sidebar-collapsed', false);
     });
   });
 
   describe('setCollapsed', () => {
     it('sets collapsed to the given value', () => {
-      const state = sidebarReducer({ collapsed: true, activeItem: 'home' }, setCollapsed(false));
+      const state = sidebarReducer({ collapsed: true }, setCollapsed(false));
       expect(state.collapsed).toBe(false);
     });
 
     it('persists to localStorage', () => {
-      sidebarReducer({ collapsed: true, activeItem: 'home' }, setCollapsed(false));
+      sidebarReducer({ collapsed: true }, setCollapsed(false));
       expect(localStorage.setItem).toHaveBeenCalledWith('araviel-sidebar-collapsed', false);
-    });
-  });
-
-  describe('setActiveItem', () => {
-    it('sets the active item', () => {
-      const state = sidebarReducer(
-        { collapsed: true, activeItem: 'home' },
-        setActiveItem('settings')
-      );
-      expect(state.activeItem).toBe('settings');
-    });
-
-    it('can set to any string', () => {
-      const state = sidebarReducer(
-        { collapsed: true, activeItem: 'home' },
-        setActiveItem('conversations')
-      );
-      expect(state.activeItem).toBe('conversations');
     });
   });
 
@@ -75,10 +50,6 @@ describe('sidebarSlice', () => {
     it('selectSidebarCollapsed returns collapsed state', () => {
       expect(selectSidebarCollapsed({ sidebar: { collapsed: true } })).toBe(true);
       expect(selectSidebarCollapsed({ sidebar: { collapsed: false } })).toBe(false);
-    });
-
-    it('selectActiveItem returns active item', () => {
-      expect(selectActiveItem({ sidebar: { activeItem: 'models' } })).toBe('models');
     });
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/((?!api/).*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
Replace Redux state-based navigation (activeItem) with proper URL routing. Browser back/forward, deep links, and share links now work correctly.

- Add react-router-dom with createBrowserRouter and all route definitions
- Create ConversationRoute for deep-linking to /conversations/:id and /chat/:id
- Extract shared conversation-loading logic into useLoadConversation hook (DRY)
- Replace all 35+ dispatch(setActiveItem(...)) calls with navigate() across 13 files
- Remove activeItem, setActiveItem, selectActiveItem from Redux sidebarSlice entirely
- Update Sidebar active highlighting to use useLocation().pathname
- Add settings sub-routes via /settings/:section URL params
- Add project and image deep-link support via useParams()
- Add vercel.json SPA rewrite for production deployment
- Remove window.__aravielNavigateToProject hack in favor of route params

https://claude.ai/code/session_016mcJFZfRJQNez6UWkDwDbW