### PR TITLE
feat(share): add public share-link flow + read-only viewer

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import {
@@ -97,6 +97,7 @@ import {
   ProjectsIcon,
   ChevronDownIcon,
   EditIcon,
+  RefreshIcon,
 } from '../Icons';
 import ModelSelector from '../ModelSelector/ModelSelector';
 import MessageList from '../MessageList/MessageList';
@@ -107,6 +108,10 @@ import {
   updateConversation,
   reportConversation,
   createProject as createProjectApi,
+  fetchConversationShare,
+  createConversationShare,
+  updateConversationShare,
+  revokeConversationShare,
 } from '../../services/api';
 import { useToast } from '../Toast/Toast';
 import { selectProjects, addProject } from '../../store/slices/projectsSlice';
@@ -386,20 +391,63 @@ function createStages(status, modelName, isManualSelection, researchProgress) {
 }
 
 /**
- * Share modal component.
+ * Share modal.
+ *
+ * Creates (or refreshes) a public, unguessable share link for a conversation.
+ * On mount we check whether an active share already exists; if not, we create
+ * one immediately so the "Copy link" affordance is available without an extra
+ * click. The owner can refresh the snapshot to include newer messages or
+ * revoke the link entirely.
  */
-function ShareModal({ onClose }) {
+function ShareModal({ conversationId, conversationTitle, messages, onClose, onSuccess, onError }) {
+  const [share, setShare] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [linkCopied, setLinkCopied] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isRevoking, setIsRevoking] = useState(false);
 
-  const handleCopyLink = () => {
-    const shareUrl = window.location.href;
-    navigator.clipboard.writeText(shareUrl).then(() => {
-      setLinkCopied(true);
-      setTimeout(() => setLinkCopied(false), 2500);
+  const shareUrl = useMemo(() => {
+    if (!share?.shareToken) return null;
+    return `${window.location.origin}/share/${share.shareToken}`;
+  }, [share]);
+
+  const hasNewMessagesSinceShare = useMemo(() => {
+    if (!share?.snapshotAt || !messages?.length) return false;
+    const snapshotMs = new Date(share.snapshotAt).getTime();
+    return messages.some((m) => {
+      const raw = m.createdAt ?? m.timestamp;
+      if (raw == null) return false;
+      const t = typeof raw === 'number' ? raw : new Date(raw).getTime();
+      return Number.isFinite(t) && t > snapshotMs;
     });
-  };
+  }, [share, messages]);
 
-  // Close on Escape
+  // Fetch existing share or create one on mount.
+  useEffect(() => {
+    if (!conversationId) return undefined;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { share: existing } = await fetchConversationShare(conversationId);
+        if (cancelled) return;
+        if (existing) {
+          setShare(existing);
+        } else {
+          const created = await createConversationShare(conversationId);
+          if (!cancelled) setShare(created);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err.message || 'Could not create share link');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationId]);
+
   useEffect(() => {
     const handleKey = (e) => {
       if (e.key === 'Escape') onClose();
@@ -408,51 +456,172 @@ function ShareModal({ onClose }) {
     return () => document.removeEventListener('keydown', handleKey);
   }, [onClose]);
 
+  const handleCopyLink = () => {
+    if (!shareUrl) return;
+    navigator.clipboard
+      .writeText(shareUrl)
+      .then(() => {
+        setLinkCopied(true);
+        setTimeout(() => setLinkCopied(false), 2500);
+      })
+      .catch((err) => onError?.(err.message || 'Could not copy link'));
+  };
+
+  const handleUpdate = async () => {
+    if (isUpdating || !conversationId) return;
+    setIsUpdating(true);
+    setError(null);
+    try {
+      const refreshed = await updateConversationShare(conversationId);
+      setShare(refreshed);
+      onSuccess?.('Snapshot updated');
+    } catch (err) {
+      setError(err.message || 'Could not update snapshot');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleRevoke = async () => {
+    if (isRevoking || !conversationId) return;
+    setIsRevoking(true);
+    setError(null);
+    try {
+      await revokeConversationShare(conversationId);
+      onSuccess?.('Share link revoked');
+      onClose();
+    } catch (err) {
+      setError(err.message || 'Could not revoke share link');
+      setIsRevoking(false);
+    }
+  };
+
+  const previewTitle = conversationTitle?.trim() || 'Araviel Conversation';
+  const previewUrl = shareUrl ? shareUrl.replace(/^https?:\/\//, '') : 'Generating link…';
+  const snapshotAt = share?.snapshotAt ? new Date(share.snapshotAt) : null;
+  const snapshotLabel = snapshotAt
+    ? `Snapshot taken ${snapshotAt.toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      })}`
+    : null;
+
   return (
     <div className={styles.shareOverlay} onClick={onClose}>
-      <div className={styles.shareModal} onClick={(e) => e.stopPropagation()}>
+      <div
+        className={styles.shareModal}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-modal-title"
+      >
         <div className={styles.shareModalHeader}>
-          <h3>Share conversation</h3>
+          <h3 id="share-modal-title">Share conversation</h3>
           <button className={styles.shareModalClose} onClick={onClose} aria-label="Close">
             <CloseIcon />
           </button>
         </div>
 
         <p className={styles.shareModalDesc}>
-          Create a public link to share this conversation. Anyone with the link will be able to view
-          it.
+          Create a public link to share this conversation. Anyone with the link can view a read-only
+          snapshot — new messages won't be visible unless you update it.
         </p>
 
-        <div className={styles.shareModalPreview}>
-          <div className={styles.sharePreviewIcon}>
-            <SparkleIcon />
+        {loading ? (
+          <div className={styles.shareLoadingRow}>
+            <span className={styles.shareSpinner} aria-hidden="true" />
+            <span>Preparing share link…</span>
           </div>
-          <div className={styles.sharePreviewInfo}>
-            <span className={styles.sharePreviewTitle}>Araviel Conversation</span>
-            <span className={styles.sharePreviewUrl}>araviel.com/share/...</span>
-          </div>
-        </div>
-
-        <div className={styles.shareModalActions}>
-          <button
-            className={`${styles.shareActionBtn} ${styles.shareCopyBtn} ${
-              linkCopied ? styles.copied : ''
-            }`}
-            onClick={handleCopyLink}
-          >
-            {linkCopied ? (
-              <>
-                <CheckIcon />
-                <span>Link copied</span>
-              </>
-            ) : (
-              <>
-                <LinkIcon />
-                <span>Copy link</span>
-              </>
+        ) : (
+          <>
+            {error && (
+              <div className={styles.shareError} role="alert">
+                {error}
+              </div>
             )}
-          </button>
-        </div>
+
+            <div className={styles.shareModalPreview}>
+              <div className={styles.sharePreviewIcon}>
+                <SparkleIcon />
+              </div>
+              <div className={styles.sharePreviewInfo}>
+                <span className={styles.sharePreviewTitle} title={previewTitle}>
+                  {previewTitle}
+                </span>
+                <span className={styles.sharePreviewUrl} title={shareUrl ?? ''}>
+                  {previewUrl}
+                </span>
+                {snapshotLabel && <span className={styles.shareSnapshotMeta}>{snapshotLabel}</span>}
+              </div>
+            </div>
+
+            <div className={styles.shareModalActions}>
+              <button
+                type="button"
+                className={`${styles.shareActionBtn} ${styles.shareDangerBtn}`}
+                onClick={handleRevoke}
+                disabled={!share || isRevoking}
+              >
+                {isRevoking ? (
+                  <>
+                    <span className={styles.shareSpinner} aria-hidden="true" />
+                    <span>Revoking…</span>
+                  </>
+                ) : (
+                  <>
+                    <TrashIcon />
+                    <span>Unshare</span>
+                  </>
+                )}
+              </button>
+
+              <div className={styles.shareModalActionsGroup}>
+                {hasNewMessagesSinceShare && (
+                  <button
+                    type="button"
+                    className={`${styles.shareActionBtn} ${styles.shareSecondaryBtn}`}
+                    onClick={handleUpdate}
+                    disabled={isUpdating}
+                    title="Include messages sent since this link was created"
+                  >
+                    {isUpdating ? (
+                      <>
+                        <span className={styles.shareSpinner} aria-hidden="true" />
+                        <span>Updating…</span>
+                      </>
+                    ) : (
+                      <>
+                        <RefreshIcon />
+                        <span>Update</span>
+                      </>
+                    )}
+                  </button>
+                )}
+
+                <button
+                  type="button"
+                  className={`${styles.shareActionBtn} ${styles.shareCopyBtn} ${
+                    linkCopied ? styles.copied : ''
+                  }`}
+                  onClick={handleCopyLink}
+                  disabled={!shareUrl}
+                >
+                  {linkCopied ? (
+                    <>
+                      <CheckIcon />
+                      <span>Link copied</span>
+                    </>
+                  ) : (
+                    <>
+                      <LinkIcon />
+                      <span>Copy link</span>
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );
@@ -2643,7 +2812,16 @@ export default function MainContent() {
       )}
 
       {/* Share modal */}
-      {showShareModal && <ShareModal onClose={() => setShowShareModal(false)} />}
+      {showShareModal && currentChatId && (
+        <ShareModal
+          conversationId={currentChatId}
+          conversationTitle={currentConv?.title}
+          messages={messages}
+          onClose={() => setShowShareModal(false)}
+          onSuccess={showSuccess}
+          onError={showError}
+        />
+      )}
 
       {showBuyPacksModal && <BuyPacksModal onClose={() => setShowBuyPacksModal(false)} />}
 

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -994,7 +994,15 @@
 
 .shareModalActions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.shareModalActionsGroup {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .shareActionBtn {
@@ -1009,24 +1017,107 @@
   cursor: pointer;
 }
 
+.shareActionBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
 .shareCopyBtn {
   background-color: var(--bg-icon-button);
   color: var(--text-icon-button);
 }
 
-.shareCopyBtn:hover {
+.shareCopyBtn:hover:not(:disabled) {
   opacity: 0.9;
   transform: translateY(-1px);
 }
 
 .shareCopyBtn.copied {
-  background-color: #22c55e;
-  color: #fff;
+  background-color: var(--bg-icon-button);
+  color: var(--text-icon-button);
 }
 
 .shareCopyBtn svg {
   width: 14px;
   height: 14px;
+}
+
+.shareSecondaryBtn {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+}
+
+.shareSecondaryBtn:hover:not(:disabled) {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.shareSecondaryBtn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.shareDangerBtn {
+  background-color: transparent;
+  color: var(--text-muted);
+  border: 1px solid transparent;
+  padding: 10px 14px;
+}
+
+.shareDangerBtn:hover:not(:disabled) {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.shareDangerBtn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.shareLoadingRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px;
+  color: var(--text-secondary);
+  font-size: 13.5px;
+}
+
+.shareSpinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--text-secondary);
+  border-radius: 50%;
+  animation: shareSpin 0.6s linear infinite;
+  display: inline-block;
+}
+
+@keyframes shareSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.shareError {
+  font-size: 13px;
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin-bottom: 16px;
+  line-height: 1.4;
+}
+
+.shareSnapshotMeta {
+  display: block;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  margin-top: 2px;
 }
 
 .container {

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -4016,6 +4016,7 @@ function ResponseActions({
   conversationId,
   onOpenSourcesPanel,
   isSourcesPanelOpen,
+  readOnly = false,
 }) {
   const [copied, setCopied] = useState(false);
   const [liked, setLiked] = useState(message.feedback === 'like');
@@ -4197,11 +4198,11 @@ function ResponseActions({
           <div
             className={styles.modelPillSmallWrapper}
             ref={modelPillRef}
-            onClick={() => setShowModelDropdown((prev) => !prev)}
+            onClick={readOnly ? undefined : () => setShowModelDropdown((prev) => !prev)}
           >
             <div
               className={`${styles.modelPillSmall} ${
-                hasAlternates ? styles.modelPillSmallClickable : ''
+                hasAlternates && !readOnly ? styles.modelPillSmallClickable : ''
               }`}
               style={{
                 backgroundColor: isDark ? providerData.accentBgDark : providerData.accentBg,
@@ -4212,13 +4213,13 @@ function ResponseActions({
             >
               <LogoComponent size={12} />
               <span>{displayName}</span>
-              {hasAlternates && (
+              {hasAlternates && !readOnly && (
                 <span className={styles.modelPillChevron}>
                   <ChevronDownIcon />
                 </span>
               )}
             </div>
-            {showModelDropdown && (
+            {showModelDropdown && !readOnly && (
               <ModelPillDropdown
                 message={message}
                 isDark={isDark}
@@ -4238,22 +4239,26 @@ function ResponseActions({
       </div>
 
       <div className={styles.responseActionsRight}>
-        <button
-          className={`${styles.actionIcon} ${liked ? styles.actionIconActive : ''}`}
-          onClick={handleLike}
-          title="Like"
-          aria-label="Like response"
-        >
-          <ThumbsUpIcon />
-        </button>
-        <button
-          className={`${styles.actionIcon} ${disliked ? styles.actionIconActive : ''}`}
-          onClick={handleDislike}
-          title="Dislike"
-          aria-label="Dislike response"
-        >
-          <ThumbsDownIcon />
-        </button>
+        {!readOnly && (
+          <button
+            className={`${styles.actionIcon} ${liked ? styles.actionIconActive : ''}`}
+            onClick={handleLike}
+            title="Like"
+            aria-label="Like response"
+          >
+            <ThumbsUpIcon />
+          </button>
+        )}
+        {!readOnly && (
+          <button
+            className={`${styles.actionIcon} ${disliked ? styles.actionIconActive : ''}`}
+            onClick={handleDislike}
+            title="Dislike"
+            aria-label="Dislike response"
+          >
+            <ThumbsDownIcon />
+          </button>
+        )}
         <button
           className={`${styles.actionIcon} ${copied ? styles.actionIconCopied : ''}`}
           onClick={handleCopy}
@@ -4262,27 +4267,31 @@ function ResponseActions({
         >
           {copied ? <CheckIcon /> : <CopyIcon />}
         </button>
-        <button
-          className={styles.actionIcon}
-          onClick={handleRetryClick}
-          title="Retry"
-          aria-label="Retry response"
-        >
-          <RefreshIcon />
-        </button>
-        <div className={styles.shareActionWrapper}>
+        {!readOnly && (
           <button
             className={styles.actionIcon}
-            onClick={() => setShowShareDropdown(!showShareDropdown)}
-            title="Share"
-            aria-label="Share response"
+            onClick={handleRetryClick}
+            title="Retry"
+            aria-label="Retry response"
           >
-            <ShareIcon />
+            <RefreshIcon />
           </button>
-          {showShareDropdown && (
-            <ShareDropdown message={message} onClose={() => setShowShareDropdown(false)} />
-          )}
-        </div>
+        )}
+        {!readOnly && (
+          <div className={styles.shareActionWrapper}>
+            <button
+              className={styles.actionIcon}
+              onClick={() => setShowShareDropdown(!showShareDropdown)}
+              title="Share"
+              aria-label="Share response"
+            >
+              <ShareIcon />
+            </button>
+            {showShareDropdown && (
+              <ShareDropdown message={message} onClose={() => setShowShareDropdown(false)} />
+            )}
+          </div>
+        )}
       </div>
 
       {feedbackPanel && (
@@ -5086,14 +5095,16 @@ function UserPrompt({ content, images, onEdit, createdAt, onRetry }) {
       )}
       <div className={styles.userPromptActions}>
         {timeStr && <span className={styles.userPromptTime}>{timeStr}</span>}
-        <button
-          className={styles.userPromptActionBtn}
-          onClick={handleEdit}
-          title="Edit prompt"
-          aria-label="Edit prompt"
-        >
-          <EditIcon />
-        </button>
+        {onEdit && (
+          <button
+            className={styles.userPromptActionBtn}
+            onClick={handleEdit}
+            title="Edit prompt"
+            aria-label="Edit prompt"
+          >
+            <EditIcon />
+          </button>
+        )}
         <button
           className={`${styles.userPromptActionBtn} ${
             copied ? styles.userPromptActionBtnActive : ''
@@ -5104,14 +5115,16 @@ function UserPrompt({ content, images, onEdit, createdAt, onRetry }) {
         >
           {copied ? <CheckIcon /> : <CopyIcon />}
         </button>
-        <button
-          className={styles.userPromptActionBtn}
-          onClick={handleRetry}
-          title="Retry"
-          aria-label="Retry prompt"
-        >
-          <RefreshIcon />
-        </button>
+        {onRetry && (
+          <button
+            className={styles.userPromptActionBtn}
+            onClick={handleRetry}
+            title="Retry"
+            aria-label="Retry prompt"
+          >
+            <RefreshIcon />
+          </button>
+        )}
       </div>
     </div>
   );
@@ -5143,6 +5156,7 @@ function Message({
   webSearchEnabled,
   onOpenSourcesPanel,
   isSourcesPanelOpen,
+  readOnly = false,
 }) {
   const isUser = message.role === 'user';
   const displayText = isStreaming ? streamedText : message.content;
@@ -5170,7 +5184,7 @@ function Message({
 
   // Handle text selection within the assistant message content
   const handleMouseUp = useCallback(() => {
-    if (isUser || isStreaming) return;
+    if (isUser || isStreaming || readOnly) return;
 
     // Small delay to let the selection settle
     if (tooltipTimeoutRef.current) clearTimeout(tooltipTimeoutRef.current);
@@ -5203,7 +5217,7 @@ function Message({
         y: rect.top - containerRect.top - 8,
       });
     }, 10);
-  }, [isUser, isStreaming]);
+  }, [isUser, isStreaming, readOnly]);
 
   // Dismiss tooltip when clicking outside or when selection clears
   useEffect(() => {
@@ -5641,9 +5655,9 @@ function Message({
           <UserPrompt
             content={message.content}
             images={message.images || message.attachments}
-            onEdit={onEditPrompt}
+            onEdit={readOnly ? null : onEditPrompt}
             createdAt={message.createdAt}
-            onRetry={onRetry}
+            onRetry={readOnly ? null : onRetry}
           />
         ) : weatherData ? (
           <div className={styles.markdownContent} ref={markdownContentRef}>
@@ -5738,11 +5752,12 @@ function Message({
           conversationId={currentChatId}
           onOpenSourcesPanel={onOpenSourcesPanel}
           isSourcesPanelOpen={isSourcesPanelOpen}
+          readOnly={readOnly}
         />
       )}
 
       {/* Sub-conversation pills */}
-      {!isUser && !isStreaming && message.content && (
+      {!isUser && !isStreaming && message.content && !readOnly && (
         <SubConversationPills
           subConversations={subConversations}
           onOpen={handleOpenSubConv}
@@ -5893,6 +5908,7 @@ export default function MessageList({
   currentChatId,
   webSearchEnabled,
   onSendMessage,
+  readOnly = false,
 }) {
   const dispatch = useDispatch();
   const effectiveTheme = useSelector(selectEffectiveTheme);
@@ -6136,7 +6152,7 @@ export default function MessageList({
                 hideThinking={isLast && isProcessing && msg.role === 'assistant'}
                 onFollowUpSelect={handleFollowUpSelect}
                 onQuestionsSend={handleQuestionsSend}
-                onRetry={onRetry}
+                onRetry={readOnly ? null : onRetry}
                 onSessionExpired={onSessionExpired}
                 onAlternateModelRequest={onAlternateModelRequest}
                 userPrompt={userPrompt}
@@ -6145,11 +6161,12 @@ export default function MessageList({
                 onSetSubConvPanelOwner={setSubConvPanelOwnerId}
                 currentChatId={currentChatId}
                 assistantIndex={assistantIndices.get(index) ?? -1}
-                onEditPrompt={handleEditPrompt}
+                onEditPrompt={readOnly ? null : handleEditPrompt}
                 onOpenCodePanel={handleOpenCodePanel}
                 webSearchEnabled={webSearchEnabled}
                 onOpenSourcesPanel={handleOpenSourcesPanel}
                 isSourcesPanelOpen={!!sourcesPanelCitations}
+                readOnly={readOnly}
               />
             </div>
           );

--- a/src/components/SettingsView/SettingsView.jsx
+++ b/src/components/SettingsView/SettingsView.jsx
@@ -32,6 +32,8 @@ import {
   DEFAULT_SETTINGS,
 } from '../../services/settings';
 import { createPackCheckoutSession } from '../../services/subscription';
+import { listMyShares, revokeConversationShare } from '../../services/api';
+import { useToast } from '../Toast/Toast';
 import ConfirmPackModal from '../ConfirmPackModal/ConfirmPackModal';
 import { GuestGate } from '../GuestGate';
 import {
@@ -104,6 +106,133 @@ const SHORTCUTS = [
 
 const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.userAgent);
 const modKey = isMac ? '⌘' : 'Ctrl';
+
+/**
+ * Manage the signed-in user's active share links. Mirrors Claude's
+ * Settings > Privacy > Manage: a simple list of shared conversations with a
+ * per-row "View" link (opens the public page) and "Unshare" button.
+ *
+ * Loading / empty / error states are rendered inline. The list is refetched
+ * when the section mounts and after each successful unshare — no global state
+ * needed.
+ */
+function SharedChatsManager() {
+  const { showError, showSuccess } = useToast();
+  const [shares, setShares] = useState(null); // null = loading
+  const [loadError, setLoadError] = useState('');
+  const [revokingToken, setRevokingToken] = useState(null);
+
+  const loadShares = useCallback(async (signal) => {
+    try {
+      const data = await listMyShares();
+      if (signal?.aborted) return;
+      setShares(Array.isArray(data?.shares) ? data.shares : []);
+      setLoadError('');
+    } catch (err) {
+      if (signal?.aborted) return;
+      setShares([]);
+      setLoadError(err?.message || 'Failed to load shared chats');
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    loadShares(controller.signal);
+    return () => controller.abort();
+  }, [loadShares]);
+
+  const handleUnshare = useCallback(
+    async (share) => {
+      if (revokingToken) return;
+      setRevokingToken(share.shareToken);
+      try {
+        await revokeConversationShare(share.conversationId);
+        setShares((prev) => (prev || []).filter((s) => s.shareToken !== share.shareToken));
+        showSuccess('Conversation unshared');
+      } catch (err) {
+        showError(err?.message || 'Failed to unshare conversation');
+      } finally {
+        setRevokingToken(null);
+      }
+    },
+    [revokingToken, showError, showSuccess]
+  );
+
+  const formatDate = (iso) => {
+    try {
+      const d = new Date(iso);
+      if (isNaN(d.getTime())) return '';
+      return d.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return '';
+    }
+  };
+
+  if (shares === null) {
+    return (
+      <div className={styles.sharedChatsLoading}>
+        <div className={styles.sharedChatsSpinner} />
+        <span>Loading shared chats…</span>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return <div className={styles.sharedChatsError}>{loadError}</div>;
+  }
+
+  if (shares.length === 0) {
+    return (
+      <div className={styles.sharedChatsEmpty}>You haven&rsquo;t shared any conversations yet.</div>
+    );
+  }
+
+  return (
+    <ul className={styles.sharedChatsList}>
+      {shares.map((share) => {
+        const url = `${window.location.origin}/share/${share.shareToken}`;
+        const isRevoking = revokingToken === share.shareToken;
+        return (
+          <li key={share.shareToken} className={styles.sharedChatsRow}>
+            <div className={styles.sharedChatsMeta}>
+              <span className={styles.sharedChatsTitle}>
+                {share.title || 'Untitled conversation'}
+              </span>
+              <span className={styles.sharedChatsSub}>
+                Shared {formatDate(share.createdAt)}
+                {typeof share.viewCount === 'number'
+                  ? ` · ${share.viewCount} view${share.viewCount === 1 ? '' : 's'}`
+                  : ''}
+              </span>
+            </div>
+            <div className={styles.sharedChatsActions}>
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.sharedChatsViewLink}
+              >
+                View
+              </a>
+              <button
+                type="button"
+                className={styles.sharedChatsUnshareBtn}
+                onClick={() => handleUnshare(share)}
+                disabled={isRevoking}
+              >
+                {isRevoking ? 'Unsharing…' : 'Unshare'}
+              </button>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
 
 export default function SettingsView() {
   const dispatch = useDispatch();
@@ -1072,9 +1201,7 @@ export default function SettingsView() {
                             <button
                               className={styles.planUpgradeBtn}
                               onClick={() =>
-                                tier === 'free'
-                                  ? navigate('/plans')
-                                  : dispatch(createPortalThunk())
+                                tier === 'free' ? navigate('/plans') : dispatch(createPortalThunk())
                               }
                               disabled={tier !== 'free' && portalLoading}
                             >
@@ -1419,6 +1546,16 @@ export default function SettingsView() {
                         onChange={(v) => updateSetting('enableAnalytics', v)}
                       />
                     </div>
+                  </div>
+
+                  {/* Shared chats */}
+                  <div className={styles.fieldGroup}>
+                    <label className={styles.fieldLabel}>Shared chats</label>
+                    <p className={styles.fieldLabelDesc}>
+                      Links to conversations you&rsquo;ve shared publicly. Unsharing revokes the
+                      link immediately.
+                    </p>
+                    <SharedChatsManager />
                   </div>
 
                   {/* Export data */}

--- a/src/components/SettingsView/SettingsView.module.css
+++ b/src/components/SettingsView/SettingsView.module.css
@@ -1321,3 +1321,139 @@
 .upgradeBtn:hover {
   opacity: 0.85;
 }
+
+/* ── Shared chats manager (Data & privacy section) ── */
+
+.sharedChatsLoading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 0 4px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.sharedChatsSpinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--text-primary);
+  animation: sharedChatsSpin 0.8s linear infinite;
+}
+
+@keyframes sharedChatsSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.sharedChatsError {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background-color: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  font-size: 13px;
+}
+
+.sharedChatsEmpty {
+  margin-top: 8px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px dashed var(--border-color);
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.sharedChatsList {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sharedChatsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background-color: var(--bg-primary);
+}
+
+.sharedChatsMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sharedChatsTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 360px;
+}
+
+.sharedChatsSub {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.sharedChatsActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.sharedChatsViewLink {
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.15s ease;
+}
+
+.sharedChatsViewLink:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.sharedChatsUnshareBtn {
+  padding: 6px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.sharedChatsUnshareBtn:hover:not(:disabled) {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.sharedChatsUnshareBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/components/SharedConversationView/SharedConversationView.jsx
+++ b/src/components/SharedConversationView/SharedConversationView.jsx
@@ -1,0 +1,199 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import MessageList from '../MessageList/MessageList';
+import { fetchSharedConversation } from '../../services/api';
+import { selectEffectiveTheme } from '../../store/slices/themeSlice';
+import { ArrowRightIcon } from '../Icons';
+import styles from './SharedConversationView.module.css';
+
+/**
+ * Public, read-only view of a shared conversation. Rendered OUTSIDE the authed
+ * <App /> shell so unauthenticated visitors don't see the sidebar, the guest
+ * gate, or any of the owner's private data.
+ *
+ * Responsibilities:
+ *  - Fetch the shared conversation snapshot from GET /api/shares/:token.
+ *  - Render messages via the existing MessageList with `readOnly` so no
+ *    feedback / retry / sub-conversation / edit controls appear.
+ *  - Set a noindex meta tag so search engines don't crawl shared pages.
+ *  - Show a clean 404 if the share was revoked or never existed.
+ *
+ * State is intentionally local — no Redux for the share payload — so we don't
+ * pollute the authed chat slice with another user's data.
+ */
+export default function SharedConversationView() {
+  const { token } = useParams();
+  const effectiveTheme = useSelector(selectEffectiveTheme);
+  const [share, setShare] = useState(null);
+  const [status, setStatus] = useState('loading'); // 'loading' | 'ok' | 'not-found' | 'error'
+  const [errorMsg, setErrorMsg] = useState('');
+
+  // Apply the active theme to <html> so CSS vars resolve. We don't mutate
+  // Redux — just echo whatever theme the visitor already has selected.
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', effectiveTheme);
+  }, [effectiveTheme]);
+
+  // Inject a robots noindex meta tag while this page is mounted, then remove
+  // it on unmount so it doesn't leak into other routes. This matches the
+  // X-Robots-Tag header the API also sets.
+  useEffect(() => {
+    const meta = document.createElement('meta');
+    meta.name = 'robots';
+    meta.content = 'noindex, nofollow';
+    document.head.appendChild(meta);
+
+    const prevTitle = document.title;
+    document.title = 'Shared conversation · Araviel';
+
+    return () => {
+      if (meta.parentNode) meta.parentNode.removeChild(meta);
+      document.title = prevTitle;
+    };
+  }, []);
+
+  // Fetch once per token, aborting if the component unmounts mid-request so we
+  // never call setState after unmount.
+  const lastTokenRef = useRef(null);
+  useEffect(() => {
+    if (!token || lastTokenRef.current === token) return;
+    lastTokenRef.current = token;
+
+    const controller = new AbortController();
+    setStatus('loading');
+    setShare(null);
+    setErrorMsg('');
+
+    fetchSharedConversation(token, { signal: controller.signal })
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setShare(data);
+        setStatus('ok');
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        if (err?.name === 'AbortError') return;
+        if (err?.code === 'SHARE_NOT_FOUND') {
+          setStatus('not-found');
+          return;
+        }
+        setStatus('error');
+        setErrorMsg(err?.message || 'Failed to load shared conversation');
+      });
+
+    return () => controller.abort();
+  }, [token]);
+
+  // MessageList expects each assistant message to carry a `provider` key so it
+  // can render the model pill. The public API returns `model: { provider, name }`
+  // — normalise once so MessageList renders without defensive checks.
+  const messages = useMemo(() => {
+    if (!share?.messages) return [];
+    return share.messages.map((m) => ({
+      ...m,
+      createdAt: m.createdAt,
+      provider: m.model?.provider ?? null,
+      modelName: m.model?.name ?? null,
+    }));
+  }, [share]);
+
+  const snapshotDateStr = useMemo(() => {
+    if (!share?.snapshotAt) return null;
+    try {
+      const d = new Date(share.snapshotAt);
+      if (isNaN(d.getTime())) return null;
+      return d.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return null;
+    }
+  }, [share]);
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link to="/" className={styles.brand} aria-label="Araviel home">
+          <span className={styles.brandMark}>A</span>
+          <span className={styles.brandText}>Araviel</span>
+        </Link>
+        <Link to="/" className={styles.ctaLink}>
+          <span>Start your own chat</span>
+          <ArrowRightIcon />
+        </Link>
+      </header>
+
+      <main className={styles.main}>
+        {status === 'loading' && (
+          <div className={styles.centered}>
+            <div className={styles.spinner} />
+          </div>
+        )}
+
+        {status === 'not-found' && (
+          <div className={styles.centered}>
+            <div className={styles.emptyState}>
+              <h1 className={styles.emptyTitle}>Conversation unavailable</h1>
+              <p className={styles.emptyBody}>
+                This shared link is no longer active. The owner may have unshared it, or the link
+                may be invalid.
+              </p>
+              <Link to="/" className={styles.emptyCta}>
+                Go to Araviel
+              </Link>
+            </div>
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div className={styles.centered}>
+            <div className={styles.emptyState}>
+              <h1 className={styles.emptyTitle}>Something went wrong</h1>
+              <p className={styles.emptyBody}>{errorMsg}</p>
+            </div>
+          </div>
+        )}
+
+        {status === 'ok' && share && (
+          <div className={styles.conversation}>
+            <div className={styles.conversationHeader}>
+              <h1 className={styles.conversationTitle}>{share.title || 'Shared conversation'}</h1>
+              {snapshotDateStr && (
+                <p className={styles.conversationMeta}>
+                  Shared via Araviel · Snapshot from {snapshotDateStr}
+                </p>
+              )}
+            </div>
+
+            <div className={styles.messageListWrapper}>
+              <MessageList
+                messages={messages}
+                isProcessing={false}
+                timelineStages={null}
+                timelineFading={false}
+                modelName={null}
+                provider={null}
+                isStreaming={false}
+                streamedText=""
+                onRetry={null}
+                onSessionExpired={() => {}}
+                onAlternateModelRequest={() => {}}
+                onSubConvPanelToggle={() => {}}
+                onCodePanelToggle={() => {}}
+                onSourcesPanelToggle={() => {}}
+                focusInput={() => {}}
+                currentChatId={share.shareToken}
+                webSearchEnabled={false}
+                onSendMessage={() => {}}
+                readOnly
+              />
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/components/SharedConversationView/SharedConversationView.module.css
+++ b/src/components/SharedConversationView/SharedConversationView.module.css
@@ -1,0 +1,193 @@
+/* Public, unauthenticated view of a shared conversation.
+ * Styled from the same CSS variables the authed chat uses so light/dark
+ * theming stays in perfect parity with the rest of the app.
+ */
+
+.page {
+  min-height: 100vh;
+  width: 100%;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border-color);
+  background-color: var(--bg-primary);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: saturate(1.1);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+.brandMark {
+  width: 30px;
+  height: 30px;
+  border-radius: 10px;
+  background-color: var(--text-primary);
+  color: var(--bg-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+
+.brandText {
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+
+.ctaLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.ctaLink:hover {
+  background-color: var(--bg-hover);
+  border-color: var(--text-muted);
+}
+
+.ctaLink svg {
+  width: 14px;
+  height: 14px;
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.centered {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+}
+
+.spinner {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--text-primary);
+  animation: sharedSpin 0.8s linear infinite;
+}
+
+@keyframes sharedSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.emptyState {
+  max-width: 440px;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.emptyTitle {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.emptyBody {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.emptyCta {
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.15s ease;
+}
+
+.emptyCta:hover {
+  background-color: var(--bg-hover);
+}
+
+.conversation {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  width: 100%;
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 32px 24px 80px;
+  box-sizing: border-box;
+}
+
+.conversationHeader {
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.conversationTitle {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 6px;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+
+.conversationMeta {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.messageListWrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}

--- a/src/components/SharedConversationView/index.js
+++ b/src/components/SharedConversationView/index.js
@@ -1,0 +1,1 @@
+export { default } from './SharedConversationView';

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -9,8 +9,14 @@ import ModelsView from './components/ModelsView';
 import SettingsView from './components/SettingsView';
 import PricingView from './components/PricingView/PricingView';
 import SubscriptionView from './components/SubscriptionView/SubscriptionView';
+import SharedConversationView from './components/SharedConversationView';
 
 const router = createBrowserRouter([
+  // Public shared-conversation viewer. Deliberately a sibling of <App />
+  // (not a child) so it does NOT mount the sidebar, auth gate, or any
+  // owner-side chrome. Unauthenticated visitors land straight into the
+  // read-only snapshot.
+  { path: '/share/:token', element: <SharedConversationView /> },
   {
     path: '/',
     element: <App />,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -296,6 +296,108 @@ export async function submitMessageFeedback(conversationId, messageId, feedback,
   return res.json();
 }
 
+// ─── Conversation Sharing ───────────────────────────────────────────────────
+
+/**
+ * Share object returned by the backend.
+ * @typedef {Object} Share
+ * @property {string} shareToken - UUID used in the public URL.
+ * @property {string} conversationId
+ * @property {string} snapshotAt - ISO timestamp; messages up to this are visible.
+ * @property {string} createdAt - ISO timestamp when the share was first created.
+ * @property {string|null} titleSnapshot - Conversation title at share time.
+ * @property {number} viewCount
+ */
+
+/**
+ * Fetch the active share for a conversation (owner-only).
+ * Returns `{ share: null }` if no active share exists.
+ * @param {string} conversationId
+ * @returns {Promise<{ share: Share | null }>}
+ */
+export async function fetchConversationShare(conversationId) {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE}/api/conversations/${conversationId}/share`, { headers });
+  if (!res.ok) throw new Error(`Failed to fetch share: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Create a share link for a conversation. If one already exists, the backend
+ * refreshes the snapshot and returns it (idempotent).
+ * @param {string} conversationId
+ * @returns {Promise<Share>}
+ */
+export async function createConversationShare(conversationId) {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE}/api/conversations/${conversationId}/share`, {
+    method: 'POST',
+    headers,
+  });
+  if (!res.ok) throw new Error(`Failed to create share link: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Refresh the snapshot on an existing share so it includes newer messages.
+ * @param {string} conversationId
+ * @returns {Promise<Share>}
+ */
+export async function updateConversationShare(conversationId) {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE}/api/conversations/${conversationId}/share`, {
+    method: 'PATCH',
+    headers,
+  });
+  if (!res.ok) throw new Error(`Failed to update share link: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Revoke the active share for a conversation.
+ * @param {string} conversationId
+ * @returns {Promise<{ success: boolean }>}
+ */
+export async function revokeConversationShare(conversationId) {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE}/api/conversations/${conversationId}/share`, {
+    method: 'DELETE',
+    headers,
+  });
+  if (!res.ok) throw new Error(`Failed to revoke share link: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * List all active shares belonging to the authenticated user.
+ * @returns {Promise<{ shares: Array<{ shareToken: string, conversationId: string, title: string | null, snapshotAt: string, createdAt: string, viewCount: number }> }>}
+ */
+export async function listMyShares() {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE}/api/shares`, { headers });
+  if (!res.ok) throw new Error(`Failed to list shares: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Fetch a public shared conversation by token. Does NOT send auth headers.
+ * @param {string} shareToken
+ * @param {{ signal?: AbortSignal }} [options]
+ * @returns {Promise<{ shareToken: string, title: string, snapshotAt: string, sharedAt: string, messages: Array }>}
+ */
+export async function fetchSharedConversation(shareToken, options = {}) {
+  const res = await fetch(`${API_BASE}/api/shares/${shareToken}`, {
+    signal: options.signal,
+  });
+  if (res.status === 404) {
+    const err = new Error('Shared conversation not found');
+    err.code = 'SHARE_NOT_FOUND';
+    throw err;
+  }
+  if (!res.ok) throw new Error(`Failed to fetch shared conversation: ${res.status}`);
+  return res.json();
+}
+
 // ─── Sub-Conversation Actions ────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
Wires the real share API into the existing ShareModal and adds a public /share/:token page plus a management surface in Settings:

- ShareModal now creates (or reuses) a backing share row on open, renders the real share URL, and exposes Copy / Update-snapshot / Unshare actions styled from existing CSS variables for full light/ dark parity. No new colors or pill shapes.
- SharedConversationView: public, read-only page mounted outside the authed App shell so there's no sidebar, auth gate, or composer. Reuses MessageList with a new readOnly prop that hides feedback, retry, sub-conversation, edit, and model-switch controls.
- Settings > Data & privacy > Shared chats: lists my active shares with a per-row "View" link and "Unshare" button.
- services/api.js: adds fetchConversationShare, createConversationShare, updateConversationShare, revokeConversationShare, listMyShares, and fetchSharedConversation (unauthenticated, supports AbortSignal).