### PR TITLE
style(web): widen chat input and message column to 768px

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -1249,7 +1249,7 @@
 
 .container {
   width: 100%;
-  max-width: 640px;
+  max-width: 768px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1257,7 +1257,7 @@
 
 /* When in chat mode, input sticks to bottom */
 .containerBottom {
-  max-width: 720px;
+  max-width: 768px;
   margin: 0 auto;
   padding: 0 24px 24px;
   flex-shrink: 0;

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -33,7 +33,7 @@
 }
 
 .messagesInner {
-  max-width: 720px;
+  max-width: 768px;
   margin: 0 auto;
   padding: 0 24px;
   padding-top: 32px;


### PR DESCRIPTION
Empty-state composer, active-conversation composer, and the message column now share a 768px max-width for a more comfortable reading measure and consistent alignment on transition from empty to chat.

https://claude.ai/code/session_01Kuva9usvXZBveRBuC9vg4T