### PR TITLE
feat(web): dedicated /search page with URL-synced filters

### DIFF
--- a/src/components/SearchModal/useSearch.js
+++ b/src/components/SearchModal/useSearch.js
@@ -1,0 +1,364 @@
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import {
+  selectConversations,
+  selectConversationsTotal,
+  setCurrentChat,
+  setMessages,
+} from '../../store/slices/chatSlice';
+import { selectProjects } from '../../store/slices/projectsSlice';
+import { searchConversations, searchProjects, searchImages } from '../../services/api';
+import { getGeneratedImages } from '../../services/imageGeneration';
+
+export const TYPE_FILTERS = [
+  { key: 'all', label: 'All' },
+  { key: 'conversations', label: 'Conversations' },
+  { key: 'projects', label: 'Projects' },
+  { key: 'images', label: 'Images' },
+];
+
+export const DATE_FILTERS = [
+  { key: 'all', label: 'All time' },
+  { key: 'today', label: 'Today' },
+  { key: '7days', label: 'Last 7 days' },
+  { key: '30days', label: 'Last 30 days' },
+];
+
+export function getDateThreshold(key) {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  switch (key) {
+    case 'today':
+      return start;
+    case '7days':
+      start.setDate(start.getDate() - 7);
+      return start;
+    case '30days':
+      start.setDate(start.getDate() - 30);
+      return start;
+    default:
+      return null;
+  }
+}
+
+export function formatRelativeDate(dateStr) {
+  if (!dateStr) return '';
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 365) return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Shared search controller for both SearchModal (popup) and SearchView (page).
+ * Owns all state, debounced API calls, filtering, and keyboard navigation so
+ * the two surfaces can never drift out of sync.
+ *
+ * @param {object} [options]
+ * @param {() => void} [options.onAfterNavigate] - Called after a result is
+ *   chosen (modal uses this to close itself; page leaves undefined).
+ * @param {boolean} [options.enableEscape] - When true, Escape triggers
+ *   onAfterNavigate (modal dismiss). Pages pass false.
+ * @param {{query?: string, typeFilter?: string, dateFilter?: string}} [options.initialState]
+ *   Seed values for the URL-synced page surface. Only read on first render.
+ */
+export function useSearch({ onAfterNavigate, enableEscape = false, initialState } = {}) {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const conversations = useSelector(selectConversations);
+  const conversationsTotal = useSelector(selectConversationsTotal);
+  const projects = useSelector(selectProjects);
+
+  const [query, setQuery] = useState(initialState?.query ?? '');
+  const [typeFilter, setTypeFilter] = useState(initialState?.typeFilter ?? 'all');
+  const [dateFilter, setDateFilter] = useState(initialState?.dateFilter ?? 'all');
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [apiConversations, setApiConversations] = useState(null);
+  const [apiProjects, setApiProjects] = useState(null);
+  const [apiLoading, setApiLoading] = useState(false);
+  const [images, setImages] = useState(() => getGeneratedImages() || []);
+  const [apiImages, setApiImages] = useState(null);
+
+  const resultsRef = useRef(null);
+  const debounceRef = useRef(null);
+
+  // Keep local image cache in sync if it's populated later.
+  useEffect(() => {
+    if (images.length === 0) {
+      const cached = getGeneratedImages();
+      if (cached && cached.length > 0) setImages(cached);
+    }
+    // Only run once on mount — further updates come through apiImages.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Build project name lookup map
+  const projectMap = useMemo(() => {
+    const map = {};
+    (projects || []).forEach((p) => {
+      map[p.id] = p.name;
+    });
+    return map;
+  }, [projects]);
+
+  // Determine if we need API search
+  const needsApiSearch = conversations.length < conversationsTotal;
+
+  // Debounced API search
+  useEffect(() => {
+    if (!query.trim() || query.trim().length < 2) {
+      setApiConversations(null);
+      setApiProjects(null);
+      setApiImages(null);
+      setApiLoading(false);
+      return;
+    }
+
+    setApiLoading(true);
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const promises = [];
+        // Always search images via API (they aren't fully cached client-side)
+        promises.push(searchImages(query.trim(), 12));
+
+        if (needsApiSearch) {
+          promises.push(searchConversations(query.trim()));
+          promises.push(searchProjects(query.trim()));
+        } else {
+          promises.push(Promise.resolve(null));
+          promises.push(Promise.resolve(null));
+        }
+
+        const [imgResult, convResult, projResult] = await Promise.all(promises);
+        setApiImages(imgResult?.images || []);
+        if (convResult) setApiConversations(convResult.conversations || []);
+        if (projResult) setApiProjects(projResult.projects || []);
+      } catch {
+        // Silent fail — client-side results still available
+      } finally {
+        setApiLoading(false);
+      }
+    }, 200);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, needsApiSearch]);
+
+  // Filter conversations
+  const filteredConversations = useMemo(() => {
+    if (typeFilter === 'projects' || typeFilter === 'images') return [];
+
+    const q = query.toLowerCase().trim();
+    const dateThreshold = getDateThreshold(dateFilter);
+
+    let source = conversations || [];
+
+    if (apiConversations) {
+      const existingIds = new Set(source.map((c) => c.id));
+      const newFromApi = apiConversations.filter((c) => !existingIds.has(c.id));
+      source = [...source, ...newFromApi];
+    }
+
+    return source.filter((conv) => {
+      if (q && !conv.title?.toLowerCase().includes(q)) return false;
+      if (dateThreshold) {
+        const updated = new Date(conv.updatedAt || conv.updated_at);
+        if (updated < dateThreshold) return false;
+      }
+      return true;
+    });
+  }, [conversations, apiConversations, query, typeFilter, dateFilter]);
+
+  // Filter projects
+  const filteredProjects = useMemo(() => {
+    if (typeFilter === 'conversations' || typeFilter === 'images') return [];
+
+    const q = query.toLowerCase().trim();
+    const dateThreshold = getDateThreshold(dateFilter);
+
+    let source = projects || [];
+
+    if (apiProjects) {
+      const existingIds = new Set(source.map((p) => p.id));
+      const newFromApi = apiProjects.filter((p) => !existingIds.has(p.id));
+      source = [...source, ...newFromApi];
+    }
+
+    return source.filter((proj) => {
+      if (q && !proj.name?.toLowerCase().includes(q)) return false;
+      if (dateThreshold) {
+        const updated = new Date(proj.updated_at);
+        if (updated < dateThreshold) return false;
+      }
+      return true;
+    });
+  }, [projects, apiProjects, query, typeFilter, dateFilter]);
+
+  // Filter images
+  const filteredImages = useMemo(() => {
+    if (typeFilter === 'conversations' || typeFilter === 'projects') return [];
+
+    const q = query.toLowerCase().trim();
+    const dateThreshold = getDateThreshold(dateFilter);
+
+    // Use API results if searching, otherwise use local cache
+    let source = q && apiImages ? apiImages : images;
+
+    // For client-side filtering when not using API
+    if (!q || !apiImages) {
+      source = (images || []).filter((img) => {
+        if (q && !img.prompt?.toLowerCase().includes(q)) return false;
+        if (dateThreshold) {
+          const created = new Date(img.createdAt || img.created_at);
+          if (created < dateThreshold) return false;
+        }
+        return true;
+      });
+    } else if (dateThreshold) {
+      source = source.filter((img) => {
+        const created = new Date(img.createdAt || img.created_at);
+        return created >= dateThreshold;
+      });
+    }
+
+    return source;
+  }, [images, apiImages, query, typeFilter, dateFilter]);
+
+  // Build flat result list for keyboard navigation (conversations + projects only, not images)
+  const allResults = useMemo(() => {
+    const items = [];
+    filteredConversations.forEach((conv) => {
+      items.push({ type: 'conversation', data: conv });
+    });
+    filteredProjects.forEach((proj) => {
+      items.push({ type: 'project', data: proj });
+    });
+    return items;
+  }, [filteredConversations, filteredProjects]);
+
+  // Reset active index when results change
+  useEffect(() => {
+    setActiveIndex(allResults.length > 0 ? 0 : -1);
+  }, [allResults.length]);
+
+  // Navigate to result
+  const navigateToResult = useCallback(
+    (item) => {
+      if (!item) return;
+      if (item.type === 'conversation') {
+        dispatch(setCurrentChat(item.data.id));
+        dispatch(setMessages([]));
+        navigate(`/conversations/${item.data.id}`);
+      } else if (item.type === 'project') {
+        navigate('/projects');
+      } else if (item.type === 'image') {
+        navigate('/images');
+      }
+      onAfterNavigate?.();
+    },
+    [dispatch, navigate, onAfterNavigate]
+  );
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setActiveIndex((prev) => {
+            const next = prev + 1;
+            return next >= allResults.length ? 0 : next;
+          });
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setActiveIndex((prev) => {
+            const next = prev - 1;
+            return next < 0 ? allResults.length - 1 : next;
+          });
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (activeIndex >= 0 && activeIndex < allResults.length) {
+            navigateToResult(allResults[activeIndex]);
+          }
+          break;
+        case 'Escape':
+          if (enableEscape) {
+            e.preventDefault();
+            onAfterNavigate?.();
+          }
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [activeIndex, allResults, navigateToResult, onAfterNavigate, enableEscape]);
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (activeIndex < 0 || !resultsRef.current) return;
+    const activeEl = resultsRef.current.querySelector(`[data-index="${activeIndex}"]`);
+    if (activeEl) {
+      activeEl.scrollIntoView({ block: 'nearest' });
+    }
+  }, [activeIndex]);
+
+  const hasQuery = query.trim().length > 0;
+  const hasAnyResults =
+    filteredConversations.length > 0 || filteredProjects.length > 0 || filteredImages.length > 0;
+  const noResults = hasQuery && !hasAnyResults && !apiLoading;
+
+  const showImages =
+    filteredImages.length > 0 && typeFilter !== 'conversations' && typeFilter !== 'projects';
+  const showConversations = filteredConversations.length > 0;
+  const showProjects = filteredProjects.length > 0;
+
+  return {
+    // state
+    query,
+    setQuery,
+    typeFilter,
+    setTypeFilter,
+    dateFilter,
+    setDateFilter,
+    activeIndex,
+    setActiveIndex,
+    // derived data
+    projectMap,
+    filteredConversations,
+    filteredProjects,
+    filteredImages,
+    // flags
+    apiLoading,
+    hasQuery,
+    hasAnyResults,
+    noResults,
+    showImages,
+    showConversations,
+    showProjects,
+    // navigation
+    navigateToResult,
+    // refs
+    resultsRef,
+  };
+}

--- a/src/components/SearchView/SearchView.jsx
+++ b/src/components/SearchView/SearchView.jsx
@@ -1,18 +1,35 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { SearchIcon, ChatIcon, ProjectsIcon, StarIcon, CalendarIcon, PhotoIcon } from '../Icons';
 import {
-  SearchIcon,
-  ChatIcon,
-  ProjectsIcon,
-  StarIcon,
-  CalendarIcon,
-  CloseIcon,
-  PhotoIcon,
-} from '../Icons';
-import { useSearch, TYPE_FILTERS, DATE_FILTERS, formatRelativeDate } from './useSearch';
-import styles from './SearchModal.module.css';
+  useSearch,
+  TYPE_FILTERS,
+  DATE_FILTERS,
+  formatRelativeDate,
+} from '../SearchModal/useSearch';
+import styles from './SearchView.module.css';
 
-export default function SearchModal({ onClose }) {
+const VALID_TYPES = new Set(TYPE_FILTERS.map((f) => f.key));
+const VALID_DATES = new Set(DATE_FILTERS.map((f) => f.key));
+
+function readInitialState(params) {
+  const rawType = params.get('type');
+  const rawDate = params.get('date');
+  return {
+    query: params.get('q') || '',
+    typeFilter: rawType && VALID_TYPES.has(rawType) ? rawType : 'all',
+    dateFilter: rawDate && VALID_DATES.has(rawDate) ? rawDate : 'all',
+  };
+}
+
+export default function SearchView() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const inputRef = useRef(null);
+
+  // Read URL params once on first render; URL is the source of truth for
+  // initial values but we then own the state locally to avoid re-render loops.
+  const [initialState] = useState(() => readInitialState(searchParams));
+
   const {
     query,
     setQuery,
@@ -35,16 +52,58 @@ export default function SearchModal({ onClose }) {
     showProjects,
     navigateToResult,
     resultsRef,
-  } = useSearch({ onAfterNavigate: onClose, enableEscape: true });
+  } = useSearch({ initialState, enableEscape: false });
 
-  // Index offset for combining sections in keyboard navigation
+  // Autofocus input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Sync state → URL. `replace: true` so Back goes to the previous page
+  // rather than walking through every keystroke. Omit default values to
+  // keep the URL clean.
+  const syncingFromParams = useRef(false);
+  useEffect(() => {
+    if (syncingFromParams.current) {
+      syncingFromParams.current = false;
+      return;
+    }
+    const next = new URLSearchParams();
+    const q = query.trim();
+    if (q) next.set('q', q);
+    if (typeFilter !== 'all') next.set('type', typeFilter);
+    if (dateFilter !== 'all') next.set('date', dateFilter);
+    // Only write if different to avoid triggering a no-op navigation.
+    if (next.toString() !== searchParams.toString()) {
+      setSearchParams(next, { replace: true });
+    }
+  }, [query, typeFilter, dateFilter, searchParams, setSearchParams]);
+
+  // Sync URL → state (Back/Forward navigation)
+  useEffect(() => {
+    const next = readInitialState(searchParams);
+    if (next.query !== query || next.typeFilter !== typeFilter || next.dateFilter !== dateFilter) {
+      syncingFromParams.current = true;
+      setQuery(next.query);
+      setTypeFilter(next.typeFilter);
+      setDateFilter(next.dateFilter);
+    }
+    // We only want this to run when the URL changes externally, not when
+    // local state drives a URL write. The guard ref handles that.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
   let currentIndex = 0;
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        {/* Search Header */}
-        <div className={styles.searchHeader}>
+    <div className={styles.page}>
+      <div className={styles.inner}>
+        <div className={styles.header}>
+          <h1 className={styles.title}>Search</h1>
+        </div>
+
+        {/* Search input */}
+        <div className={styles.searchBox}>
           <SearchIcon />
           <input
             ref={inputRef}
@@ -52,17 +111,13 @@ export default function SearchModal({ onClose }) {
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search everything..."
-            autoFocus
+            placeholder="Search conversations, projects, and images…"
             autoComplete="off"
             spellCheck="false"
           />
-          <button className={styles.closeBtn} onClick={onClose} aria-label="Close search">
-            <CloseIcon />
-          </button>
         </div>
 
-        {/* Navigation hints + filter bar */}
+        {/* Toolbar: keyboard hints + date filter */}
         <div className={styles.toolbar}>
           <div className={styles.navHints}>
             <span className={styles.navHint}>
@@ -72,22 +127,19 @@ export default function SearchModal({ onClose }) {
               Open <kbd>&crarr;</kbd>
             </span>
           </div>
-          <div className={styles.toolbarRight}>
-            <div className={styles.dateFilterWrap}>
-              <CalendarIcon />
-              <select
-                className={styles.dateSelect}
-                value={dateFilter}
-                onChange={(e) => setDateFilter(e.target.value)}
-              >
-                {DATE_FILTERS.map((f) => (
-                  <option key={f.key} value={f.key}>
-                    {f.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <kbd className={styles.escKbd}>ESC</kbd>
+          <div className={styles.dateFilterWrap}>
+            <CalendarIcon />
+            <select
+              className={styles.dateSelect}
+              value={dateFilter}
+              onChange={(e) => setDateFilter(e.target.value)}
+            >
+              {DATE_FILTERS.map((f) => (
+                <option key={f.key} value={f.key}>
+                  {f.label}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
 
@@ -116,9 +168,20 @@ export default function SearchModal({ onClose }) {
           ))}
         </div>
 
-        {/* Results area — fixed height, scrollable */}
+        {/* Results */}
         <div className={styles.results} ref={resultsRef}>
-          {/* No results — only when user has typed something */}
+          {!hasQuery && !hasAnyResults && (
+            <div className={styles.emptyState}>
+              <div className={styles.emptyIcon}>
+                <SearchIcon />
+              </div>
+              <span className={styles.emptyTitle}>Start typing to search</span>
+              <span className={styles.emptyHint}>
+                Search across conversations, projects, and generated images
+              </span>
+            </div>
+          )}
+
           {noResults && (
             <div className={styles.emptyState}>
               <div className={styles.emptyIcon}>
@@ -129,7 +192,6 @@ export default function SearchModal({ onClose }) {
             </div>
           )}
 
-          {/* Loading */}
           {apiLoading && hasQuery && !hasAnyResults && (
             <div className={styles.loadingDot}>
               <span />
@@ -138,7 +200,6 @@ export default function SearchModal({ onClose }) {
             </div>
           )}
 
-          {/* Images carousel section */}
           {showImages && (
             <div className={styles.section}>
               <div className={styles.sectionHeader}>
@@ -168,7 +229,6 @@ export default function SearchModal({ onClose }) {
             </div>
           )}
 
-          {/* Conversation results */}
           {showConversations && (
             <div className={styles.section}>
               <div className={styles.sectionHeader}>
@@ -209,7 +269,6 @@ export default function SearchModal({ onClose }) {
             </div>
           )}
 
-          {/* Project results */}
           {showProjects && (
             <div className={styles.section}>
               <div className={styles.sectionHeader}>

--- a/src/components/SearchView/SearchView.module.css
+++ b/src/components/SearchView/SearchView.module.css
@@ -1,0 +1,569 @@
+/* ═══════════════════════════════════════════════════════════════
+   SearchView — dedicated /search page.
+   Chrome mirrors ConversationsView; chips and results mirror
+   SearchModal. No new colors, no pill shapes.
+   ═══════════════════════════════════════════════════════════════ */
+
+.page {
+  flex: 1;
+  height: 100%;
+  overflow-y: auto;
+  background-color: var(--bg-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.inner {
+  width: 100%;
+  max-width: 720px;
+  padding: 48px 28px 120px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Header ── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.title {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.03em;
+}
+
+/* ── Search input ── */
+.searchBox {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.searchBox:focus-within {
+  border-color: var(--text-muted);
+  background-color: var(--bg-primary);
+}
+
+.searchBox > svg {
+  width: 18px;
+  height: 18px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.searchInput {
+  flex: 1;
+  font-size: 15px;
+  font-weight: 400;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  outline: none;
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+
+.searchInput::placeholder {
+  color: var(--text-muted);
+}
+
+/* ── Toolbar ── */
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 14px;
+}
+
+.navHints {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.navHint {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.navHint kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--text-muted);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  line-height: 1;
+}
+
+.dateFilterWrap {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  transition: border-color 0.12s ease;
+}
+
+.dateFilterWrap:hover {
+  border-color: var(--text-muted);
+}
+
+.dateFilterWrap svg {
+  width: 12px;
+  height: 12px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.dateSelect {
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 1px 2px 1px 0;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  outline: none;
+  cursor: pointer;
+}
+
+/* ── Filter chips ── */
+.filterBar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 14px;
+  overflow-x: auto;
+}
+
+.filterBar::-webkit-scrollbar {
+  display: none;
+}
+
+.chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
+  font-family: inherit;
+}
+
+.chip svg {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+}
+
+.chip:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.chipActive {
+  background-color: var(--bg-active);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.chipActive:hover {
+  background-color: var(--bg-active);
+}
+
+.chipCount {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--bg-primary);
+  padding: 0 5px;
+  border-radius: 10px;
+  line-height: 1.6;
+  min-width: 16px;
+  text-align: center;
+}
+
+/* ── Results ── */
+.results {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Section ── */
+.section {
+  padding: 4px 0;
+}
+
+.section + .section {
+  border-top: 1px solid var(--border-color);
+  margin-top: 8px;
+  padding-top: 12px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 4px 8px;
+}
+
+.sectionLabel {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.sectionCount {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--bg-hover);
+  padding: 1px 6px;
+  border-radius: 10px;
+  line-height: 1.5;
+}
+
+/* ── Image carousel ── */
+.imageCarousel {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  padding: 4px 2px 8px;
+  scroll-behavior: smooth;
+  scroll-snap-type: x mandatory;
+}
+
+.imageCarousel::-webkit-scrollbar {
+  height: 4px;
+}
+
+.imageCarousel::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.imageCarousel::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 2px;
+}
+
+.imageCard {
+  flex-shrink: 0;
+  width: 168px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
+  scroll-snap-align: start;
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+}
+
+.imageCard:hover {
+  border-color: var(--text-muted);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+}
+
+[data-theme='dark'] .imageCard:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.imageThumb {
+  width: 100%;
+  height: 112px;
+  overflow: hidden;
+  background: var(--bg-hover);
+}
+
+.imageThumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.2s ease;
+}
+
+.imageCard:hover .imageThumb img {
+  transform: scale(1.03);
+}
+
+.imageInfo {
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.imagePrompt {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.imageMeta {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+/* ── Result item ── */
+.resultItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  text-align: left;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.1s ease, color 0.1s ease;
+  font-family: inherit;
+}
+
+.resultItem:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.resultItemActive {
+  background-color: var(--bg-active);
+  color: var(--text-primary);
+}
+
+.resultIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: var(--bg-hover);
+  flex-shrink: 0;
+  color: var(--text-muted);
+  transition: background-color 0.1s ease, color 0.1s ease;
+}
+
+.resultIcon svg {
+  width: 15px;
+  height: 15px;
+}
+
+.resultItemActive .resultIcon,
+.resultItem:hover .resultIcon {
+  background: var(--bg-active);
+  color: var(--text-primary);
+}
+
+.resultInfo {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.resultTitle {
+  font-size: 13px;
+  font-weight: 500;
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resultMeta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.resultDesc {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.projectBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 500;
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.starIndicator {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--text-muted);
+}
+
+.starIndicator svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* ── Loading ── */
+.loadingDot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px;
+  gap: 5px;
+}
+
+.loadingDot span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  animation: dotPulse 1.2s ease-in-out infinite;
+}
+
+.loadingDot span:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.loadingDot span:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes dotPulse {
+  0%,
+  80%,
+  100% {
+    opacity: 0.25;
+    transform: scale(0.85);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* ── Empty state ── */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 20px;
+  gap: 10px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.emptyIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: var(--bg-hover);
+  margin-bottom: 4px;
+}
+
+.emptyIcon svg {
+  width: 22px;
+  height: 22px;
+  opacity: 0.4;
+}
+
+.emptyTitle {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.emptyHint {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .inner {
+    padding: 32px 20px 96px;
+  }
+
+  .navHints {
+    display: none;
+  }
+
+  .imageCard {
+    width: 144px;
+  }
+
+  .imageThumb {
+    height: 96px;
+  }
+}
+
+@media (max-width: 480px) {
+  .inner {
+    padding: 24px 16px 96px;
+  }
+
+  .title {
+    font-size: 22px;
+  }
+
+  .chip {
+    padding: 5px 10px;
+    font-size: 11px;
+  }
+}

--- a/src/components/SearchView/index.js
+++ b/src/components/SearchView/index.js
@@ -1,0 +1,1 @@
+export { default } from './SearchView';

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -302,6 +302,13 @@ export default function Sidebar() {
     }
   };
 
+  const handleSearchClick = () => {
+    navigate('/search');
+    if (isMobile) {
+      dispatch(setCollapsed(true));
+    }
+  };
+
   const handleProjectsClick = () => {
     navigate(location.pathname.startsWith('/projects') ? '/' : '/projects');
     if (isMobile) {
@@ -632,8 +639,8 @@ export default function Sidebar() {
         </button>
 
         <button
-          className={styles.searchBtn}
-          onClick={() => setSearchOpen(true)}
+          className={`${styles.searchBtn} ${location.pathname === '/search' ? styles.active : ''}`}
+          onClick={handleSearchClick}
           title="Search"
           aria-label="Search"
         >

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -241,6 +241,11 @@
   color: var(--text-primary);
 }
 
+.searchBtn.active {
+  background-color: var(--bg-active);
+  color: var(--text-primary);
+}
+
 .searchBtn:active {
   transform: scale(0.98);
 }

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -5,6 +5,7 @@ import ConversationsView from './components/ConversationsView';
 import ConversationRoute from './components/ConversationRoute';
 import ProjectsView from './components/ProjectsView';
 import ImageGalleryView from './components/ImageGalleryView';
+import SearchView from './components/SearchView';
 import ModelsView from './components/ModelsView';
 import SettingsView from './components/SettingsView';
 import PricingView from './components/PricingView/PricingView';
@@ -111,6 +112,14 @@ const router = createBrowserRouter([
         element: (
           <RouteShell feature="images" seo={{ title: 'Image', noindex: true }}>
             <ImageGalleryView />
+          </RouteShell>
+        ),
+      },
+      {
+        path: 'search',
+        element: (
+          <RouteShell feature="search" seo={{ title: 'Search', noindex: true }}>
+            <SearchView />
           </RouteShell>
         ),
       },


### PR DESCRIPTION
Search is now a first-class route at /search with the full sidebar chrome, so users can deep-link, bookmark, and use browser back/forward on a search state. The sidebar Search button navigates to the page; Cmd/Ctrl+K still opens the existing popup for quick lookups.

- Extract shared useSearch hook so the modal and page can't drift
- SearchView mirrors ConversationsView's page chrome (720px, 48px top pad, 26/700 title) and reuses SearchModal's chip/result visual language
- Query, type, and date filters sync to ?q=&type=&date= with replace nav and cleaned defaults; Back/Forward reconcile via a ref-guarded effect
- Sidebar Search button gets an .active state when on /search