### PR TITLE
Fix new chat reload bug and improve UI polish

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -1872,6 +1872,7 @@ export default function MainContent() {
     setStreamedText('');
     setRouteResult(null);
     setIsManualRequest(false);
+    navigate('/');
   };
 
   /**
@@ -2338,7 +2339,9 @@ export default function MainContent() {
                   {(() => {
                     const available = projects
                       .filter(
-                        (p) => !p.is_archived && (!conversationProject || p.id !== conversationProject.id)
+                        (p) =>
+                          !p.is_archived &&
+                          (!conversationProject || p.id !== conversationProject.id)
                       )
                       .filter(
                         (p) =>
@@ -2410,19 +2413,23 @@ export default function MainContent() {
           </div>
         )}
         <div className={styles.topNavInner}>
-          {currentConv?.isReported && (
-            <span className={styles.reportedFlag} title="This conversation has been reported">
-              <FlagIcon />
-            </span>
+          {currentChatId && (
+            <>
+              {currentConv?.isReported && (
+                <span className={styles.reportedFlag} title="This conversation has been reported">
+                  <FlagIcon />
+                </span>
+              )}
+              <button
+                className={styles.shareBtn}
+                onClick={() => setShowShareModal(true)}
+                title="Share"
+                aria-label="Share conversation"
+              >
+                <ShareIcon />
+              </button>
+            </>
           )}
-          <button
-            className={styles.shareBtn}
-            onClick={() => setShowShareModal(true)}
-            title="Share"
-            aria-label="Share conversation"
-          >
-            <ShareIcon />
-          </button>
           <button
             className={styles.newChatNavBtn}
             onClick={handleNewChat}
@@ -2431,67 +2438,69 @@ export default function MainContent() {
           >
             <NewChatIcon />
           </button>
-          <div className={styles.chatMenuWrapper} ref={chatMenuRef}>
-            <button
-              className={`${styles.chatMenuBtn} ${showChatMenu ? styles.chatMenuBtnActive : ''}`}
-              onClick={() => setShowChatMenu(!showChatMenu)}
-              title="More options"
-              aria-label="More options"
-            >
-              <MoreVerticalIcon />
-            </button>
-            {showChatMenu && (
-              <div className={styles.chatMenuDropdown}>
-                <button
-                  className={styles.chatMenuItem}
-                  onClick={() => {
-                    setShowChatMenu(false);
-                    handleToggleStar();
-                  }}
-                >
-                  <StarIcon />
-                  <span>{currentConv?.isStarred ? 'Unstar' : 'Star conversation'}</span>
-                </button>
-                <button
-                  className={styles.chatMenuItem}
-                  onClick={() => {
-                    setShowChatMenu(false);
-                    handleToggleArchive();
-                  }}
-                >
-                  <ArchiveIcon />
-                  <span>{currentConv?.isArchived ? 'Unarchive' : 'Archive'}</span>
-                </button>
-                <button
-                  className={`${styles.chatMenuItem} ${
-                    currentConv?.isReported ? styles.chatMenuItemReported : ''
-                  }`}
-                  onClick={() => {
-                    setShowChatMenu(false);
-                    if (currentConv?.isReported) {
-                      handleUnreport();
-                    } else {
-                      setShowReportDialog(true);
-                    }
-                  }}
-                >
-                  <FlagIcon />
-                  <span>{currentConv?.isReported ? 'Unreport' : 'Report'}</span>
-                </button>
-                <div className={styles.chatMenuDivider} />
-                <button
-                  className={`${styles.chatMenuItem} ${styles.chatMenuItemDanger}`}
-                  onClick={() => {
-                    setShowChatMenu(false);
-                    setShowDeleteConfirm(true);
-                  }}
-                >
-                  <TrashIcon />
-                  <span>Delete</span>
-                </button>
-              </div>
-            )}
-          </div>
+          {currentChatId && (
+            <div className={styles.chatMenuWrapper} ref={chatMenuRef}>
+              <button
+                className={`${styles.chatMenuBtn} ${showChatMenu ? styles.chatMenuBtnActive : ''}`}
+                onClick={() => setShowChatMenu(!showChatMenu)}
+                title="More options"
+                aria-label="More options"
+              >
+                <MoreVerticalIcon />
+              </button>
+              {showChatMenu && (
+                <div className={styles.chatMenuDropdown}>
+                  <button
+                    className={styles.chatMenuItem}
+                    onClick={() => {
+                      setShowChatMenu(false);
+                      handleToggleStar();
+                    }}
+                  >
+                    <StarIcon />
+                    <span>{currentConv?.isStarred ? 'Unstar' : 'Star conversation'}</span>
+                  </button>
+                  <button
+                    className={styles.chatMenuItem}
+                    onClick={() => {
+                      setShowChatMenu(false);
+                      handleToggleArchive();
+                    }}
+                  >
+                    <ArchiveIcon />
+                    <span>{currentConv?.isArchived ? 'Unarchive' : 'Archive'}</span>
+                  </button>
+                  <button
+                    className={`${styles.chatMenuItem} ${
+                      currentConv?.isReported ? styles.chatMenuItemReported : ''
+                    }`}
+                    onClick={() => {
+                      setShowChatMenu(false);
+                      if (currentConv?.isReported) {
+                        handleUnreport();
+                      } else {
+                        setShowReportDialog(true);
+                      }
+                    }}
+                  >
+                    <FlagIcon />
+                    <span>{currentConv?.isReported ? 'Unreport' : 'Report'}</span>
+                  </button>
+                  <div className={styles.chatMenuDivider} />
+                  <button
+                    className={`${styles.chatMenuItem} ${styles.chatMenuItemDanger}`}
+                    onClick={() => {
+                      setShowChatMenu(false);
+                      setShowDeleteConfirm(true);
+                    }}
+                  >
+                    <TrashIcon />
+                    <span>Delete</span>
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -16,6 +16,7 @@
   justify-content: flex-end;
   align-items: stretch;
   padding: 0;
+  padding-top: 24px;
 }
 
 /* When sub-conversation panel is open, make room on the right (card width + spacing) */

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -131,12 +131,8 @@
   justify-content: flex-end;
   gap: 2px;
   padding-top: 6px;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-}
-
-.userPromptWrapper:hover .userPromptActions {
   opacity: 1;
+  transition: opacity 0.15s ease;
 }
 
 .userPromptTime {


### PR DESCRIPTION
- Fix new chat reload bug: Added navigate('/') to handleNewChat() in MainContent to ensure navigation to fresh chat and prevent ConversationRoute from reloading the previous conversation based on stale URL params
- Hide top-right icons on fresh chat: Conditionally render share and menu buttons only when viewing a conversation (currentChatId exists), keeping the new chat button always visible
- Add spacing below top nav: Added 24px padding-top to main.hasMessages for subtle visual breathing room between the nav bar and first message
- Always show user message action icons: Changed user message action icons (edit, copy, retry) from hidden-by-default (hover to reveal) to always-visible so users immediately see these actions are available

https://claude.ai/code/session_01442dyuKF5nxeJ33yuRFBAX