### PR TITLE
style(web): trim composer height for a tighter, Claude-like resting s…

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -1305,7 +1305,7 @@
   background-color: var(--bg-input);
   border: 1px solid var(--border-input);
   border-radius: 16px;
-  padding: 16px;
+  padding: 14px 16px;
   transition: border-color 0.15s ease, background-color 0.2s ease;
 }
 
@@ -1319,7 +1319,7 @@
   color: var(--text-primary);
   background: transparent;
   resize: none;
-  min-height: 44px;
+  min-height: 40px;
   max-height: 360px;
   line-height: 1.5;
   overflow-y: auto;


### PR DESCRIPTION
…tate

Vertical padding on .inputWrapper drops 16px → 14px and textarea min-height drops 44px → 40px, removing ~8px of dead space above and below the caret without affecting the action row or growth ceiling.

https://claude.ai/code/session_01Kuva9usvXZBveRBuC9vg4T