### PR TITLE
fix(share): unstick viewer loading + explicit share controls

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -112,6 +112,7 @@ import {
   createConversationShare,
   updateConversationShare,
   revokeConversationShare,
+  rotateConversationShare,
 } from '../../services/api';
 import { useToast } from '../Toast/Toast';
 import { selectProjects, addProject } from '../../store/slices/projectsSlice';
@@ -391,21 +392,56 @@ function createStages(status, modelName, isManualSelection, researchProgress) {
 }
 
 /**
+ * Format a past Date as a short relative label ("2 min ago", "yesterday",
+ * "Mar 14"). Falls back to an absolute medium-format date for anything over a
+ * week old so viewers always see a concrete timestamp.
+ */
+function formatRelativeTime(date) {
+  const now = Date.now();
+  const ms = now - date.getTime();
+  if (!Number.isFinite(ms) || ms < 0) {
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+  const sec = Math.round(ms / 1000);
+  if (sec < 45) return 'just now';
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min} min ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr} hr ago`;
+  const day = Math.round(hr / 24);
+  if (day === 1) return 'yesterday';
+  if (day < 7) return `${day} days ago`;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/**
  * Share modal.
  *
- * Creates (or refreshes) a public, unguessable share link for a conversation.
- * On mount we check whether an active share already exists; if not, we create
- * one immediately so the "Copy link" affordance is available without an extra
- * click. The owner can refresh the snapshot to include newer messages or
- * revoke the link entirely.
+ * Renders one of three states, driven by whether an active share exists:
+ *
+ *   empty  — no active share; shows a primary "Create share link" CTA.
+ *   ready  — share exists; shows URL, metadata, and Copy/Update/Rotate/Unshare
+ *            actions. A contextual stale banner appears only when the
+ *            conversation has new messages since the last snapshot.
+ *   loading — initial fetch in-flight; shown briefly so we don't flash an
+ *            incorrect empty state.
+ *
+ * We intentionally do NOT auto-create a share on open: creating a public link
+ * is a deliberate action that should only happen when the user asks for it.
+ * Reopening the modal for a conversation that already has a share will show
+ * the existing link (the backend's partial unique index guarantees at most
+ * one active share per conversation, so there's never ambiguity).
  */
 function ShareModal({ conversationId, conversationTitle, messages, onClose, onSuccess, onError }) {
   const [share, setShare] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [linkCopied, setLinkCopied] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isRevoking, setIsRevoking] = useState(false);
+  const [isRotating, setIsRotating] = useState(false);
+  const [rotateConfirm, setRotateConfirm] = useState(false);
 
   const shareUrl = useMemo(() => {
     if (!share?.shareToken) return null;
@@ -423,22 +459,19 @@ function ShareModal({ conversationId, conversationTitle, messages, onClose, onSu
     });
   }, [share, messages]);
 
-  // Fetch existing share or create one on mount.
+  // Look up the existing share when the modal opens. We do not create one
+  // automatically — creation is an explicit user action below.
   useEffect(() => {
     if (!conversationId) return undefined;
     let cancelled = false;
+    setLoading(true);
+    setError(null);
     (async () => {
       try {
         const { share: existing } = await fetchConversationShare(conversationId);
-        if (cancelled) return;
-        if (existing) {
-          setShare(existing);
-        } else {
-          const created = await createConversationShare(conversationId);
-          if (!cancelled) setShare(created);
-        }
+        if (!cancelled) setShare(existing ?? null);
       } catch (err) {
-        if (!cancelled) setError(err.message || 'Could not create share link');
+        if (!cancelled) setError(err.message || 'Could not check share status');
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -450,11 +483,31 @@ function ShareModal({ conversationId, conversationTitle, messages, onClose, onSu
 
   useEffect(() => {
     const handleKey = (e) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key === 'Escape') {
+        // If the rotate-confirm prompt is open, ESC backs out of that first
+        // rather than closing the whole modal — less surprising.
+        if (rotateConfirm) setRotateConfirm(false);
+        else onClose();
+      }
     };
     document.addEventListener('keydown', handleKey);
     return () => document.removeEventListener('keydown', handleKey);
-  }, [onClose]);
+  }, [onClose, rotateConfirm]);
+
+  const handleCreate = async () => {
+    if (isCreating || !conversationId) return;
+    setIsCreating(true);
+    setError(null);
+    try {
+      const created = await createConversationShare(conversationId);
+      setShare(created);
+      onSuccess?.('Share link created');
+    } catch (err) {
+      setError(err.message || 'Could not create share link');
+    } finally {
+      setIsCreating(false);
+    }
+  };
 
   const handleCopyLink = () => {
     if (!shareUrl) return;
@@ -482,6 +535,33 @@ function ShareModal({ conversationId, conversationTitle, messages, onClose, onSu
     }
   };
 
+  const handleRotate = async () => {
+    if (isRotating || !conversationId) return;
+    setIsRotating(true);
+    setError(null);
+    try {
+      const rotated = await rotateConversationShare(conversationId);
+      setShare(rotated);
+      setLinkCopied(false);
+      setRotateConfirm(false);
+      onSuccess?.('New link generated — the old one no longer works');
+    } catch (err) {
+      // If the DELETE succeeded but the POST failed, the server now has no
+      // active share for this conversation. Clear local state so the UI
+      // returns to the empty-state CTA, from which the user can retry cleanly.
+      try {
+        const { share: current } = await fetchConversationShare(conversationId);
+        setShare(current ?? null);
+      } catch {
+        setShare(null);
+      }
+      setRotateConfirm(false);
+      setError(err.message || 'Could not rotate share link');
+    } finally {
+      setIsRotating(false);
+    }
+  };
+
   const handleRevoke = async () => {
     if (isRevoking || !conversationId) return;
     setIsRevoking(true);
@@ -497,14 +577,11 @@ function ShareModal({ conversationId, conversationTitle, messages, onClose, onSu
   };
 
   const previewTitle = conversationTitle?.trim() || 'Araviel Conversation';
-  const previewUrl = shareUrl ? shareUrl.replace(/^https?:\/\//, '') : 'Generating link…';
+  const previewUrl = shareUrl ? shareUrl.replace(/^https?:\/\//, '') : '';
   const snapshotAt = share?.snapshotAt ? new Date(share.snapshotAt) : null;
-  const snapshotLabel = snapshotAt
-    ? `Snapshot taken ${snapshotAt.toLocaleString(undefined, {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-      })}`
-    : null;
+  const snapshotRelative = snapshotAt ? formatRelativeTime(snapshotAt) : null;
+  const viewCount = share?.viewCount ?? 0;
+  const busy = isCreating || isUpdating || isRevoking || isRotating;
 
   return (
     <div className={styles.shareOverlay} onClick={onClose}>
@@ -523,15 +600,48 @@ function ShareModal({ conversationId, conversationTitle, messages, onClose, onSu
         </div>
 
         <p className={styles.shareModalDesc}>
-          Create a public link to share this conversation. Anyone with the link can view a read-only
-          snapshot — new messages won't be visible unless you update it.
+          {share
+            ? 'Anyone with this link can view a read-only snapshot of this conversation. Update it to include new messages, or unshare to revoke access.'
+            : 'Create a public link to share this conversation. Anyone with the link will see a read-only snapshot — no account needed.'}
         </p>
 
         {loading ? (
           <div className={styles.shareLoadingRow}>
             <span className={styles.shareSpinner} aria-hidden="true" />
-            <span>Preparing share link…</span>
+            <span>Checking share status…</span>
           </div>
+        ) : !share ? (
+          <>
+            {error && (
+              <div className={styles.shareError} role="alert">
+                {error}
+              </div>
+            )}
+            <div className={styles.shareEmptyState}>
+              <div className={styles.shareEmptyIcon} aria-hidden="true">
+                <LinkIcon />
+              </div>
+              <p className={styles.shareEmptyText}>This conversation isn't shared yet.</p>
+              <button
+                type="button"
+                className={`${styles.shareActionBtn} ${styles.sharePrimaryBtn}`}
+                onClick={handleCreate}
+                disabled={isCreating}
+              >
+                {isCreating ? (
+                  <>
+                    <span className={styles.shareSpinner} aria-hidden="true" />
+                    <span>Creating link…</span>
+                  </>
+                ) : (
+                  <>
+                    <LinkIcon />
+                    <span>Create share link</span>
+                  </>
+                )}
+              </button>
+            </div>
+          </>
         ) : (
           <>
             {error && (
@@ -551,75 +661,138 @@ function ShareModal({ conversationId, conversationTitle, messages, onClose, onSu
                 <span className={styles.sharePreviewUrl} title={shareUrl ?? ''}>
                   {previewUrl}
                 </span>
-                {snapshotLabel && <span className={styles.shareSnapshotMeta}>{snapshotLabel}</span>}
+                <span className={styles.shareSnapshotMeta}>
+                  {snapshotRelative ? `Snapshot ${snapshotRelative}` : 'Snapshot ready'}
+                  {viewCount > 0 && (
+                    <>
+                      <span className={styles.shareMetaDot} aria-hidden="true">
+                        ·
+                      </span>
+                      {viewCount === 1 ? '1 view' : `${viewCount.toLocaleString()} views`}
+                    </>
+                  )}
+                </span>
               </div>
             </div>
 
-            <div className={styles.shareModalActions}>
-              <button
-                type="button"
-                className={`${styles.shareActionBtn} ${styles.shareDangerBtn}`}
-                onClick={handleRevoke}
-                disabled={!share || isRevoking}
-              >
-                {isRevoking ? (
-                  <>
-                    <span className={styles.shareSpinner} aria-hidden="true" />
-                    <span>Revoking…</span>
-                  </>
-                ) : (
-                  <>
-                    <TrashIcon />
-                    <span>Unshare</span>
-                  </>
-                )}
-              </button>
-
-              <div className={styles.shareModalActionsGroup}>
-                {hasNewMessagesSinceShare && (
-                  <button
-                    type="button"
-                    className={`${styles.shareActionBtn} ${styles.shareSecondaryBtn}`}
-                    onClick={handleUpdate}
-                    disabled={isUpdating}
-                    title="Include messages sent since this link was created"
-                  >
-                    {isUpdating ? (
-                      <>
-                        <span className={styles.shareSpinner} aria-hidden="true" />
-                        <span>Updating…</span>
-                      </>
-                    ) : (
-                      <>
-                        <RefreshIcon />
-                        <span>Update</span>
-                      </>
-                    )}
-                  </button>
-                )}
-
+            {hasNewMessagesSinceShare && !rotateConfirm && (
+              <div className={styles.shareStaleBanner} role="status">
+                <div className={styles.shareStaleText}>
+                  <strong>New messages since this snapshot.</strong>
+                  <span>Update the link to include them, or leave it as-is.</span>
+                </div>
                 <button
                   type="button"
-                  className={`${styles.shareActionBtn} ${styles.shareCopyBtn} ${
-                    linkCopied ? styles.copied : ''
-                  }`}
-                  onClick={handleCopyLink}
-                  disabled={!shareUrl}
+                  className={`${styles.shareActionBtn} ${styles.shareSecondaryBtn} ${styles.shareStaleAction}`}
+                  onClick={handleUpdate}
+                  disabled={busy}
                 >
-                  {linkCopied ? (
+                  {isUpdating ? (
                     <>
-                      <CheckIcon />
-                      <span>Link copied</span>
+                      <span className={styles.shareSpinner} aria-hidden="true" />
+                      <span>Updating…</span>
                     </>
                   ) : (
                     <>
-                      <LinkIcon />
-                      <span>Copy link</span>
+                      <RefreshIcon />
+                      <span>Update snapshot</span>
                     </>
                   )}
                 </button>
               </div>
-            </div>
+            )}
+
+            {rotateConfirm ? (
+              <div className={styles.shareRotateConfirm} role="alertdialog">
+                <div className={styles.shareRotateText}>
+                  <strong>Generate a new link?</strong>
+                  <span>The current link will stop working for everyone who has it.</span>
+                </div>
+                <div className={styles.shareModalActionsGroup}>
+                  <button
+                    type="button"
+                    className={`${styles.shareActionBtn} ${styles.shareSecondaryBtn}`}
+                    onClick={() => setRotateConfirm(false)}
+                    disabled={isRotating}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className={`${styles.shareActionBtn} ${styles.shareDangerBtn}`}
+                    onClick={handleRotate}
+                    disabled={isRotating}
+                  >
+                    {isRotating ? (
+                      <>
+                        <span className={styles.shareSpinner} aria-hidden="true" />
+                        <span>Rotating…</span>
+                      </>
+                    ) : (
+                      <>
+                        <RefreshIcon />
+                        <span>Rotate link</span>
+                      </>
+                    )}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className={styles.shareModalActions}>
+                <button
+                  type="button"
+                  className={`${styles.shareActionBtn} ${styles.shareDangerBtn}`}
+                  onClick={handleRevoke}
+                  disabled={busy}
+                >
+                  {isRevoking ? (
+                    <>
+                      <span className={styles.shareSpinner} aria-hidden="true" />
+                      <span>Unsharing…</span>
+                    </>
+                  ) : (
+                    <>
+                      <TrashIcon />
+                      <span>Unshare</span>
+                    </>
+                  )}
+                </button>
+
+                <div className={styles.shareModalActionsGroup}>
+                  <button
+                    type="button"
+                    className={`${styles.shareActionBtn} ${styles.shareSecondaryBtn}`}
+                    onClick={() => setRotateConfirm(true)}
+                    disabled={busy}
+                    title="Invalidate the current link and generate a new one"
+                  >
+                    <RefreshIcon />
+                    <span>Rotate link</span>
+                  </button>
+
+                  <button
+                    type="button"
+                    className={`${styles.shareActionBtn} ${styles.shareCopyBtn} ${
+                      linkCopied ? styles.copied : ''
+                    }`}
+                    onClick={handleCopyLink}
+                    disabled={!shareUrl || busy}
+                  >
+                    {linkCopied ? (
+                      <>
+                        <CheckIcon />
+                        <span>Link copied</span>
+                      </>
+                    ) : (
+                      <>
+                        <LinkIcon />
+                        <span>Copy link</span>
+                      </>
+                    )}
+                  </button>
+                </div>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -1120,6 +1120,133 @@
   margin-top: 2px;
 }
 
+.shareMetaDot {
+  margin: 0 6px;
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
+/* Empty state — shown when the conversation has no active share yet. */
+.shareEmptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 28px 16px 8px;
+  text-align: center;
+}
+
+.shareEmptyIcon {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, var(--bg-hover), var(--bg-active));
+  border-radius: 12px;
+  color: var(--text-secondary);
+}
+
+.shareEmptyIcon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.shareEmptyText {
+  font-size: 13.5px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.sharePrimaryBtn {
+  background-color: var(--bg-icon-button);
+  color: var(--text-icon-button);
+  padding: 10px 22px;
+}
+
+.sharePrimaryBtn:hover:not(:disabled) {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.sharePrimaryBtn svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Contextual banner that surfaces when the conversation has new messages
+   since the last snapshot. Offers an inline "Update snapshot" action. */
+.shareStaleBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+}
+
+.shareStaleText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.shareStaleText strong {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.shareStaleText span {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.shareStaleAction {
+  padding: 8px 14px;
+  flex-shrink: 0;
+}
+
+/* Inline confirmation prompt for rotating the share link. Replaces the
+   default action row while active to keep decision load localised. */
+.shareRotateConfirm {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+}
+
+.shareRotateText {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.shareRotateText strong {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.shareRotateText span {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.shareRotateConfirm .shareModalActionsGroup {
+  justify-content: flex-end;
+}
+
 .container {
   width: 100%;
   max-width: 640px;

--- a/src/components/SharedConversationView/SharedConversationView.jsx
+++ b/src/components/SharedConversationView/SharedConversationView.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import MessageList from '../MessageList/MessageList';
@@ -53,12 +53,14 @@ export default function SharedConversationView() {
     };
   }, []);
 
-  // Fetch once per token, aborting if the component unmounts mid-request so we
-  // never call setState after unmount.
-  const lastTokenRef = useRef(null);
+  // Fetch the snapshot whenever the token changes. The AbortController alone
+  // correctly handles React 18 StrictMode's synthetic double-invoke: the first
+  // effect's cleanup aborts the in-flight request, and the second invocation
+  // starts a fresh one that actually resolves. No token-equality guard — that
+  // caused the second invocation to early-return and leave the UI stuck on the
+  // loading spinner forever.
   useEffect(() => {
-    if (!token || lastTokenRef.current === token) return;
-    lastTokenRef.current = token;
+    if (!token) return undefined;
 
     const controller = new AbortController();
     setStatus('loading');

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -369,6 +369,23 @@ export async function revokeConversationShare(conversationId) {
 }
 
 /**
+ * Rotate the share link: revoke the current token and issue a new one. This
+ * invalidates the previous URL (anyone who had it will now see a 404) and
+ * returns a fresh share with a new token + current snapshot.
+ *
+ * The partial unique index on `shared_conversations` guarantees that after
+ * DELETE there can be no active row, so the subsequent POST always inserts
+ * cleanly. If the POST fails after the DELETE succeeds, the caller will see
+ * the "no active share" state and can retry with a plain create.
+ * @param {string} conversationId
+ * @returns {Promise<Share>}
+ */
+export async function rotateConversationShare(conversationId) {
+  await revokeConversationShare(conversationId);
+  return createConversationShare(conversationId);
+}
+
+/**
  * List all active shares belonging to the authenticated user.
  * @returns {Promise<{ shares: Array<{ shareToken: string, conversationId: string, title: string | null, snapshotAt: string, createdAt: string, viewCount: number }> }>}
  */


### PR DESCRIPTION
The public viewer was stuck on its loading spinner because a ref-based token guard combined with React 18 StrictMode's double-invoke aborted the first fetch and then early-returned on the second. Drop the guard — AbortController alone already handles StrictMode correctly.

Rework the owner-side ShareModal so creating a public link is always a deliberate action:

  * Empty state with a "Create share link" CTA (no more auto-creation on open — surprising and irreversible).
  * When a share exists: URL, relative snapshot time, and view count.
  * Contextual stale banner with inline "Update snapshot" only when new messages exist since the snapshot.
  * Explicit "Rotate link" action with inline confirmation. On half-rotated failure we refetch so the UI self-heals.
  * Unshare, Copy link, and Update remain one click each.

All styling reuses existing CSS variables for light/dark parity.