### PR TITLE
feat(main): vertical providers rail with real logos

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -125,6 +125,7 @@ import {
 } from '../../store/slices/subscriptionSlice';
 import { getNextTier } from '../../config/subscription';
 import { PROVIDERS, isImageGenerationModel } from '../../data/models';
+import { getProviderLogo } from '../getProviderLogo';
 import { compressImage, isAcceptedImageType } from '../../utils/imageCompression';
 import {
   canGenerateImage,
@@ -156,6 +157,18 @@ const getGreeting = () => {
   if (hour < 18) return 'Good afternoon.';
   return 'Good evening.';
 };
+
+// Providers surfaced in the landing "Providers available" rail.
+// Order is intentional (most-used first) and labels use the product names
+// users recognise, not the company names stored in PROVIDERS.
+const LANDING_PROVIDERS = [
+  { id: 'openai', label: 'ChatGPT' },
+  { id: 'anthropic', label: 'Claude' },
+  { id: 'google', label: 'Gemini' },
+  { id: 'perplexity', label: 'Perplexity' },
+  { id: 'xai', label: 'Grok' },
+  { id: 'elevenlabs', label: 'ElevenLabs' },
+];
 
 const MODE_CONFIG = [
   {
@@ -3612,18 +3625,26 @@ export default function MainContent() {
       </div>
 
       {!hasMessages && (
-        <div className={styles.providersBadge} aria-hidden="true">
+        <aside className={styles.providersBadge} aria-label="Providers available">
           <span className={styles.providersBadgeLabel}>Providers available</span>
-          <div className={styles.providersBadgeDashes}>
-            {Object.values(PROVIDERS).map((p) => (
-              <span
-                key={p.id}
-                className={styles.providersBadgeDash}
-                style={{ backgroundColor: p.accentColor }}
-              />
-            ))}
-          </div>
-        </div>
+          <ul className={styles.providersBadgeList}>
+            {LANDING_PROVIDERS.map(({ id, label }) => {
+              const Logo = getProviderLogo(id);
+              return (
+                <li key={id} className={styles.providersBadgeItem}>
+                  <span
+                    className={styles.providersBadgeIcon}
+                    title={label}
+                    role="img"
+                    aria-label={label}
+                  >
+                    <Logo size={16} />
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </aside>
       )}
     </main>
   );

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -2963,51 +2963,83 @@
   }
 }
 
-/* "Providers available" indicator — bottom-right of the landing screen */
+/* "Providers available" rail — vertical floating stack on the right edge */
 .providersBadge {
   position: absolute;
   right: 20px;
-  bottom: 16px;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  gap: 6px;
-  pointer-events: none;
+  align-items: center;
+  gap: 12px;
+  pointer-events: auto;
   opacity: 0;
   animation: providersBadgeIn 0.5s cubic-bezier(0.2, 0, 0, 1) 0.15s forwards;
 }
 
 .providersBadgeLabel {
-  font-size: 11px;
-  font-weight: 500;
+  font-size: 10px;
+  font-weight: 600;
   color: var(--text-muted);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  user-select: none;
+  text-align: center;
 }
 
-.providersBadgeDashes {
+.providersBadgeList {
   display: flex;
-  gap: 4px;
+  flex-direction: column;
+  gap: 6px;
+  list-style: none;
+  padding: 6px;
+  margin: 0;
+  background-color: var(--bg-button);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  box-shadow: var(--shadow);
 }
 
-.providersBadgeDash {
-  width: 14px;
-  height: 3px;
-  border-radius: 2px;
-  opacity: 0.85;
+.providersBadgeItem {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.providersBadgeIcon {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  background-color: transparent;
+  transition: color 0.15s ease, background-color 0.15s ease, transform 0.15s ease;
+  cursor: default;
+}
+
+.providersBadgeIcon:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+  transform: scale(1.08);
 }
 
 @keyframes providersBadgeIn {
   from {
     opacity: 0;
-    transform: translateY(6px);
+    transform: translate(6px, -50%);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translate(0, -50%);
   }
 }
 
-@media (max-width: 640px) {
+/* Hide on narrow screens so it never crowds the input */
+@media (max-width: 1024px) {
   .providersBadge {
     display: none;
   }

--- a/src/components/ProviderLogos.jsx
+++ b/src/components/ProviderLogos.jsx
@@ -77,3 +77,16 @@ export const XAILogo = ({ size = 18 }) => (
     />
   </svg>
 );
+
+export const ElevenLabsLogo = ({ size = 18 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="6" y="5" width="3.5" height="14" rx="0.6" fill="currentColor" />
+    <rect x="14.5" y="5" width="3.5" height="14" rx="0.6" fill="currentColor" />
+  </svg>
+);

--- a/src/components/getProviderLogo.js
+++ b/src/components/getProviderLogo.js
@@ -1,4 +1,11 @@
-import { AnthropicLogo, OpenAILogo, GoogleLogo, PerplexityLogo, XAILogo } from './ProviderLogos';
+import {
+  AnthropicLogo,
+  OpenAILogo,
+  GoogleLogo,
+  PerplexityLogo,
+  XAILogo,
+  ElevenLabsLogo,
+} from './ProviderLogos';
 
 /**
  * Get the logo component for a given provider ID.
@@ -10,6 +17,7 @@ export function getProviderLogo(providerId) {
     google: GoogleLogo,
     perplexity: PerplexityLogo,
     xai: XAILogo,
+    elevenlabs: ElevenLabsLogo,
   };
   return logos[providerId] || AnthropicLogo;
 }


### PR DESCRIPTION
Replace the horizontal colour-dash indicator on the landing screen with a vertical floating rail showing the actual provider logos (ChatGPT, Claude, Gemini, Perplexity, Grok, ElevenLabs), anchored mid-right and wrapped in a subtle card. Adds a minimal ElevenLabs mark to ProviderLogos and registers it in getProviderLogo. Hidden during active conversations and under 1024px to avoid crowding the input.

https://claude.ai/code/session_01C6L8ASjGDNtgKcyt7LuCSP