### PR TITLE
style(credits): redesign credits indicator as responsive premium card

### DIFF
--- a/src/components/CreditBalance/CreditBalance.jsx
+++ b/src/components/CreditBalance/CreditBalance.jsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 import { selectCreditBalance } from '../../store/slices/chatSlice';
+import { PlusIcon } from '../Icons';
 import styles from './CreditBalance.module.css';
 
 function formatResetTime(isoDate) {
@@ -9,54 +10,74 @@ function formatResetTime(isoDate) {
   return `in ${days} days`;
 }
 
-export default function CreditBalance({ onBuyCredits }) {
+const TIER_LABELS = {
+  free: 'Free',
+  lite: 'Lite',
+  pro: 'Pro',
+  ultra: 'Ultra',
+  apex: 'Apex',
+};
+
+export default function CreditBalance({ onBuyCredits, tier = 'free' }) {
   const balance = useSelector(selectCreditBalance);
 
   if (!balance) return null;
 
   const hasPackCredits = balance.packs.remaining > 0;
   const monthlyDepleted = balance.monthly.remaining === 0;
+  const outOfCredits = balance.combined <= 0;
   const resetLabel = balance.cycleResetsAt ? formatResetTime(balance.cycleResetsAt) : null;
+  const tierKey = TIER_LABELS[tier] ? tier : 'free';
+  const isPaidTier = tierKey !== 'free';
+  const actionLabel = outOfCredits ? 'Get credits' : 'Add more';
 
   return (
-    <div className={styles.container}>
-      <div className={styles.balanceMain}>
-        <span className={styles.available}>{balance.combined}</span>
-        <span className={styles.availableLabel}>
-          credit{balance.combined !== 1 ? 's' : ''} available
+    <div className={`${styles.card} ${outOfCredits ? styles.cardUrgent : ''}`}>
+      <div className={styles.primaryRow}>
+        <span className={styles.pulseDot} aria-hidden="true" />
+        <span className={`${styles.available} ${outOfCredits ? styles.availableUrgent : ''}`}>
+          {balance.combined}
         </span>
+        <span className={styles.availableLabel}>credit{balance.combined !== 1 ? 's' : ''}</span>
+        {hasPackCredits && (
+          <span className={styles.bonus} title={`${balance.packs.remaining} bonus credits`}>
+            +{balance.packs.remaining}
+          </span>
+        )}
+        <span className={styles.spacer} aria-hidden="true" />
+        <span
+          className={`${styles.tierBadge} ${isPaidTier ? styles.tierBadgePaid : ''}`}
+          aria-label={`${TIER_LABELS[tierKey]} tier`}
+        >
+          {TIER_LABELS[tierKey]}
+        </span>
+        {onBuyCredits && (
+          <button
+            type="button"
+            className={`${styles.buyButton} ${outOfCredits ? styles.buyButtonUrgent : ''}`}
+            onClick={onBuyCredits}
+            aria-label={actionLabel}
+          >
+            <PlusIcon />
+            <span className={styles.buyButtonLabel}>{actionLabel}</span>
+          </button>
+        )}
       </div>
-      <div className={styles.breakdown}>
-        <span className={monthlyDepleted ? styles.monthlyDepleted : styles.monthly}>
-          {monthlyDepleted
-            ? `0 of ${balance.monthly.total} monthly left`
-            : `${balance.monthly.remaining} of ${balance.monthly.total} monthly left`}
+      <div className={styles.secondaryRow}>
+        <span className={monthlyDepleted ? styles.secondaryUrgent : ''}>
+          {balance.monthly.remaining} of {balance.monthly.total} monthly
         </span>
         {resetLabel && (
           <>
-            <span className={styles.separator}>&bull;</span>
-            <span className={monthlyDepleted ? styles.resetInfoUrgent : styles.resetInfo}>
+            <span className={styles.secondaryDivider} aria-hidden="true">
+              ·
+            </span>
+            <span className={monthlyDepleted ? styles.secondaryUrgent : ''}>
               resets {resetLabel}
             </span>
           </>
         )}
-        {hasPackCredits && (
-          <>
-            <span className={styles.separator}>&bull;</span>
-            <span className={styles.packs}>
-              {balance.packs.remaining} bonus
-            </span>
-          </>
-        )}
       </div>
-      {onBuyCredits && (
-        <button
-          className={`${styles.buyButton} ${balance.combined <= 0 ? styles.buyButtonUrgent : ''}`}
-          onClick={onBuyCredits}
-        >
-          {balance.combined <= 0 ? 'Get Credits' : 'Add More'}
-        </button>
-      )}
     </div>
   );
 }

--- a/src/components/CreditBalance/CreditBalance.module.css
+++ b/src/components/CreditBalance/CreditBalance.module.css
@@ -1,93 +1,226 @@
-.container {
+.card {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 12px;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 10px 8px 12px;
+  border-radius: 12px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  max-width: 100%;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 }
 
-.balanceMain {
-  display: flex;
-  align-items: baseline;
-  gap: 4px;
+.card:hover {
+  border-color: var(--border-input);
 }
 
-.available {
-  font-size: 15px;
-  font-weight: 700;
-  color: var(--text-primary);
-  letter-spacing: -0.01em;
+.cardUrgent {
+  border-color: rgba(217, 119, 6, 0.35);
 }
 
-.availableLabel {
-  font-size: 11px;
-  color: var(--text-muted);
-  white-space: nowrap;
+.cardUrgent:hover {
+  border-color: rgba(217, 119, 6, 0.55);
 }
 
-.breakdown {
+.primaryRow {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
+}
+
+.pulseDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--text-muted);
+  flex-shrink: 0;
+  animation: creditPulse 2.4s ease-in-out infinite;
+}
+
+.cardUrgent .pulseDot {
+  background-color: #d97706;
+}
+
+@keyframes creditPulse {
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.25);
+  }
+}
+
+.available {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.availableUrgent {
+  color: #d97706;
+}
+
+.availableLabel {
+  font-size: 11.5px;
   color: var(--text-muted);
-  font-size: 11px;
-}
-
-.monthly {
   white-space: nowrap;
 }
 
-.monthlyDepleted {
+.bonus {
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--text-muted);
+  padding: 1px 5px;
+  border-radius: 5px;
+  background-color: var(--bg-active);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
   white-space: nowrap;
-  opacity: 0.5;
 }
 
-.separator {
-  opacity: 0.3;
-  font-size: 8px;
+.spacer {
+  flex: 1;
+  min-width: 4px;
 }
 
-.packs {
-  white-space: nowrap;
-  color: #d97706;
+.tierBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 3px 6px;
+  border-radius: 6px;
+  color: var(--text-muted);
+  background-color: transparent;
+  border: 1px solid var(--border-color);
+  text-transform: uppercase;
+  line-height: 1;
+  flex-shrink: 0;
 }
 
-.resetInfo {
-  white-space: nowrap;
-  font-style: italic;
-  opacity: 0.7;
-}
-
-.resetInfoUrgent {
-  white-space: nowrap;
-  font-style: italic;
-  color: #d97706;
+.tierBadgePaid {
+  color: var(--text-primary);
+  background-color: var(--bg-active);
+  border-color: var(--border-input);
 }
 
 .buyButton {
-  padding: 3px 10px;
-  border-radius: 6px;
-  border: 1px solid var(--border-input);
-  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px 4px 8px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background-color: transparent;
   color: var(--text-secondary);
-  font-size: 11px;
+  font-size: 11.5px;
   font-weight: 500;
-  cursor: pointer;
   white-space: nowrap;
-  transition: all 0.2s ease;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.buyButton svg {
+  width: 12px;
+  height: 12px;
 }
 
 .buyButton:hover {
-  background: var(--bg-icon-button);
-  color: var(--text-icon-button);
-  border-color: var(--bg-icon-button);
+  background-color: var(--bg-hover);
+  border-color: var(--border-input);
+  color: var(--text-primary);
+}
+
+.buyButton:focus-visible {
+  outline: 2px solid var(--text-secondary);
+  outline-offset: 2px;
+}
+
+.buyButtonLabel {
+  line-height: 1;
 }
 
 .buyButtonUrgent {
-  background: var(--bg-icon-button);
-  color: var(--text-icon-button);
-  border-color: var(--bg-icon-button);
+  background-color: #d97706;
+  border-color: #d97706;
+  color: #fff;
 }
 
 .buyButtonUrgent:hover {
-  opacity: 0.85;
+  background-color: #b45309;
+  border-color: #b45309;
+  color: #fff;
+}
+
+.secondaryRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+  padding-left: 14px;
+  line-height: 1.3;
+}
+
+.secondaryDivider {
+  opacity: 0.5;
+  font-size: 9px;
+}
+
+.secondaryUrgent {
+  color: #d97706;
+}
+
+/* Responsive — collapse to a tight single row on narrow viewports */
+@media (max-width: 480px) {
+  .card {
+    padding: 7px 8px 7px 10px;
+  }
+
+  .secondaryRow {
+    display: none;
+  }
+
+  .availableLabel {
+    display: none;
+  }
+
+  .bonus {
+    display: none;
+  }
+
+  .buyButtonLabel {
+    display: none;
+  }
+
+  .buyButton {
+    padding: 5px;
+    border-radius: 8px;
+  }
+
+  .buyButton svg {
+    width: 14px;
+    height: 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulseDot {
+    animation: none;
+  }
+
+  .card,
+  .buyButton {
+    transition: none;
+  }
 }

--- a/src/components/ImageGalleryView/ImageGalleryView.jsx
+++ b/src/components/ImageGalleryView/ImageGalleryView.jsx
@@ -30,10 +30,7 @@ import {
   getLimitInfo,
 } from '../../services/imageGeneration';
 import { PROVIDERS } from '../../data/models';
-import {
-  selectCurrentTier,
-  setImageCredits,
-} from '../../store/slices/subscriptionSlice';
+import { selectCurrentTier, setImageCredits } from '../../store/slices/subscriptionSlice';
 import {
   CloseIcon,
   FileDownIcon,
@@ -152,13 +149,15 @@ export default function ImageGalleryView() {
       .then((data) => {
         if (data.balance) {
           dispatch(setCreditBalance(data.balance));
-          dispatch(setImageCredits({
-            used: data.balance.monthly?.used ?? 0,
-            limit: data.balance.monthly?.total ?? 5,
-            remaining: data.balance.monthly?.remaining ?? 0,
-            packRemaining: data.balance.packs?.remaining ?? 0,
-            cycleResetsAt: data.balance.cycleResetsAt ?? null,
-          }));
+          dispatch(
+            setImageCredits({
+              used: data.balance.monthly?.used ?? 0,
+              limit: data.balance.monthly?.total ?? 5,
+              remaining: data.balance.monthly?.remaining ?? 0,
+              packRemaining: data.balance.packs?.remaining ?? 0,
+              cycleResetsAt: data.balance.cycleResetsAt ?? null,
+            })
+          );
         }
       })
       .catch(() => {});
@@ -193,13 +192,15 @@ export default function ImageGalleryView() {
         .then((data) => {
           if (data?.balance) {
             dispatch(setCreditBalance(data.balance));
-            dispatch(setImageCredits({
-              used: data.balance.monthly?.used ?? 0,
-              limit: data.balance.monthly?.total ?? 5,
-              remaining: data.balance.monthly?.remaining ?? 0,
-              packRemaining: data.balance.packs?.remaining ?? 0,
-              cycleResetsAt: data.balance.cycleResetsAt ?? null,
-            }));
+            dispatch(
+              setImageCredits({
+                used: data.balance.monthly?.used ?? 0,
+                limit: data.balance.monthly?.total ?? 5,
+                remaining: data.balance.monthly?.remaining ?? 0,
+                packRemaining: data.balance.packs?.remaining ?? 0,
+                cycleResetsAt: data.balance.cycleResetsAt ?? null,
+              })
+            );
           }
         })
         .catch(() => {});
@@ -549,6 +550,7 @@ export default function ImageGalleryView() {
           {/* Credit balance */}
           <div className={styles.usagePill}>
             <CreditBalance
+              tier={creditBalance?.tier ?? 'free'}
               onBuyCredits={() => {
                 if (!isAuthenticated) {
                   setShowAuthModal(true);
@@ -557,13 +559,6 @@ export default function ImageGalleryView() {
                 }
               }}
             />
-            <span className={styles.usagePillBadge}>
-              {creditBalance?.tier === 'pro'
-                ? 'PRO'
-                : creditBalance?.tier === 'lite'
-                ? 'LITE'
-                : 'FREE'}
-            </span>
           </div>
           {showBuyPacks && <BuyPacksModal onClose={() => setShowBuyPacks(false)} />}
         </div>
@@ -953,7 +948,9 @@ function ImageDetailView({ images, startIndex, onClose, onDownload, onDelete }) 
               )}
               <div className={styles.detailMetaRow}>
                 {img.provider && (
-                  <span className={styles.detailMetaChip}>{providerData?.name || img.provider}</span>
+                  <span className={styles.detailMetaChip}>
+                    {providerData?.name || img.provider}
+                  </span>
                 )}
                 {img.size && <span className={styles.detailMetaChip}>{img.size}</span>}
                 {images.length > 1 && (

--- a/src/components/ImageGalleryView/ImageGalleryView.module.css
+++ b/src/components/ImageGalleryView/ImageGalleryView.module.css
@@ -211,68 +211,13 @@
   display: none;
 }
 
-/* ===== Usage Pill ===== */
+/* ===== Credit balance wrapper ===== */
 .usagePill {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 16px 6px 12px;
-  border-radius: 100px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  display: flex;
+  justify-content: center;
   margin: 0 auto;
-  transition: border-color 0.3s ease;
-}
-
-.usagePill:hover {
-  border-color: var(--text-muted);
-}
-
-.usagePillDot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  flex-shrink: 0;
-  animation: pillPulse 2.4s ease-in-out infinite;
-}
-
-@keyframes pillPulse {
-  0%,
-  100% {
-    opacity: 0.4;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 1;
-    transform: scale(1.3);
-  }
-}
-
-.usagePillText {
-  font-size: 11.5px;
-  font-weight: 500;
-  color: var(--text-muted);
-  letter-spacing: 0.01em;
-}
-
-.usagePillBadge {
-  font-size: 9px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 2px 7px;
-  border-radius: 6px;
-  background: var(--bg-icon-button);
-  color: var(--text-icon-button);
-  opacity: 0.8;
-}
-
-.usagePillLimit {
-  font-size: 10.5px;
-  color: #d97706;
-  font-weight: 500;
-  margin-left: 2px;
+  max-width: 100%;
+  width: fit-content;
 }
 
 /* ===== Quality Dropdown ===== */


### PR DESCRIPTION
The credits pill was a long rounded-100px strip with six data points on one nowrap line, so it overflowed on narrow viewports and read as visually generic. Replaces it with a self-contained two-row card (12px radius, monochrome chrome) that scales down cleanly:

- Primary row: pulse dot · bold count · "credits" · subtle +bonus suffix · spacer · tonal tier badge · "Add more" button.
- Secondary row: "X of Y monthly · resets in N days" — one muted line, no italics, no bullet clutter.
- Below 480px the secondary row hides, the button collapses to its plus icon, and the card still fits at 320px.
- Amber appears only in urgent states (no credits left, monthly depleted) — the "bonus" count is now monochrome.
- Tier badge moves inside CreditBalance (new `tier` prop); dead .usagePillBadge / .usagePillDot / .usagePillText / .usagePillLimit and the orphaned pillPulse keyframe are removed.

https://claude.ai/code/session_01BqB6yhejZd2QBwEox9Qs9s