### PR TITLE
feat: remember-me, disclaimer scoping, mobile ambient icons, real pro…

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   signInWithGoogle,
@@ -11,6 +11,28 @@ import {
 } from '../../store/slices/authSlice';
 import { CloseIcon } from '../Icons';
 import styles from './AuthModal.module.css';
+
+const REMEMBER_ME_STORAGE_KEY = 'araviel.auth.rememberMe';
+
+function readRememberMePreference() {
+  if (typeof window === 'undefined') return true;
+  try {
+    const stored = window.localStorage.getItem(REMEMBER_ME_STORAGE_KEY);
+    // Default to true when no preference has been saved yet.
+    return stored === null ? true : stored === 'true';
+  } catch {
+    return true;
+  }
+}
+
+function writeRememberMePreference(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(REMEMBER_ME_STORAGE_KEY, String(value));
+  } catch {
+    // Ignore storage errors — the checkbox still reflects the user's intent for this session.
+  }
+}
 
 const GoogleIcon = () => (
   <svg className={styles.googleIcon} viewBox="0 0 24 24">
@@ -54,6 +76,11 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
   const [successMessage, setSuccessMessage] = useState('');
   const [showForgotPassword, setShowForgotPassword] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [rememberMe, setRememberMe] = useState(() => readRememberMePreference());
+
+  useEffect(() => {
+    writeRememberMePreference(rememberMe);
+  }, [rememberMe]);
 
   const clearState = useCallback(() => {
     setEmail('');
@@ -112,7 +139,7 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
     }
 
     if (activeTab === 'signin') {
-      const result = await dispatch(signInWithEmail({ email: email.trim(), password }));
+      const result = await dispatch(signInWithEmail({ email: email.trim(), password, rememberMe }));
       if (result.meta.requestStatus === 'fulfilled') {
         handleClose();
       }
@@ -297,8 +324,36 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
                 </button>
               </div>
               {activeTab === 'signin' && (
-                <div className={styles.forgotLink}>
-                  <button type="button" onClick={handleForgotPassword}>
+                <div className={styles.credentialsRow}>
+                  <label className={styles.rememberMe}>
+                    <input
+                      type="checkbox"
+                      className={styles.rememberMeInput}
+                      checked={rememberMe}
+                      onChange={(e) => setRememberMe(e.target.checked)}
+                    />
+                    <span className={styles.rememberMeBox} aria-hidden="true">
+                      <svg
+                        className={styles.rememberMeCheck}
+                        viewBox="0 0 16 16"
+                        width="10"
+                        height="10"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <polyline points="3 8.5 6.5 12 13 4.5" />
+                      </svg>
+                    </span>
+                    <span className={styles.rememberMeLabel}>Remember me</span>
+                  </label>
+                  <button
+                    type="button"
+                    className={styles.forgotLinkBtn}
+                    onClick={handleForgotPassword}
+                  >
                     Forgot password?
                   </button>
                 </div>

--- a/src/components/Auth/AuthModal.module.css
+++ b/src/components/Auth/AuthModal.module.css
@@ -319,22 +319,111 @@
   opacity: 0.8;
 }
 
-/* Forgot password link */
-.forgotLink {
-  text-align: right;
+/* Credentials helper row — sits below the password field with Remember Me on the left
+   and Forgot password on the right (space-between). */
+.credentialsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 2px;
 }
 
-.forgotLink button {
+/* Remember me checkbox */
+.rememberMe {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.rememberMeInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.rememberMeBox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 5px;
+  border: 1.5px solid var(--border-input);
+  background-color: var(--bg-input);
+  color: transparent;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.rememberMe:hover .rememberMeBox {
+  border-color: var(--text-muted);
+}
+
+.rememberMeInput:focus-visible + .rememberMeBox {
+  border-color: var(--text-secondary);
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.08);
+}
+
+:global([data-theme='dark']) .rememberMeInput:focus-visible + .rememberMeBox {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.1);
+}
+
+.rememberMeInput:checked + .rememberMeBox {
+  background-color: var(--bg-icon-button);
+  border-color: var(--bg-icon-button);
+  color: var(--text-icon-button);
+}
+
+.rememberMeCheck {
+  opacity: 0;
+  transform: scale(0.7);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.rememberMeInput:checked + .rememberMeBox .rememberMeCheck {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.rememberMeLabel {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  line-height: 1;
+}
+
+/* Forgot password link */
+.forgotLinkBtn {
   background: none;
   border: none;
   color: var(--text-muted);
   font-size: 12px;
+  font-weight: 500;
   cursor: pointer;
   padding: 0;
+  transition: color 0.15s ease;
+  line-height: 1;
 }
 
-.forgotLink button:hover {
+.forgotLinkBtn:hover {
   color: var(--text-secondary);
+}
+
+.forgotLinkBtn:focus-visible {
+  outline: none;
+  color: var(--text-secondary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* Spinner */

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -3575,7 +3575,9 @@ export default function MainContent() {
               aria-hidden="true"
             />
           </form>
-          <p className={styles.disclaimer}>AI outputs can be wrong. Always verify.</p>
+          {hasMessages && (
+            <p className={styles.disclaimer}>AI outputs can be wrong. Always verify.</p>
+          )}
 
           {!hasMessages && activeDropdown && currentPromptData && (
             <div className={styles.promptsDropdown} ref={dropdownRef}>

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -3116,7 +3116,8 @@
   }
 }
 
-/* Hide on narrow screens so the ambient field never crowds the input. */
+/* Narrow desktops / tablets: drop the two centre badges so the greeting
+   and input never compete with them. */
 @media (max-width: 1100px) {
   .ambientProvider_topCenter,
   .ambientProvider_bottomCenter {
@@ -3124,9 +3125,64 @@
   }
 }
 
+/* Mobile: keep the four corner badges visible as compact icon-only chips so
+   the ambient presence of every provider still reads on small screens. */
 @media (max-width: 820px) {
-  .ambientProviders {
+  .ambientProvider {
+    gap: 6px;
+    opacity: 0.7;
+  }
+
+  .ambientProviderIcon {
+    width: 28px;
+    height: 28px;
+  }
+
+  .ambientProviderIcon svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .ambientProviderText {
     display: none;
+  }
+
+  .ambientProvider_topLeft {
+    top: 12%;
+    left: 4%;
+  }
+
+  .ambientProvider_topRight {
+    top: 12%;
+    right: 4%;
+  }
+
+  .ambientProvider_bottomLeft {
+    bottom: 14%;
+    left: 4%;
+  }
+
+  .ambientProvider_bottomRight {
+    bottom: 14%;
+    right: 4%;
+  }
+}
+
+/* Very small phones: tighten further so the icons never cross the input. */
+@media (max-width: 480px) {
+  .ambientProviderIcon {
+    width: 26px;
+    height: 26px;
+  }
+
+  .ambientProvider_topLeft,
+  .ambientProvider_topRight {
+    top: 8%;
+  }
+
+  .ambientProvider_bottomLeft,
+  .ambientProvider_bottomRight {
+    bottom: 10%;
   }
 }
 

--- a/src/components/ModelsView/ModelsView.jsx
+++ b/src/components/ModelsView/ModelsView.jsx
@@ -16,6 +16,7 @@ import {
 } from '../../data/models';
 import { selectCurrentTier } from '../../store/slices/subscriptionSlice';
 import { CloseIcon, SearchIcon, CheckIcon, FilterIcon, ChevronDownIcon } from '../Icons';
+import { getProviderLogo } from '../getProviderLogo';
 // updateUserTier removed — tier is now determined by subscription, not a manual toggle
 import styles from './ModelsView.module.css';
 
@@ -98,6 +99,7 @@ function SelectedModelPill({ modelId, onSelect }) {
   const model = MODELS.find((m) => m.id === modelId);
   if (!model) return null;
   const provider = PROVIDERS[model.provider];
+  const ProviderLogo = getProviderLogo(provider.id);
 
   return (
     <div className={styles.selectedPill} onClick={() => onSelect(model)} role="button" tabIndex={0}>
@@ -108,8 +110,9 @@ function SelectedModelPill({ modelId, onSelect }) {
           '--chip-text': provider.accentText,
           '--chip-bg-dark': provider.accentBgDark,
         }}
+        aria-label={provider.name}
       >
-        {provider.logoChar}
+        <ProviderLogo size={13} />
       </span>
       <span className={styles.selectedPillLabel}>{model.name}</span>
       <span className={styles.selectedPillTag}>Default</span>
@@ -221,6 +224,7 @@ function ProviderFilterDropdown({ activeFilter, onFilterChange, providerCounts }
   }, []);
 
   const activeProvider = activeFilter !== 'all' ? PROVIDERS[activeFilter] : null;
+  const ActiveProviderLogo = activeProvider ? getProviderLogo(activeProvider.id) : null;
   const totalCount = MODELS.length;
 
   return (
@@ -232,7 +236,7 @@ function ProviderFilterDropdown({ activeFilter, onFilterChange, providerCounts }
         onClick={() => setIsOpen(!isOpen)}
       >
         <span className={styles.filterTriggerIcon}>
-          <FilterIcon />
+          {ActiveProviderLogo ? <ActiveProviderLogo size={14} /> : <FilterIcon />}
         </span>
         <span className={styles.filterTriggerLabel}>
           {activeProvider ? activeProvider.shortName : 'All providers'}
@@ -270,6 +274,7 @@ function ProviderFilterDropdown({ activeFilter, onFilterChange, providerCounts }
             const provider = PROVIDERS[pid];
             const count = providerCounts[pid] || 0;
             if (count === 0) return null;
+            const ProviderLogo = getProviderLogo(pid);
             return (
               <button
                 key={pid}
@@ -281,7 +286,17 @@ function ProviderFilterDropdown({ activeFilter, onFilterChange, providerCounts }
                   setIsOpen(false);
                 }}
               >
-                <span className={styles.filterMenuDot}>{provider.logoChar}</span>
+                <span
+                  className={styles.filterMenuDot}
+                  style={{
+                    '--chip-bg': provider.accentBg,
+                    '--chip-text': provider.accentText,
+                    '--chip-bg-dark': provider.accentBgDark,
+                  }}
+                  aria-hidden="true"
+                >
+                  <ProviderLogo size={12} />
+                </span>
                 <span className={styles.filterMenuLabel}>{provider.name}</span>
                 <span className={styles.filterMenuCount}>{count}</span>
                 {activeFilter === pid && (
@@ -302,6 +317,7 @@ function ProviderFilterDropdown({ activeFilter, onFilterChange, providerCounts }
 
 function ModelCard({ model, isSelected, isLocked, onSelect }) {
   const provider = PROVIDERS[model.provider];
+  const ProviderLogo = getProviderLogo(provider.id);
 
   return (
     <div
@@ -320,8 +336,9 @@ function ModelCard({ model, isSelected, isLocked, onSelect }) {
               '--chip-text': provider.accentText,
               '--chip-bg-dark': provider.accentBgDark,
             }}
+            aria-label={provider.name}
           >
-            {provider.logoChar}
+            <ProviderLogo size={15} />
           </span>
           <div className={styles.cardBadges}>
             {isSelected && <span className={styles.cardSelectedBadge}>Selected</span>}
@@ -388,6 +405,7 @@ function ModelCard({ model, isSelected, isLocked, onSelect }) {
 
 function ProviderGroupHeader({ providerId, count }) {
   const provider = PROVIDERS[providerId];
+  const ProviderLogo = getProviderLogo(providerId);
   return (
     <div className={styles.providerGroupHeader}>
       <span
@@ -397,8 +415,9 @@ function ProviderGroupHeader({ providerId, count }) {
           '--chip-text': provider.accentText,
           '--chip-bg-dark': provider.accentBgDark,
         }}
+        aria-hidden="true"
       >
-        {provider.logoChar}
+        <ProviderLogo size={13} />
       </span>
       <span className={styles.providerGroupName}>{provider.name}</span>
       <span className={styles.providerGroupCount}>{count}</span>
@@ -509,6 +528,7 @@ function ModelDetailPanel({
   onClose,
 }) {
   const provider = PROVIDERS[model.provider];
+  const ProviderLogo = getProviderLogo(provider.id);
   const panelRef = useRef(null);
   const nextTier = NEXT_TIER[userTier];
 
@@ -533,8 +553,9 @@ function ModelDetailPanel({
                 '--chip-text': provider.accentText,
                 '--chip-bg-dark': provider.accentBgDark,
               }}
+              aria-label={provider.name}
             >
-              {provider.logoChar}
+              <ProviderLogo size={22} />
             </span>
             <div>
               <h2 className={styles.detailName}>{model.name}</h2>

--- a/src/components/ModelsView/ModelsView.module.css
+++ b/src/components/ModelsView/ModelsView.module.css
@@ -335,10 +335,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 9px;
-  font-weight: 700;
-  background-color: var(--bg-secondary);
-  color: var(--text-secondary);
+  background-color: var(--chip-bg, var(--bg-secondary));
+  color: var(--chip-text, var(--text-secondary));
+}
+
+:global([data-theme='dark']) .filterMenuDot {
+  background-color: var(--chip-bg-dark, var(--bg-secondary));
 }
 
 .filterMenuLabel {

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -90,10 +90,15 @@ export const signInWithGoogle = createAsyncThunk(
   }
 );
 
-/** Sign in with email & password. */
+/** Sign in with email & password.
+ *
+ * The `rememberMe` flag reflects the user's "Remember me" choice. It is
+ * persisted via the AuthModal so the preference survives across sessions;
+ * the underlying Supabase client already persists the session itself.
+ */
 export const signInWithEmail = createAsyncThunk(
   'auth/signInWithEmail',
-  async ({ email, password }, { rejectWithValue }) => {
+  async ({ email, password, rememberMe = true }, { rejectWithValue }) => {
     try {
       const { data, error } = await supabase.auth.signInWithPassword({
         email,
@@ -103,6 +108,7 @@ export const signInWithEmail = createAsyncThunk(
       return {
         user: mapUser(data.user),
         session: mapSession(data.session),
+        rememberMe,
       };
     } catch (err) {
       return rejectWithValue(err.message);


### PR DESCRIPTION
…vider logos

- Hide "AI outputs can be wrong" disclaimer on the new-chat landing so it only appears once a conversation is active.
- Add a "Remember me" checkbox to the sign-in form, laid out opposite the existing "Forgot password?" link with space between. Choice persists to localStorage and is forwarded through signInWithEmail.
- Keep the four corner ambient provider badges visible on mobile as compact icon-only chips (dropping labels at <=820px and tightening positions further at <=480px) so every provider still reads at any viewport size.
- Replace letter placeholders in the Models screen with the real brand SVG logos (model cards, selected model pill, provider group headers, detail panel, and the All providers dropdown), matching the ambient provider treatment and keeping each provider's accent palette.