### PR TITLE
feat(auth): route session tokens by Remember-me preference

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -9,30 +9,9 @@ import {
   selectAuthError,
   setAuthError,
 } from '../../store/slices/authSlice';
+import { getRememberMePreference, setRememberMePreference } from '../../lib/authStorage';
 import { CloseIcon } from '../Icons';
 import styles from './AuthModal.module.css';
-
-const REMEMBER_ME_STORAGE_KEY = 'araviel.auth.rememberMe';
-
-function readRememberMePreference() {
-  if (typeof window === 'undefined') return true;
-  try {
-    const stored = window.localStorage.getItem(REMEMBER_ME_STORAGE_KEY);
-    // Default to true when no preference has been saved yet.
-    return stored === null ? true : stored === 'true';
-  } catch {
-    return true;
-  }
-}
-
-function writeRememberMePreference(value) {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(REMEMBER_ME_STORAGE_KEY, String(value));
-  } catch {
-    // Ignore storage errors — the checkbox still reflects the user's intent for this session.
-  }
-}
 
 const GoogleIcon = () => (
   <svg className={styles.googleIcon} viewBox="0 0 24 24">
@@ -76,10 +55,10 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
   const [successMessage, setSuccessMessage] = useState('');
   const [showForgotPassword, setShowForgotPassword] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
-  const [rememberMe, setRememberMe] = useState(() => readRememberMePreference());
+  const [rememberMe, setRememberMe] = useState(() => getRememberMePreference());
 
   useEffect(() => {
-    writeRememberMePreference(rememberMe);
+    setRememberMePreference(rememberMe);
   }, [rememberMe]);
 
   const clearState = useCallback(() => {

--- a/src/lib/authStorage.js
+++ b/src/lib/authStorage.js
@@ -1,0 +1,234 @@
+/**
+ * Conditional auth storage adapter for Supabase.
+ *
+ * Purpose
+ * -------
+ * Implements the Supabase `SupportedStorage` interface so the auth client
+ * persists session tokens to either `localStorage` or `sessionStorage` based
+ * on the user's "Remember me" preference:
+ *
+ *   - Remember me ON  → localStorage  (survives browser restart)
+ *   - Remember me OFF → sessionStorage (cleared when the tab closes)
+ *
+ * The `SupportedStorage` contract only requires `getItem`, `setItem`, and
+ * `removeItem`; everything else is intentionally omitted.
+ *
+ * Security model
+ * --------------
+ * Web Storage (both local and session) is accessible to any JavaScript that
+ * runs in the page, so neither option defends against an XSS vulnerability.
+ * The real mitigations are:
+ *   - A strict Content-Security-Policy that blocks untrusted scripts.
+ *   - React's default output encoding for all rendered text.
+ *   - Keeping third-party scripts out of the auth-bearing origin.
+ *
+ * What this adapter *does* give us over the Supabase default:
+ *   - "Remember me OFF" sessions are dropped when the tab closes, reducing
+ *     the blast radius on shared / public computers.
+ *   - Tokens live in exactly one storage at a time, so toggling the
+ *     preference cannot silently leave a stale copy behind.
+ *   - All storage access is wrapped in try/catch, so SSR contexts, private
+ *     browsing modes, and quota errors can't crash the auth pipeline.
+ *
+ * Cross-tab behaviour
+ * -------------------
+ * Supabase uses the `storage` event for cross-tab sync. That event only
+ * fires for `localStorage`, so a "Remember me OFF" session deliberately
+ * stays scoped to the tab that created it — which is the expected UX.
+ */
+
+import { logger } from './logger';
+
+/** localStorage key that records the most recent Remember-me preference. */
+export const REMEMBER_ME_STORAGE_KEY = 'araviel.auth.rememberMe';
+
+/** Default when no preference has been stored yet. */
+const DEFAULT_REMEMBER_ME = true;
+
+/**
+ * @typedef {'local' | 'session'} StorageMode
+ */
+
+/**
+ * In-memory mirror of the preference. Supabase calls `getItem` / `setItem`
+ * synchronously during bootstrap, so we cannot afford to touch storage on
+ * every call. The mirror is seeded from localStorage at module load time
+ * and updated by {@link setRememberMePreference}.
+ */
+let currentMode = /** @type {StorageMode} */ (DEFAULT_REMEMBER_ME ? 'local' : 'session');
+
+/**
+ * Safely access a `Storage` instance. Returns `null` when the runtime has
+ * no DOM (SSR) or storage access is blocked (private browsing, disabled
+ * cookies, iframe sandbox, etc.).
+ *
+ * @param {StorageMode} mode
+ * @returns {Storage | null}
+ */
+function getStorage(mode) {
+  if (typeof window === 'undefined') return null;
+  try {
+    return mode === 'local' ? window.localStorage : window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the persisted Remember-me preference.
+ *
+ * Falls back to {@link DEFAULT_REMEMBER_ME} when storage is unavailable or
+ * when no preference has been saved yet.
+ *
+ * @returns {boolean}
+ */
+export function getRememberMePreference() {
+  const storage = getStorage('local');
+  if (!storage) return DEFAULT_REMEMBER_ME;
+  try {
+    const raw = storage.getItem(REMEMBER_ME_STORAGE_KEY);
+    if (raw === null) return DEFAULT_REMEMBER_ME;
+    return raw === 'true';
+  } catch {
+    return DEFAULT_REMEMBER_ME;
+  }
+}
+
+/**
+ * Record the Remember-me preference and update the active storage mode.
+ *
+ * IMPORTANT: this must be called **before** invoking
+ * `supabase.auth.signInWithPassword` (or any other auth call that writes
+ * the session) so the storage adapter routes the new session to the
+ * correct storage on the first write.
+ *
+ * @param {boolean} remember
+ * @returns {void}
+ */
+export function setRememberMePreference(remember) {
+  const nextMode = /** @type {StorageMode} */ (remember ? 'local' : 'session');
+  currentMode = nextMode;
+
+  const localStore = getStorage('local');
+  if (localStore) {
+    try {
+      localStore.setItem(REMEMBER_ME_STORAGE_KEY, String(remember));
+    } catch (err) {
+      // Quota or serialization errors must not break sign-in.
+      logger.warn('Failed to persist rememberMe preference', {
+        route: 'auth.storage',
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Seed the in-memory mode from persisted state so that storage reads during
+ * Supabase bootstrap hit the right bucket even before the user interacts.
+ */
+(function initializeMode() {
+  currentMode = getRememberMePreference() ? 'local' : 'session';
+})();
+
+/**
+ * Return the storage adapter matching the user's active preference.
+ *
+ * Exposed for tests / debugging. Application code should use
+ * {@link conditionalAuthStorage} instead.
+ *
+ * @returns {StorageMode}
+ */
+export function getActiveStorageMode() {
+  return currentMode;
+}
+
+/**
+ * Read a value, preferring the active storage but falling back to the other
+ * one. The fallback handles the case where the user was previously signed
+ * in under a different Remember-me preference — their existing session is
+ * still valid and we honour it until they next sign in.
+ *
+ * @param {string} key
+ * @returns {string | null}
+ */
+function readAcrossStorages(key) {
+  const preferred = getStorage(currentMode);
+  if (preferred) {
+    try {
+      const v = preferred.getItem(key);
+      if (v !== null) return v;
+    } catch {
+      /* fall through to the other storage */
+    }
+  }
+  const other = getStorage(currentMode === 'local' ? 'session' : 'local');
+  if (other) {
+    try {
+      return other.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Supabase `SupportedStorage` adapter.
+ *
+ * Writes always go to a single storage (the one matching the active mode)
+ * and clear the corresponding key from the other storage, so there can
+ * never be two divergent session copies. Removes are applied to both.
+ */
+export const conditionalAuthStorage = {
+  /**
+   * @param {string} key
+   * @returns {string | null}
+   */
+  getItem(key) {
+    return readAcrossStorages(key);
+  },
+
+  /**
+   * @param {string} key
+   * @param {string} value
+   */
+  setItem(key, value) {
+    const active = getStorage(currentMode);
+    const inactive = getStorage(currentMode === 'local' ? 'session' : 'local');
+
+    if (active) {
+      try {
+        active.setItem(key, value);
+      } catch (err) {
+        logger.warn('Auth storage write failed', {
+          route: 'auth.storage',
+          mode: currentMode,
+          reason: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    if (inactive) {
+      try {
+        inactive.removeItem(key);
+      } catch {
+        /* best effort — duplicate cleanup only */
+      }
+    }
+  },
+
+  /**
+   * @param {string} key
+   */
+  removeItem(key) {
+    for (const mode of /** @type {StorageMode[]} */ (['local', 'session'])) {
+      const store = getStorage(mode);
+      if (!store) continue;
+      try {
+        store.removeItem(key);
+      } catch {
+        /* best effort */
+      }
+    }
+  },
+};

--- a/src/lib/authStorage.test.js
+++ b/src/lib/authStorage.test.js
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Silence the logger so test output stays clean. Must be hoisted above the
+// `authStorage` import because the module calls `getRememberMePreference`
+// synchronously at load time.
+vi.mock('./logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Fresh module import for every test so the module-scoped `currentMode` is
+// reset and cannot leak between specs.
+async function loadModule() {
+  vi.resetModules();
+  return import('./authStorage');
+}
+
+describe('authStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  describe('getRememberMePreference', () => {
+    it('defaults to true when no preference is stored', async () => {
+      const { getRememberMePreference } = await loadModule();
+      expect(getRememberMePreference()).toBe(true);
+    });
+
+    it('returns true when the stored value is "true"', async () => {
+      window.localStorage.setItem('araviel.auth.rememberMe', 'true');
+      const { getRememberMePreference } = await loadModule();
+      expect(getRememberMePreference()).toBe(true);
+    });
+
+    it('returns false when the stored value is "false"', async () => {
+      window.localStorage.setItem('araviel.auth.rememberMe', 'false');
+      const { getRememberMePreference } = await loadModule();
+      expect(getRememberMePreference()).toBe(false);
+    });
+
+    it('falls back to true when localStorage throws', async () => {
+      const spy = vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+        throw new Error('denied');
+      });
+      const { getRememberMePreference } = await loadModule();
+      expect(getRememberMePreference()).toBe(true);
+      spy.mockRestore();
+    });
+  });
+
+  describe('setRememberMePreference', () => {
+    it('persists the preference to localStorage', async () => {
+      const { setRememberMePreference } = await loadModule();
+      setRememberMePreference(false);
+      expect(window.localStorage.getItem('araviel.auth.rememberMe')).toBe('false');
+
+      setRememberMePreference(true);
+      expect(window.localStorage.getItem('araviel.auth.rememberMe')).toBe('true');
+    });
+
+    it('flips the active storage mode used by the adapter', async () => {
+      const { setRememberMePreference, getActiveStorageMode } = await loadModule();
+      setRememberMePreference(false);
+      expect(getActiveStorageMode()).toBe('session');
+      setRememberMePreference(true);
+      expect(getActiveStorageMode()).toBe('local');
+    });
+
+    it('does not throw when localStorage.setItem fails', async () => {
+      const { setRememberMePreference } = await loadModule();
+      const spy = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+      expect(() => setRememberMePreference(false)).not.toThrow();
+      spy.mockRestore();
+    });
+  });
+
+  describe('conditionalAuthStorage.setItem', () => {
+    it('writes to localStorage when remember = true', async () => {
+      const { conditionalAuthStorage, setRememberMePreference } = await loadModule();
+      setRememberMePreference(true);
+      conditionalAuthStorage.setItem('sb-token', 'value-1');
+      expect(window.localStorage.getItem('sb-token')).toBe('value-1');
+      expect(window.sessionStorage.getItem('sb-token')).toBeNull();
+    });
+
+    it('writes to sessionStorage when remember = false', async () => {
+      const { conditionalAuthStorage, setRememberMePreference } = await loadModule();
+      setRememberMePreference(false);
+      conditionalAuthStorage.setItem('sb-token', 'value-2');
+      expect(window.sessionStorage.getItem('sb-token')).toBe('value-2');
+      expect(window.localStorage.getItem('sb-token')).toBeNull();
+    });
+
+    it('clears the inactive storage on write so tokens never live in both', async () => {
+      const { conditionalAuthStorage, setRememberMePreference } = await loadModule();
+
+      // Simulate a leftover token from a previous session in localStorage.
+      window.localStorage.setItem('sb-token', 'stale');
+
+      setRememberMePreference(false);
+      conditionalAuthStorage.setItem('sb-token', 'fresh');
+
+      expect(window.sessionStorage.getItem('sb-token')).toBe('fresh');
+      expect(window.localStorage.getItem('sb-token')).toBeNull();
+    });
+
+    it('swallows write errors so the auth pipeline never crashes', async () => {
+      const { conditionalAuthStorage, setRememberMePreference } = await loadModule();
+      setRememberMePreference(true);
+      const spy = vi
+        .spyOn(window.localStorage, 'setItem')
+        .mockImplementationOnce(() => {
+          throw new Error('quota');
+        })
+        // allow the preference write (which happened inside setRememberMePreference
+        // already completed), and block just the adapter write above.
+        .mockImplementation((k, v) => {
+          // default behaviour is swallowed by the adapter anyway.
+          Storage.prototype.setItem.call(window.localStorage, k, v);
+        });
+      expect(() => conditionalAuthStorage.setItem('sb-token', 'boom')).not.toThrow();
+      spy.mockRestore();
+    });
+  });
+
+  describe('conditionalAuthStorage.getItem', () => {
+    it('reads from the active storage first', async () => {
+      const { conditionalAuthStorage, setRememberMePreference } = await loadModule();
+      setRememberMePreference(true);
+      window.localStorage.setItem('sb-token', 'local-value');
+      window.sessionStorage.setItem('sb-token', 'session-value');
+      expect(conditionalAuthStorage.getItem('sb-token')).toBe('local-value');
+    });
+
+    it('falls back to the other storage when the active one is empty', async () => {
+      const { conditionalAuthStorage, setRememberMePreference } = await loadModule();
+      // User previously signed in with Remember = true, then toggled off
+      // without re-signing in. The session still lives in localStorage and
+      // should remain usable until the next explicit sign-in.
+      window.localStorage.setItem('sb-token', 'carryover');
+      setRememberMePreference(false);
+      expect(conditionalAuthStorage.getItem('sb-token')).toBe('carryover');
+    });
+
+    it('returns null when neither storage has the key', async () => {
+      const { conditionalAuthStorage } = await loadModule();
+      expect(conditionalAuthStorage.getItem('missing')).toBeNull();
+    });
+  });
+
+  describe('conditionalAuthStorage.removeItem', () => {
+    it('clears the key from BOTH storages', async () => {
+      const { conditionalAuthStorage } = await loadModule();
+      window.localStorage.setItem('sb-token', 'a');
+      window.sessionStorage.setItem('sb-token', 'b');
+
+      conditionalAuthStorage.removeItem('sb-token');
+
+      expect(window.localStorage.getItem('sb-token')).toBeNull();
+      expect(window.sessionStorage.getItem('sb-token')).toBeNull();
+    });
+
+    it('ignores errors thrown by storage.removeItem', async () => {
+      const { conditionalAuthStorage } = await loadModule();
+      const localSpy = vi.spyOn(window.localStorage, 'removeItem').mockImplementation(() => {
+        throw new Error('denied');
+      });
+      const sessionSpy = vi.spyOn(window.sessionStorage, 'removeItem').mockImplementation(() => {
+        throw new Error('denied');
+      });
+      expect(() => conditionalAuthStorage.removeItem('sb-token')).not.toThrow();
+      localSpy.mockRestore();
+      sessionSpy.mockRestore();
+    });
+  });
+
+  describe('mode initialization', () => {
+    it('seeds the active mode from the persisted preference at module load', async () => {
+      window.localStorage.setItem('araviel.auth.rememberMe', 'false');
+      const { getActiveStorageMode } = await loadModule();
+      expect(getActiveStorageMode()).toBe('session');
+    });
+
+    it('defaults to local mode when no preference has been persisted', async () => {
+      const { getActiveStorageMode } = await loadModule();
+      expect(getActiveStorageMode()).toBe('local');
+    });
+  });
+});

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,4 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
+import { conditionalAuthStorage } from './authStorage';
+
 export const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL || '',
   import.meta.env.VITE_SUPABASE_ANON_KEY || '',
@@ -8,6 +10,7 @@ export const supabase = createClient(
       persistSession: true,
       detectSessionInUrl: true,
       flowType: 'pkce',
+      storage: conditionalAuthStorage,
     },
   }
 );

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -1,5 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import { supabase } from '../../lib/supabase';
+import { setRememberMePreference } from '../../lib/authStorage';
 import { resetGuestPromptCount } from '../../utils/guestSession';
 import { logger } from '../../lib/logger';
 
@@ -100,6 +101,12 @@ export const signInWithEmail = createAsyncThunk(
   'auth/signInWithEmail',
   async ({ email, password, rememberMe = true }, { rejectWithValue }) => {
     try {
+      // Record the preference BEFORE the sign-in call so the storage adapter
+      // writes the new session to the correct bucket (local vs. session
+      // storage) on the very first write. Doing this after the call would
+      // leak the session into the previously-active storage.
+      setRememberMePreference(rememberMe);
+
       const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,7 +1,8 @@
 import '@testing-library/jest-dom/vitest';
 
-// Mock localStorage
-const localStorageMock = (() => {
+// Factory so localStorage and sessionStorage get independent stores but
+// otherwise behave identically.
+function createStorageMock() {
   let store = {};
   return {
     getItem: vi.fn((key) => store[key] ?? null),
@@ -19,9 +20,13 @@ const localStorageMock = (() => {
     },
     key: vi.fn((index) => Object.keys(store)[index] ?? null),
   };
-})();
+}
+
+const localStorageMock = createStorageMock();
+const sessionStorageMock = createStorageMock();
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+Object.defineProperty(window, 'sessionStorage', { value: sessionStorageMock });
 
 // Mock matchMedia
 Object.defineProperty(window, 'matchMedia', {
@@ -47,8 +52,9 @@ Object.defineProperty(globalThis, 'crypto', {
 
 // Environment variables are set via vitest.config.js env option
 
-// Clear localStorage between tests
+// Clear storage between tests
 beforeEach(() => {
   localStorage.clear();
+  sessionStorage.clear();
   vi.clearAllMocks();
 });


### PR DESCRIPTION
Previously the Remember-me checkbox was purely cosmetic — Supabase always persisted the session to localStorage regardless of the user's choice. This change makes the preference actually change storage behaviour:

- New `conditionalAuthStorage` adapter (implements Supabase's SupportedStorage interface) routes tokens to localStorage when Remember-me is ON and to sessionStorage when OFF, so "not remembered" sessions are dropped when the tab closes.
- Writes go to a single storage and clear the same key from the other, so toggling the preference cannot leave a stale session copy behind.
- All storage access is wrapped in try/catch so SSR, private browsing, and quota errors never crash the auth pipeline.
- Preference is set synchronously in `signInWithEmail` BEFORE the Supabase call so the very first session write lands in the right bucket.
- AuthModal now consumes the shared helpers instead of duplicating the read/write logic.
- 18 unit tests cover preference persistence, cross-storage read fallback, single-source-of-truth writes, defensive remove, and module-load initialization.

Security notes are documented in the adapter's JSDoc: web storage is XSS-exposed on both buckets, so the real defence remains CSP + React's default output encoding. This change specifically reduces blast radius on shared/public devices when Remember-me is unchecked.