### PR TITLE
style(web): slim collapsed side-nav rail from 64px to 58px

### DIFF
--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -66,8 +66,8 @@
 }
 
 .sidebar.collapsed {
-  width: 64px;
-  padding: 12px 8px;
+  width: 58px;
+  padding: 12px 6px;
 }
 
 /* In-header collapse/expand chevron pill (replaces the external half-disc) */
@@ -220,9 +220,9 @@
 .collapsed .newChatBtn {
   justify-content: center;
   padding: 0;
-  width: 40px;
-  height: 40px;
-  border-radius: 12px;
+  width: 38px;
+  height: 38px;
+  border-radius: 11px;
   margin-bottom: 6px;
   background-color: var(--text-primary);
   color: var(--bg-primary);
@@ -295,8 +295,8 @@
 .collapsed .searchBtn {
   justify-content: center;
   padding: 0;
-  width: 40px;
-  height: 40px;
+  width: 38px;
+  height: 38px;
   border-radius: 10px;
   margin-bottom: 6px;
 }
@@ -355,8 +355,8 @@
 .collapsed .navItem {
   justify-content: center;
   padding: 0;
-  width: 40px;
-  height: 40px;
+  width: 38px;
+  height: 38px;
   border-radius: 10px;
 }
 
@@ -1002,7 +1002,7 @@
 
 .userDropdownCollapsed {
   position: fixed;
-  left: calc(64px + 12px + 4px);
+  left: calc(58px + 12px + 4px);
   right: auto;
   width: 210px;
   bottom: 72px;
@@ -1058,8 +1058,8 @@
 
 .collapsed .userSection {
   border-radius: 10px;
-  width: 40px;
-  height: 40px;
+  width: 38px;
+  height: 38px;
   padding: 0;
   justify-content: center;
 }


### PR DESCRIPTION
Tightens the rail width and drops the icon buttons from 40px to 38px (primary +, search, nav items, user avatar) while relaxing inner padding to 12px/6px so every icon still sits with 4px of breathing room on each side. Updates the collapsed-rail user-dropdown anchor to calc(58px + 12px + 4px). The (+) focal button keeps its filled styling and lifted shadow — just a touch sleeker.

https://claude.ai/code/session_01BqB6yhejZd2QBwEox9Qs9s