### PR TITLE
feat(top-nav): clean breadcrumb with rename + contextual project actions

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -96,6 +96,7 @@ import {
   TrashIcon,
   ProjectsIcon,
   ChevronDownIcon,
+  EditIcon,
 } from '../Icons';
 import ModelSelector from '../ModelSelector/ModelSelector';
 import MessageList from '../MessageList/MessageList';
@@ -714,9 +715,12 @@ export default function MainContent() {
   const [creatingProject, setCreatingProject] = useState(false);
   const [showRemoveFromProject, setShowRemoveFromProject] = useState(false);
   const [projectSearch, setProjectSearch] = useState('');
+  const [isRenamingTitle, setIsRenamingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState('');
   const newProjectInputRef = useRef(null);
   const projectSearchRef = useRef(null);
   const projectDropdownRef = useRef(null);
+  const titleRenameInputRef = useRef(null);
   const dropdownRef = useRef(null);
   const attachDropdownRef = useRef(null);
   const chatMenuRef = useRef(null);
@@ -924,6 +928,38 @@ export default function MainContent() {
     navigate(`/projects/${conversationProject.id}`);
   };
 
+  const handleStartRename = () => {
+    setTitleDraft(conversationTitle || '');
+    setIsRenamingTitle(true);
+    setShowProjectDropdown(false);
+  };
+
+  const handleCommitRename = async () => {
+    const trimmed = titleDraft.trim();
+    setIsRenamingTitle(false);
+    if (!currentChatId) return;
+    if (!trimmed || trimmed === conversationTitle) return;
+
+    const previousTitle = conversationTitle;
+    const prevConversations = [...conversations];
+    setConversationTitle(trimmed);
+    updateConvState(
+      conversations.map((c) => (c.id === currentChatId ? { ...c, title: trimmed } : c))
+    );
+    try {
+      await updateConversation(currentChatId, { title: trimmed });
+    } catch {
+      setConversationTitle(previousTitle);
+      updateConvState(prevConversations);
+      showError('Could not rename conversation. Try again.');
+    }
+  };
+
+  const handleCancelRename = () => {
+    setIsRenamingTitle(false);
+    setTitleDraft('');
+  };
+
   // Close project dropdown on outside click
   useEffect(() => {
     if (!showProjectDropdown) return;
@@ -953,6 +989,21 @@ export default function MainContent() {
       projectSearchRef.current.focus();
     }
   }, [showProjectPicker, showProjectCreate]);
+
+  // Focus + select the rename input when rename mode activates
+  useEffect(() => {
+    if (isRenamingTitle && titleRenameInputRef.current) {
+      const el = titleRenameInputRef.current;
+      el.focus();
+      el.select();
+    }
+  }, [isRenamingTitle]);
+
+  // Cancel rename if the user switches conversation mid-edit
+  useEffect(() => {
+    setIsRenamingTitle(false);
+    setTitleDraft('');
+  }, [currentChatId]);
 
   // Streaming / timeline state
   const [pipelineStatus, setPipelineStatus] = useState('idle'); // idle | routing | researching | thinking | writing | complete
@@ -2154,53 +2205,97 @@ export default function MainContent() {
     >
       {/* Top nav bar */}
       <div className={styles.topNav}>
-        {/* Project context header — left side */}
-        {conversationProject && (
-          <div className={styles.projectHeader} ref={projectDropdownRef}>
-            <button
-              className={styles.projectBadge}
-              onClick={handleNavigateToProject}
-              title={`Go to ${conversationProject.name}`}
-            >
-              <ProjectsIcon />
-              <span>{conversationProject.name}</span>
-            </button>
-            <span className={styles.projectHeaderSep}>›</span>
-            <button
-              className={`${styles.projectHeaderTitleBtn} ${
-                showProjectDropdown ? styles.projectHeaderTitleBtnOpen : ''
-              }`}
-              onClick={() => {
-                setShowProjectDropdown(!showProjectDropdown);
-                setShowProjectPicker(false);
-                setProjectSearch('');
-              }}
-              aria-label="Project options"
-            >
-              <span className={styles.projectHeaderTitle}>{conversationTitle || 'Untitled'}</span>
-              <ChevronDownIcon />
-            </button>
+        {/* Breadcrumb — title + project context */}
+        {currentChatId && conversationTitle && (
+          <div className={styles.breadcrumb} ref={projectDropdownRef}>
+            {conversationProject && (
+              <>
+                <button
+                  className={styles.breadcrumbProject}
+                  onClick={handleNavigateToProject}
+                  title={`Open ${conversationProject.name}`}
+                >
+                  <ProjectsIcon />
+                  <span>{conversationProject.name}</span>
+                </button>
+                <span className={styles.breadcrumbSep} aria-hidden="true">
+                  /
+                </span>
+              </>
+            )}
 
-            {/* Project dropdown menu */}
-            {showProjectDropdown && !showProjectPicker && (
-              <div className={styles.projectDropdown}>
+            {isRenamingTitle ? (
+              <input
+                ref={titleRenameInputRef}
+                type="text"
+                className={styles.breadcrumbRenameInput}
+                value={titleDraft}
+                onChange={(e) => setTitleDraft(e.target.value)}
+                onBlur={handleCommitRename}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleCommitRename();
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    handleCancelRename();
+                  }
+                }}
+                maxLength={200}
+                aria-label="Rename conversation"
+              />
+            ) : (
+              <button
+                className={`${styles.breadcrumbTitleBtn} ${
+                  showProjectDropdown ? styles.breadcrumbTitleBtnOpen : ''
+                }`}
+                onClick={() => {
+                  setShowProjectDropdown(!showProjectDropdown);
+                  setShowProjectPicker(false);
+                  setShowProjectCreate(false);
+                  setProjectSearch('');
+                }}
+                aria-haspopup="menu"
+                aria-expanded={showProjectDropdown}
+                aria-label="Conversation options"
+              >
+                <span className={styles.breadcrumbTitle}>{conversationTitle}</span>
+                <ChevronDownIcon />
+              </button>
+            )}
+
+            {/* Main dropdown menu */}
+            {showProjectDropdown && !showProjectPicker && !showProjectCreate && (
+              <div className={styles.projectDropdown} role="menu">
                 <button
                   className={styles.projectDropdownItem}
+                  role="menuitem"
+                  onClick={handleStartRename}
+                >
+                  <EditIcon />
+                  <span>Rename</span>
+                </button>
+                <button
+                  className={styles.projectDropdownItem}
+                  role="menuitem"
                   onClick={() => setShowProjectPicker(true)}
                 >
                   <ProjectsIcon />
-                  <span>Change project</span>
+                  <span>{conversationProject ? 'Change project' : 'Add to project'}</span>
                 </button>
-                <button
-                  className={`${styles.projectDropdownItem} ${styles.projectDropdownItemDanger}`}
-                  onClick={() => {
-                    setShowProjectDropdown(false);
-                    setShowRemoveFromProject(true);
-                  }}
-                >
-                  <CloseIcon />
-                  <span>Remove from project</span>
-                </button>
+                {conversationProject && (
+                  <button
+                    className={`${styles.projectDropdownItem} ${styles.projectDropdownItemDanger}`}
+                    role="menuitem"
+                    onClick={() => {
+                      setShowProjectDropdown(false);
+                      setShowRemoveFromProject(true);
+                    }}
+                  >
+                    <CloseIcon />
+                    <span>Remove from project</span>
+                  </button>
+                )}
               </div>
             )}
 
@@ -2214,6 +2309,7 @@ export default function MainContent() {
                       setShowProjectPicker(false);
                       setProjectSearch('');
                     }}
+                    aria-label="Back"
                   >
                     <ChevronLeftIcon />
                   </button>
@@ -2239,14 +2335,28 @@ export default function MainContent() {
                       <span>New project</span>
                     </button>
                   )}
-                  {projects
-                    .filter((p) => !p.is_archived && p.id !== conversationProject.id)
-                    .filter(
-                      (p) =>
-                        !projectSearch.trim() ||
-                        p.name.toLowerCase().includes(projectSearch.trim().toLowerCase())
-                    )
-                    .map((project) => (
+                  {(() => {
+                    const available = projects
+                      .filter(
+                        (p) => !p.is_archived && (!conversationProject || p.id !== conversationProject.id)
+                      )
+                      .filter(
+                        (p) =>
+                          !projectSearch.trim() ||
+                          p.name.toLowerCase().includes(projectSearch.trim().toLowerCase())
+                      );
+                    if (available.length === 0) {
+                      return (
+                        <p className={styles.projectPickerEmpty}>
+                          {projectSearch.trim()
+                            ? `No projects match "${projectSearch.trim()}"`
+                            : conversationProject
+                            ? 'No other projects available'
+                            : 'No projects yet — create one above'}
+                        </p>
+                      );
+                    }
+                    return available.map((project) => (
                       <button
                         key={project.id}
                         className={styles.projectPickerItem}
@@ -2255,20 +2365,8 @@ export default function MainContent() {
                         <ProjectsIcon />
                         <span>{project.name}</span>
                       </button>
-                    ))}
-                  {projects
-                    .filter((p) => !p.is_archived && p.id !== conversationProject.id)
-                    .filter(
-                      (p) =>
-                        !projectSearch.trim() ||
-                        p.name.toLowerCase().includes(projectSearch.trim().toLowerCase())
-                    ).length === 0 && (
-                    <p className={styles.projectPickerEmpty}>
-                      {projectSearch.trim()
-                        ? `No projects match "${projectSearch.trim()}"`
-                        : 'No other projects available'}
-                    </p>
-                  )}
+                    ));
+                  })()}
                 </div>
               </div>
             )}
@@ -2283,10 +2381,11 @@ export default function MainContent() {
                       setShowProjectCreate(false);
                       setNewProjectName('');
                     }}
+                    aria-label="Back"
                   >
                     <ChevronLeftIcon />
                   </button>
-                  <span>New project</span>
+                  <span className={styles.projectPickerHeaderTitle}>New project</span>
                 </div>
                 <form className={styles.projectCreateForm} onSubmit={handleCreateAndAssignProject}>
                   <input

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -48,12 +48,8 @@
   height: 52px;
   z-index: 10;
   pointer-events: none;
-  background: linear-gradient(
-    to bottom,
-    var(--bg-primary) 0%,
-    var(--bg-primary) 60%,
-    transparent 100%
-  );
+  background-color: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .topNavInner {
@@ -77,22 +73,23 @@
   height: 14px;
 }
 
-/* Project context — top-left */
-.projectHeader {
+/* Breadcrumb — top-left title bar */
+.breadcrumb {
   pointer-events: auto;
   display: flex;
   align-items: center;
-  gap: 0;
+  gap: 2px;
   margin-right: auto;
-  margin-left: 8px;
+  margin-left: 4px;
   position: relative;
-  animation: projectHeaderIn 0.3s cubic-bezier(0.2, 0, 0, 1);
+  min-width: 0;
+  animation: breadcrumbIn 0.25s cubic-bezier(0.2, 0, 0, 1);
 }
 
-@keyframes projectHeaderIn {
+@keyframes breadcrumbIn {
   from {
     opacity: 0;
-    transform: translateX(-8px);
+    transform: translateX(-6px);
   }
   to {
     opacity: 1;
@@ -100,107 +97,116 @@
   }
 }
 
-/* Warm amber project badge */
-.projectBadge {
+/* Project segment — navigates to the project */
+.breadcrumbProject {
   display: flex;
   align-items: center;
-  gap: 5px;
-  padding: 5px 10px 5px 8px;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  color: #b45309;
-  background: linear-gradient(135deg, rgba(217, 119, 6, 0.1) 0%, rgba(245, 158, 11, 0.07) 100%);
-  border: 1px solid rgba(217, 119, 6, 0.15);
-  border-radius: 20px;
+  gap: 6px;
+  padding: 5px 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.12s ease, color 0.12s ease;
   white-space: nowrap;
-  max-width: 160px;
+  max-width: 180px;
   flex-shrink: 0;
 }
 
-:global([data-theme='dark']) .projectBadge {
-  color: #fbbf24;
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.12) 0%, rgba(217, 119, 6, 0.08) 100%);
-  border-color: rgba(251, 191, 36, 0.18);
+.breadcrumbProject:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
 }
 
-.projectBadge:hover {
-  background: linear-gradient(135deg, rgba(217, 119, 6, 0.16) 0%, rgba(245, 158, 11, 0.12) 100%);
-  border-color: rgba(217, 119, 6, 0.25);
-  transform: translateY(-0.5px);
-}
-
-:global([data-theme='dark']) .projectBadge:hover {
-  background: linear-gradient(135deg, rgba(251, 191, 36, 0.18) 0%, rgba(217, 119, 6, 0.14) 100%);
-  border-color: rgba(251, 191, 36, 0.28);
-}
-
-.projectBadge svg {
-  width: 12px;
-  height: 12px;
+.breadcrumbProject svg {
+  width: 13px;
+  height: 13px;
   flex-shrink: 0;
-  opacity: 0.75;
+  color: var(--text-muted);
 }
 
-.projectBadge span {
+.breadcrumbProject span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Separator */
-.projectHeaderSep {
-  font-size: 16px;
+/* Thin separator between project and title */
+.breadcrumbSep {
+  font-size: 13px;
   color: var(--text-muted);
-  opacity: 0.3;
-  margin: 0 8px;
+  opacity: 0.4;
   user-select: none;
-  font-weight: 300;
+  padding: 0 2px;
+  line-height: 1;
 }
 
-/* Title + chevron as one clickable unit */
-.projectHeaderTitleBtn {
+/* Title segment — opens context menu */
+.breadcrumbTitleBtn {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 6px 4px 2px;
+  gap: 5px;
+  padding: 5px 6px 5px 8px;
   background: transparent;
   border: none;
-  border-radius: 8px;
+  border-radius: 6px;
   cursor: pointer;
-  transition: all 0.15s ease;
-  max-width: 260px;
+  transition: background-color 0.12s ease;
+  min-width: 0;
+  max-width: 320px;
 }
 
-.projectHeaderTitleBtn:hover {
+.breadcrumbTitleBtn:hover {
   background-color: var(--bg-hover);
 }
 
-.projectHeaderTitleBtn svg {
-  width: 13px;
-  height: 13px;
+.breadcrumbTitleBtn svg {
+  width: 12px;
+  height: 12px;
   color: var(--text-muted);
   flex-shrink: 0;
   transition: transform 0.2s ease;
 }
 
-.projectHeaderTitleBtnOpen {
+.breadcrumbTitleBtnOpen {
   background-color: var(--bg-hover);
 }
 
-.projectHeaderTitleBtnOpen svg {
+.breadcrumbTitleBtnOpen svg {
   transform: rotate(180deg);
 }
 
-.projectHeaderTitle {
-  font-size: 14px;
+.breadcrumbTitle {
+  font-size: 13px;
   font-weight: 500;
-  color: var(--text-secondary);
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Inline rename input */
+.breadcrumbRenameInput {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 4px 8px;
+  outline: none;
+  min-width: 160px;
+  max-width: 320px;
+  margin-left: 4px;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.breadcrumbRenameInput:focus {
+  border-color: var(--text-secondary);
+  box-shadow: 0 0 0 2px var(--bg-hover);
 }
 
 /* Project dropdown menu */
@@ -270,10 +276,17 @@
 .projectPickerHeader {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   padding: 6px 8px;
   border-bottom: 1px solid var(--border-color);
   margin-bottom: 4px;
+}
+
+.projectPickerHeaderTitle {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  letter-spacing: 0.01em;
 }
 
 .projectPickerBack {
@@ -331,8 +344,8 @@
 }
 
 .projectPickerSearchInput:focus {
-  border-color: #d97706;
-  box-shadow: 0 0 0 2px rgba(217, 119, 6, 0.08);
+  border-color: var(--text-secondary);
+  box-shadow: 0 0 0 2px var(--bg-hover);
 }
 
 .projectPickerSearchInput::placeholder {
@@ -370,7 +383,7 @@
   width: 14px;
   height: 14px;
   flex-shrink: 0;
-  color: #d97706;
+  color: var(--text-muted);
 }
 
 .projectPickerItem span {
@@ -396,23 +409,27 @@
   border-radius: 7px;
   font-size: 13px;
   font-weight: 500;
-  color: #d97706;
+  color: var(--text-primary);
   background: transparent;
   border: none;
+  border-bottom: 1px solid var(--border-color);
   cursor: pointer;
   transition: background-color 0.12s ease;
   text-align: left;
-  margin-bottom: 2px;
+  margin-bottom: 4px;
+  padding-bottom: 10px;
+  border-radius: 7px 7px 0 0;
 }
 
 .projectPickerCreate:hover {
-  background-color: rgba(217, 119, 6, 0.08);
+  background-color: var(--bg-hover);
 }
 
 .projectPickerCreate svg {
   width: 14px;
   height: 14px;
   flex-shrink: 0;
+  color: var(--text-muted);
 }
 
 /* Inline create project form inside dropdown */
@@ -434,8 +451,8 @@
 }
 
 .projectCreateInput:focus {
-  border-color: #d97706;
-  box-shadow: 0 0 0 2px rgba(217, 119, 6, 0.1);
+  border-color: var(--text-secondary);
+  box-shadow: 0 0 0 2px var(--bg-hover);
 }
 
 .projectCreateInput::placeholder {
@@ -448,15 +465,15 @@
   border-radius: 8px;
   font-size: 13px;
   font-weight: 500;
-  background-color: #d97706;
-  color: white;
+  background-color: var(--text-primary);
+  color: var(--bg-primary);
   border: none;
   cursor: pointer;
-  transition: background-color 0.15s ease, transform 0.1s ease;
+  transition: opacity 0.15s ease, transform 0.1s ease;
 }
 
 .projectCreateSubmit:hover:not(:disabled) {
-  background-color: #b45309;
+  opacity: 0.88;
 }
 
 .projectCreateSubmit:active:not(:disabled) {
@@ -473,8 +490,8 @@
   width: 48px;
   height: 48px;
   border-radius: 14px;
-  background: rgba(217, 119, 6, 0.08);
-  color: #d97706;
+  background-color: var(--bg-hover);
+  color: var(--text-secondary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2424,30 +2441,30 @@
   .topNav {
     padding: 0 12px;
     height: 56px;
-    background: linear-gradient(
-      to bottom,
-      var(--bg-primary) 0%,
-      var(--bg-primary) 70%,
-      transparent 100%
-    );
   }
 
-  .projectHeader {
+  .breadcrumb {
     margin-left: 40px;
   }
 
-  .projectBadge {
-    font-size: 11px;
-    padding: 4px 8px 4px 6px;
-    max-width: 110px;
-  }
-
-  .projectHeaderTitleBtn {
+  .breadcrumbProject {
+    font-size: 12px;
+    padding: 4px 6px;
     max-width: 120px;
   }
 
-  .projectHeaderTitle {
+  .breadcrumbTitleBtn {
+    max-width: 140px;
+  }
+
+  .breadcrumbTitle {
     font-size: 12px;
+  }
+
+  .breadcrumbRenameInput {
+    font-size: 12px;
+    min-width: 120px;
+    max-width: 180px;
   }
 
   .projectDropdown {


### PR DESCRIPTION
- Replace the gradient bottom fade on the top nav with a single 1px border-bottom line for a crisper, more deliberate edge.
- Retire the amber rounded project pill in favour of a neutral breadcrumb: "<project> / <title> ⌄" when linked to a project, just "<title> ⌄" otherwise. Both segments are clickable — project navigates to /projects/:id, title opens the context menu.
- Inline rename: selecting "Rename" swaps the title for a focused input; Enter or blur commits, Esc cancels. Optimistic update to Redux + server via updateConversation; rolls back on failure.
- Dropdown adapts to state:
  - In-project: Rename / Change project / Remove from project
  - Projectless: Rename / Add to project
  - Change + Add both open the same picker (with search, "+ New project" header, and inline create form — all reused).
- Cancel any in-flight rename when the active conversation changes so the input can't leak stale drafts across chats.
- Neutralise leftover amber accents in the picker + create form (search focus ring, "New project" button, submit button, remove confirm icon) to match the site's neutral palette in light + dark.
- Update mobile overrides to the new class names.

Keyboard + a11y: aria-haspopup/aria-expanded on the title trigger, role="menu"/"menuitem" on dropdown items, aria-label on the rename input, aria-hidden separator. Star/Archive/Report/Delete stay on the right-side "more" menu — untouched — avoiding duplicate actions.

No other components touched. Build green, 370 tests passing (the 3 pre-existing subscription-config failures are unrelated).