### PR TITLE
feat(web): paginate /search results with Load more + View all

### DIFF
--- a/src/components/SearchModal/SearchModal.jsx
+++ b/src/components/SearchModal/SearchModal.jsx
@@ -23,9 +23,12 @@ export default function SearchModal({ onClose }) {
     activeIndex,
     setActiveIndex,
     projectMap,
-    filteredConversations,
-    filteredProjects,
-    filteredImages,
+    displayedConversations,
+    displayedProjects,
+    displayedImages,
+    totalConversations,
+    totalProjects,
+    totalImages,
     apiLoading,
     hasQuery,
     hasAnyResults,
@@ -104,13 +107,13 @@ export default function SearchModal({ onClose }) {
               {f.key === 'images' && <PhotoIcon />}
               {f.label}
               {f.key === 'conversations' && hasQuery && (
-                <span className={styles.chipCount}>{filteredConversations.length}</span>
+                <span className={styles.chipCount}>{totalConversations}</span>
               )}
               {f.key === 'projects' && hasQuery && (
-                <span className={styles.chipCount}>{filteredProjects.length}</span>
+                <span className={styles.chipCount}>{totalProjects}</span>
               )}
               {f.key === 'images' && hasQuery && (
-                <span className={styles.chipCount}>{filteredImages.length}</span>
+                <span className={styles.chipCount}>{totalImages}</span>
               )}
             </button>
           ))}
@@ -143,10 +146,10 @@ export default function SearchModal({ onClose }) {
             <div className={styles.section}>
               <div className={styles.sectionHeader}>
                 <span className={styles.sectionLabel}>Images</span>
-                <span className={styles.sectionCount}>{filteredImages.length}</span>
+                <span className={styles.sectionCount}>{totalImages}</span>
               </div>
               <div className={styles.imageCarousel}>
-                {filteredImages.map((img) => (
+                {displayedImages.map((img) => (
                   <button
                     key={img.id}
                     className={styles.imageCard}
@@ -173,9 +176,9 @@ export default function SearchModal({ onClose }) {
             <div className={styles.section}>
               <div className={styles.sectionHeader}>
                 <span className={styles.sectionLabel}>Conversations</span>
-                <span className={styles.sectionCount}>{filteredConversations.length}</span>
+                <span className={styles.sectionCount}>{totalConversations}</span>
               </div>
-              {filteredConversations.map((conv) => {
+              {displayedConversations.map((conv) => {
                 const idx = currentIndex++;
                 const projectName = conv.projectId ? projectMap[conv.projectId] : null;
                 return (
@@ -214,9 +217,9 @@ export default function SearchModal({ onClose }) {
             <div className={styles.section}>
               <div className={styles.sectionHeader}>
                 <span className={styles.sectionLabel}>Projects</span>
-                <span className={styles.sectionCount}>{filteredProjects.length}</span>
+                <span className={styles.sectionCount}>{totalProjects}</span>
               </div>
-              {filteredProjects.map((proj) => {
+              {displayedProjects.map((proj) => {
                 const idx = currentIndex++;
                 return (
                   <button

--- a/src/components/SearchModal/useSearch.js
+++ b/src/components/SearchModal/useSearch.js
@@ -66,8 +66,8 @@ export function formatRelativeDate(dateStr) {
 
 /**
  * Shared search controller for both SearchModal (popup) and SearchView (page).
- * Owns all state, debounced API calls, filtering, and keyboard navigation so
- * the two surfaces can never drift out of sync.
+ * Owns all state, debounced API calls, filtering, pagination, and keyboard
+ * navigation so the two surfaces can never drift out of sync.
  *
  * @param {object} [options]
  * @param {() => void} [options.onAfterNavigate] - Called after a result is
@@ -76,8 +76,20 @@ export function formatRelativeDate(dateStr) {
  *   onAfterNavigate (modal dismiss). Pages pass false.
  * @param {{query?: string, typeFilter?: string, dateFilter?: string}} [options.initialState]
  *   Seed values for the URL-synced page surface. Only read on first render.
+ * @param {{conversationsPageSize?: number, projectsPageSize?: number, imagesPageSize?: number}} [options.pagination]
+ *   When provided, each list is clipped to its page size and exposes a
+ *   load-more callback. Defaults to no pagination (all results shown).
  */
-export function useSearch({ onAfterNavigate, enableEscape = false, initialState } = {}) {
+export function useSearch({
+  onAfterNavigate,
+  enableEscape = false,
+  initialState,
+  pagination,
+} = {}) {
+  const conversationsPageSize = pagination?.conversationsPageSize ?? Infinity;
+  const projectsPageSize = pagination?.projectsPageSize ?? Infinity;
+  const imagesPageSize = pagination?.imagesPageSize ?? Infinity;
+
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const conversations = useSelector(selectConversations);
@@ -242,22 +254,82 @@ export function useSearch({ onAfterNavigate, enableEscape = false, initialState 
     return source;
   }, [images, apiImages, query, typeFilter, dateFilter]);
 
-  // Build flat result list for keyboard navigation (conversations + projects only, not images)
+  // ── Pagination ────────────────────────────────────────────────
+  // Each list has a "visible count" that grows via loadMore. Counts reset
+  // whenever the user changes the query or a filter so the user always
+  // starts from the first page after a new search.
+  const [visibleConversations, setVisibleConversations] = useState(conversationsPageSize);
+  const [visibleProjects, setVisibleProjects] = useState(projectsPageSize);
+  const [visibleImages, setVisibleImages] = useState(imagesPageSize);
+
+  useEffect(() => {
+    setVisibleConversations(conversationsPageSize);
+    setVisibleProjects(projectsPageSize);
+    setVisibleImages(imagesPageSize);
+  }, [query, typeFilter, dateFilter, conversationsPageSize, projectsPageSize, imagesPageSize]);
+
+  const displayedConversations = useMemo(
+    () => filteredConversations.slice(0, visibleConversations),
+    [filteredConversations, visibleConversations]
+  );
+  const displayedProjects = useMemo(
+    () => filteredProjects.slice(0, visibleProjects),
+    [filteredProjects, visibleProjects]
+  );
+  const displayedImages = useMemo(
+    () => filteredImages.slice(0, visibleImages),
+    [filteredImages, visibleImages]
+  );
+
+  const hasMoreConversations = filteredConversations.length > displayedConversations.length;
+  const hasMoreProjects = filteredProjects.length > displayedProjects.length;
+  const hasMoreImages = filteredImages.length > displayedImages.length;
+
+  const loadMoreConversations = useCallback(() => {
+    setVisibleConversations((n) => n + conversationsPageSize);
+  }, [conversationsPageSize]);
+  const loadMoreProjects = useCallback(() => {
+    setVisibleProjects((n) => n + projectsPageSize);
+  }, [projectsPageSize]);
+  const loadMoreImages = useCallback(() => {
+    setVisibleImages((n) => n + imagesPageSize);
+  }, [imagesPageSize]);
+
+  // Build flat result list for keyboard navigation — only covers visible
+  // items so keyboard nav never targets something the user cannot see.
+  // Images are intentionally excluded from keyboard navigation.
   const allResults = useMemo(() => {
     const items = [];
-    filteredConversations.forEach((conv) => {
+    displayedConversations.forEach((conv) => {
       items.push({ type: 'conversation', data: conv });
     });
-    filteredProjects.forEach((proj) => {
+    displayedProjects.forEach((proj) => {
       items.push({ type: 'project', data: proj });
     });
     return items;
-  }, [filteredConversations, filteredProjects]);
+  }, [displayedConversations, displayedProjects]);
 
-  // Reset active index when results change
+  // Reset active index only when the filter set changes. Load More (which
+  // extends the list) must preserve the user's current selection.
+  const filterKey = `${query}|${typeFilter}|${dateFilter}`;
+  const prevFilterKeyRef = useRef(filterKey);
   useEffect(() => {
-    setActiveIndex(allResults.length > 0 ? 0 : -1);
-  }, [allResults.length]);
+    const isFilterChange = prevFilterKeyRef.current !== filterKey;
+    prevFilterKeyRef.current = filterKey;
+
+    if (isFilterChange) {
+      setActiveIndex(allResults.length > 0 ? 0 : -1);
+      return;
+    }
+
+    // Filter unchanged — clamp / seed without jumping the user.
+    setActiveIndex((prev) => {
+      if (allResults.length === 0) return -1;
+      if (prev === -1) return 0;
+      if (prev >= allResults.length) return allResults.length - 1;
+      return prev;
+    });
+  }, [filterKey, allResults.length]);
 
   // Navigate to result
   const navigateToResult = useCallback(
@@ -329,9 +401,9 @@ export function useSearch({ onAfterNavigate, enableEscape = false, initialState 
   const noResults = hasQuery && !hasAnyResults && !apiLoading;
 
   const showImages =
-    filteredImages.length > 0 && typeFilter !== 'conversations' && typeFilter !== 'projects';
-  const showConversations = filteredConversations.length > 0;
-  const showProjects = filteredProjects.length > 0;
+    displayedImages.length > 0 && typeFilter !== 'conversations' && typeFilter !== 'projects';
+  const showConversations = displayedConversations.length > 0;
+  const showProjects = displayedProjects.length > 0;
 
   return {
     // state
@@ -343,11 +415,22 @@ export function useSearch({ onAfterNavigate, enableEscape = false, initialState 
     setDateFilter,
     activeIndex,
     setActiveIndex,
-    // derived data
+    // derived data — what to render
     projectMap,
-    filteredConversations,
-    filteredProjects,
-    filteredImages,
+    displayedConversations,
+    displayedProjects,
+    displayedImages,
+    // totals — for chip counts, section counts, and "view all" labels
+    totalConversations: filteredConversations.length,
+    totalProjects: filteredProjects.length,
+    totalImages: filteredImages.length,
+    // pagination
+    hasMoreConversations,
+    hasMoreProjects,
+    hasMoreImages,
+    loadMoreConversations,
+    loadMoreProjects,
+    loadMoreImages,
     // flags
     apiLoading,
     hasQuery,

--- a/src/components/SearchView/SearchView.jsx
+++ b/src/components/SearchView/SearchView.jsx
@@ -12,6 +12,21 @@ import styles from './SearchView.module.css';
 const VALID_TYPES = new Set(TYPE_FILTERS.map((f) => f.key));
 const VALID_DATES = new Set(DATE_FILTERS.map((f) => f.key));
 
+// Page sizes for the dedicated search page. The All tab shows the first
+// batch only and points the user to the specific tab for more. The
+// specific tabs start with the same batch and reveal more via Load More.
+// Images use a larger page size because the grid renders ~4 per row on
+// desktop, so 12 ≈ 3 rows of premium-density thumbnails.
+const CONVERSATIONS_PAGE_SIZE = 7;
+const PROJECTS_PAGE_SIZE = 7;
+const IMAGES_PAGE_SIZE = 12;
+
+const TYPE_LABEL_PLURAL = {
+  conversations: 'conversations',
+  projects: 'projects',
+  images: 'images',
+};
+
 function readInitialState(params) {
   const rawType = params.get('type');
   const rawDate = params.get('date');
@@ -40,9 +55,18 @@ export default function SearchView() {
     activeIndex,
     setActiveIndex,
     projectMap,
-    filteredConversations,
-    filteredProjects,
-    filteredImages,
+    displayedConversations,
+    displayedProjects,
+    displayedImages,
+    totalConversations,
+    totalProjects,
+    totalImages,
+    hasMoreConversations,
+    hasMoreProjects,
+    hasMoreImages,
+    loadMoreConversations,
+    loadMoreProjects,
+    loadMoreImages,
     apiLoading,
     hasQuery,
     hasAnyResults,
@@ -52,7 +76,15 @@ export default function SearchView() {
     showProjects,
     navigateToResult,
     resultsRef,
-  } = useSearch({ initialState, enableEscape: false });
+  } = useSearch({
+    initialState,
+    enableEscape: false,
+    pagination: {
+      conversationsPageSize: CONVERSATIONS_PAGE_SIZE,
+      projectsPageSize: PROJECTS_PAGE_SIZE,
+      imagesPageSize: IMAGES_PAGE_SIZE,
+    },
+  });
 
   // Autofocus input on mount
   useEffect(() => {
@@ -93,7 +125,13 @@ export default function SearchView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
+  const isAllTab = typeFilter === 'all';
+  const isImagesTab = typeFilter === 'images';
   let currentIndex = 0;
+
+  // "View all" on the All tab switches to the specific filter; the hook
+  // resets pagination automatically when typeFilter changes.
+  const viewAll = (tab) => setTypeFilter(tab);
 
   return (
     <div className={styles.page}>
@@ -156,13 +194,13 @@ export default function SearchView() {
               {f.key === 'images' && <PhotoIcon />}
               {f.label}
               {f.key === 'conversations' && hasQuery && (
-                <span className={styles.chipCount}>{filteredConversations.length}</span>
+                <span className={styles.chipCount}>{totalConversations}</span>
               )}
               {f.key === 'projects' && hasQuery && (
-                <span className={styles.chipCount}>{filteredProjects.length}</span>
+                <span className={styles.chipCount}>{totalProjects}</span>
               )}
               {f.key === 'images' && hasQuery && (
-                <span className={styles.chipCount}>{filteredImages.length}</span>
+                <span className={styles.chipCount}>{totalImages}</span>
               )}
             </button>
           ))}
@@ -204,10 +242,10 @@ export default function SearchView() {
             <div className={styles.section}>
               <div className={styles.sectionHeader}>
                 <span className={styles.sectionLabel}>Images</span>
-                <span className={styles.sectionCount}>{filteredImages.length}</span>
+                <span className={styles.sectionCount}>{totalImages}</span>
               </div>
-              <div className={styles.imageCarousel}>
-                {filteredImages.map((img) => (
+              <div className={isImagesTab ? styles.imageGrid : styles.imageCarousel}>
+                {displayedImages.map((img) => (
                   <button
                     key={img.id}
                     className={styles.imageCard}
@@ -226,6 +264,27 @@ export default function SearchView() {
                   </button>
                 ))}
               </div>
+              {isImagesTab && hasMoreImages && (
+                <div className={styles.sectionFooter}>
+                  <button type="button" className={styles.loadMoreBtn} onClick={loadMoreImages}>
+                    Load more
+                  </button>
+                </div>
+              )}
+              {isAllTab && hasMoreImages && (
+                <div className={styles.sectionFooter}>
+                  <button
+                    type="button"
+                    className={styles.viewAllBtn}
+                    onClick={() => viewAll('images')}
+                  >
+                    View all {totalImages} {TYPE_LABEL_PLURAL.images}
+                    <span aria-hidden="true" className={styles.viewAllArrow}>
+                      &rarr;
+                    </span>
+                  </button>
+                </div>
+              )}
             </div>
           )}
 
@@ -233,9 +292,9 @@ export default function SearchView() {
             <div className={styles.section}>
               <div className={styles.sectionHeader}>
                 <span className={styles.sectionLabel}>Conversations</span>
-                <span className={styles.sectionCount}>{filteredConversations.length}</span>
+                <span className={styles.sectionCount}>{totalConversations}</span>
               </div>
-              {filteredConversations.map((conv) => {
+              {displayedConversations.map((conv) => {
                 const idx = currentIndex++;
                 const projectName = conv.projectId ? projectMap[conv.projectId] : null;
                 return (
@@ -266,6 +325,31 @@ export default function SearchView() {
                   </button>
                 );
               })}
+              {!isAllTab && hasMoreConversations && (
+                <div className={styles.sectionFooter}>
+                  <button
+                    type="button"
+                    className={styles.loadMoreBtn}
+                    onClick={loadMoreConversations}
+                  >
+                    Load more
+                  </button>
+                </div>
+              )}
+              {isAllTab && hasMoreConversations && (
+                <div className={styles.sectionFooter}>
+                  <button
+                    type="button"
+                    className={styles.viewAllBtn}
+                    onClick={() => viewAll('conversations')}
+                  >
+                    View all {totalConversations} {TYPE_LABEL_PLURAL.conversations}
+                    <span aria-hidden="true" className={styles.viewAllArrow}>
+                      &rarr;
+                    </span>
+                  </button>
+                </div>
+              )}
             </div>
           )}
 
@@ -273,9 +357,9 @@ export default function SearchView() {
             <div className={styles.section}>
               <div className={styles.sectionHeader}>
                 <span className={styles.sectionLabel}>Projects</span>
-                <span className={styles.sectionCount}>{filteredProjects.length}</span>
+                <span className={styles.sectionCount}>{totalProjects}</span>
               </div>
-              {filteredProjects.map((proj) => {
+              {displayedProjects.map((proj) => {
                 const idx = currentIndex++;
                 return (
                   <button
@@ -307,6 +391,27 @@ export default function SearchView() {
                   </button>
                 );
               })}
+              {!isAllTab && hasMoreProjects && (
+                <div className={styles.sectionFooter}>
+                  <button type="button" className={styles.loadMoreBtn} onClick={loadMoreProjects}>
+                    Load more
+                  </button>
+                </div>
+              )}
+              {isAllTab && hasMoreProjects && (
+                <div className={styles.sectionFooter}>
+                  <button
+                    type="button"
+                    className={styles.viewAllBtn}
+                    onClick={() => viewAll('projects')}
+                  >
+                    View all {totalProjects} {TYPE_LABEL_PLURAL.projects}
+                    <span aria-hidden="true" className={styles.viewAllArrow}>
+                      &rarr;
+                    </span>
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/components/SearchView/SearchView.module.css
+++ b/src/components/SearchView/SearchView.module.css
@@ -258,7 +258,72 @@
   line-height: 1.5;
 }
 
-/* ── Image carousel ── */
+/* ── Section footer (Load more / View all) ── */
+.sectionFooter {
+  display: flex;
+  justify-content: center;
+  padding: 12px 0 4px;
+}
+
+.loadMoreBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 18px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.loadMoreBtn:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.loadMoreBtn:active {
+  transform: scale(0.99);
+}
+
+.viewAllBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.viewAllBtn:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-color);
+}
+
+.viewAllArrow {
+  font-size: 13px;
+  line-height: 1;
+  transition: transform 0.15s ease;
+}
+
+.viewAllBtn:hover .viewAllArrow {
+  transform: translateX(2px);
+}
+
+/* ── Image carousel (All tab) ── */
 .imageCarousel {
   display: flex;
   gap: 10px;
@@ -281,16 +346,29 @@
   border-radius: 2px;
 }
 
-.imageCard {
+/* Carousel-only card sizing. In the grid variant the grid controls width. */
+.imageCarousel .imageCard {
   flex-shrink: 0;
   width: 168px;
+  scroll-snap-align: start;
+}
+
+/* ── Image grid (Images tab) ── */
+.imageGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+  padding: 4px 0 8px;
+}
+
+/* ── Image card (layout-agnostic) ── */
+.imageCard {
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   overflow: hidden;
   cursor: pointer;
   transition: border-color 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
-  scroll-snap-align: start;
   text-align: left;
   font-family: inherit;
   color: inherit;
@@ -544,8 +622,13 @@
     display: none;
   }
 
-  .imageCard {
+  .imageCarousel .imageCard {
     width: 144px;
+  }
+
+  .imageGrid {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 10px;
   }
 
   .imageThumb {


### PR DESCRIPTION
Long result lists were overwhelming the dedicated search page. Each list now shows a premium, human-sized first page and grows on demand.

- All tab: shows 7 conversations and 7 projects; when more exist, a subtle "View all N" link switches to the specific tab
- Conversations / Projects tabs: 7 initially, "Load more" reveals 7 more per click
- Images tab: switches from carousel to a responsive grid (12 per page, ~3 rows on desktop) with "Load more" at the bottom; All tab keeps the horizontal carousel preview
- Pagination lives in useSearch so allResults (keyboard nav) only ever covers visible items and activeIndex preserves position across Load more (jumps to 0 only on genuine filter/query change)
- Modal passes no pagination → behavior unchanged there