### PR TITLE
feat(followup): show checkboxes for multi-select question options

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -4560,36 +4560,67 @@ function QuestionCard({ questions, onComplete, onDismiss }) {
         </div>
       </div>
 
-      <div className={styles.questionOptions}>
-        {current.options.map((option, idx) => (
-          <button
-            key={idx}
-            className={`${styles.questionOption} ${
-              isOptionSelected(option) ? styles.questionOptionSelected : ''
-            }`}
-            onClick={() => handleSelectOption(option)}
-          >
-            <span className={styles.questionOptionNumber}>{idx + 1}</span>
-            <span className={styles.questionOptionLabel}>{option}</span>
-            {isOptionSelected(option) && (
-              <svg
-                className={styles.questionOptionCheck}
-                width="14"
-                height="14"
-                viewBox="0 0 14 14"
-                fill="none"
-              >
-                <path
-                  d="M11.5 4L5.5 10L2.5 7"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            )}
-          </button>
-        ))}
+      <div
+        className={styles.questionOptions}
+        role={isMultiSelect ? 'group' : undefined}
+        aria-label={isMultiSelect ? 'Select all that apply' : undefined}
+      >
+        {current.options.map((option, idx) => {
+          const selected = isOptionSelected(option);
+          return (
+            <button
+              key={idx}
+              type="button"
+              className={`${styles.questionOption} ${
+                selected ? styles.questionOptionSelected : ''
+              }`}
+              onClick={() => handleSelectOption(option)}
+              role={isMultiSelect ? 'checkbox' : undefined}
+              aria-checked={isMultiSelect ? selected : undefined}
+            >
+              {isMultiSelect ? (
+                <span
+                  className={`${styles.questionOptionCheckbox} ${
+                    selected ? styles.questionOptionCheckboxChecked : ''
+                  }`}
+                  aria-hidden="true"
+                >
+                  {selected && (
+                    <svg width="12" height="12" viewBox="0 0 14 14" fill="none">
+                      <path
+                        d="M11.5 4L5.5 10L2.5 7"
+                        stroke="currentColor"
+                        strokeWidth="1.8"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </span>
+              ) : (
+                <span className={styles.questionOptionNumber}>{idx + 1}</span>
+              )}
+              <span className={styles.questionOptionLabel}>{option}</span>
+              {!isMultiSelect && selected && (
+                <svg
+                  className={styles.questionOptionCheck}
+                  width="14"
+                  height="14"
+                  viewBox="0 0 14 14"
+                  fill="none"
+                >
+                  <path
+                    d="M11.5 4L5.5 10L2.5 7"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+            </button>
+          );
+        })}
 
         <div
           className={`${styles.questionCustom} ${

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -2154,6 +2154,29 @@
   opacity: 0.7;
 }
 
+.questionOptionCheckbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 1.5px solid var(--text-muted);
+  color: transparent;
+  flex-shrink: 0;
+  transition: all 0.18s ease;
+}
+
+.questionOption:hover .questionOptionCheckbox {
+  border-color: var(--text-secondary);
+}
+
+.questionOptionCheckboxChecked {
+  background: var(--text-primary);
+  border-color: var(--text-primary);
+  color: var(--bg-primary);
+}
+
 /* --- Custom Input --- */
 .questionCustom {
   display: flex;


### PR DESCRIPTION
Signal "pick all that apply" visually by swapping the numeric badge for a checkbox on multi-select follow-up questions. Single-select flow stays unchanged. Adds role="checkbox"/aria-checked and a group label for a11y.

https://claude.ai/code/session_0195t6nq7VDzrbVV6PUX7JW8