### PR TITLE
feat(apex): refresh quick-prompt pills and wire Image pill to modality

### DIFF
--- a/src/components/Icons.jsx
+++ b/src/components/Icons.jsx
@@ -456,6 +456,24 @@ export const PhotoIcon = () => (
   </svg>
 );
 
+export const PaletteIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 2a10 10 0 1 0 0 20c1.5 0 2-1 2-2a2 2 0 0 0-2-2h-1a2 2 0 0 1-2-2 2 2 0 0 1 2-2h4a5 5 0 0 0 5-5c0-4-4-7-9-7z"></path>
+    <circle cx="7.5" cy="10.5" r="1"></circle>
+    <circle cx="12" cy="7.5" r="1"></circle>
+    <circle cx="16.5" cy="10.5" r="1"></circle>
+  </svg>
+);
+
 export const FileIcon = () => (
   <svg
     width="20"

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -45,6 +45,7 @@ import {
   selectCreditBalance,
   setCreditBalance,
   setSelectedModality,
+  revertQuickPromptImageOverride,
 } from '../../store/slices/chatSlice';
 import { recordMessage } from '../../store/slices/analyticsSlice';
 import {
@@ -246,6 +247,7 @@ const MOOD_OPTIONS = [
 ];
 
 import { promptsData, quickPromptKeys } from '../../utils/quickPromptsData';
+import { handleQuickPromptSelection } from '../../utils/quickPromptHandler';
 
 // SVG icon components for cloud providers
 function GoogleDriveIcon() {
@@ -2112,6 +2114,11 @@ export default function MainContent() {
       imageQuality: willGenerateImage ? imageQuality : undefined,
       images: compressedImages.length > 0 ? compressedImages : undefined,
     });
+
+    // Image quick-prompt one-shot: after the message completes, revert
+    // modality + quality to whatever the user had before clicking the pill.
+    // A no-op when no override is active.
+    dispatch(revertQuickPromptImageOverride());
   };
 
   // Auto-submit when navigating from another view (e.g. Image Gallery quick prompt).
@@ -2204,8 +2211,14 @@ export default function MainContent() {
     }
   };
 
-  const handlePromptSelect = (text) => {
-    dispatch(setInputValue(text + ' '));
+  const handlePromptSelect = (pillKey, itemIndex) => {
+    const applied = handleQuickPromptSelection({
+      dispatch,
+      pillKey,
+      itemIndex,
+      currentTier,
+    });
+    if (!applied) return;
     setActiveDropdown(null);
     if (textareaRef.current) {
       textareaRef.current.focus();
@@ -3606,7 +3619,7 @@ export default function MainContent() {
                     <button
                       key={index}
                       className={styles.promptItem}
-                      onClick={() => handlePromptSelect(item.text)}
+                      onClick={() => handlePromptSelect(activeDropdown, index)}
                     >
                       <span className={styles.promptItemIcon}>
                         <ItemIcon />

--- a/src/config/credits.js
+++ b/src/config/credits.js
@@ -28,6 +28,24 @@ export const IMAGE_QUALITY_OPTIONS = [
   { value: 'ultra', label: 'Ultra', cost: 4 },
 ];
 
+// Tier-aware image quality defaults used when switching modality via a
+// shortcut (e.g. the Image quick-prompt pill). Free stays on the cheapest
+// tier, Lite steps up to HD, Pro gets Ultra by default.
+export const TIER_IMAGE_QUALITY_DEFAULTS = {
+  free: 'standard',
+  lite: 'hd',
+  pro: 'ultra',
+};
+
+/**
+ * Resolve the default image quality for a given subscription tier, falling
+ * back to 'standard' if the tier is unknown.
+ * @param {string | null | undefined} tier
+ * @returns {'standard' | 'hd' | 'ultra'}
+ */
+export const getDefaultImageQualityForTier = (tier) =>
+  TIER_IMAGE_QUALITY_DEFAULTS[tier] || 'standard';
+
 export const IMAGE_PACKS = {
   starter: { credits: 20, label: 'Starter Pack', price: '£3.99' },
   creator: { credits: 50, label: 'Creator Pack', price: '£7.99' },

--- a/src/config/credits.test.js
+++ b/src/config/credits.test.js
@@ -8,6 +8,8 @@ import {
   PACK_EXPIRY_DAYS,
   GUEST_TEXT_LIMIT,
   GUEST_IMAGE_LIMIT,
+  TIER_IMAGE_QUALITY_DEFAULTS,
+  getDefaultImageQualityForTier,
 } from './credits';
 
 describe('credits config', () => {
@@ -95,6 +97,37 @@ describe('credits config', () => {
     it('pack credits scale up', () => {
       expect(IMAGE_PACKS.starter.credits).toBeLessThan(IMAGE_PACKS.creator.credits);
       expect(IMAGE_PACKS.creator.credits).toBeLessThan(IMAGE_PACKS.studio.credits);
+    });
+  });
+
+  describe('TIER_IMAGE_QUALITY_DEFAULTS', () => {
+    it('maps each tier to a valid quality value', () => {
+      expect(TIER_IMAGE_QUALITY_DEFAULTS.free).toBe('standard');
+      expect(TIER_IMAGE_QUALITY_DEFAULTS.lite).toBe('hd');
+      expect(TIER_IMAGE_QUALITY_DEFAULTS.pro).toBe('ultra');
+    });
+
+    it('default quality escalates with tier (cost strictly non-decreasing)', () => {
+      expect(IMAGE_QUALITY_COSTS[TIER_IMAGE_QUALITY_DEFAULTS.free]).toBeLessThanOrEqual(
+        IMAGE_QUALITY_COSTS[TIER_IMAGE_QUALITY_DEFAULTS.lite]
+      );
+      expect(IMAGE_QUALITY_COSTS[TIER_IMAGE_QUALITY_DEFAULTS.lite]).toBeLessThanOrEqual(
+        IMAGE_QUALITY_COSTS[TIER_IMAGE_QUALITY_DEFAULTS.pro]
+      );
+    });
+  });
+
+  describe('getDefaultImageQualityForTier', () => {
+    it('returns the tier-specific default', () => {
+      expect(getDefaultImageQualityForTier('free')).toBe('standard');
+      expect(getDefaultImageQualityForTier('lite')).toBe('hd');
+      expect(getDefaultImageQualityForTier('pro')).toBe('ultra');
+    });
+
+    it('falls back to standard for unknown or missing tiers', () => {
+      expect(getDefaultImageQualityForTier(null)).toBe('standard');
+      expect(getDefaultImageQualityForTier(undefined)).toBe('standard');
+      expect(getDefaultImageQualityForTier('enterprise')).toBe('standard');
     });
   });
 

--- a/src/store/slices/analyticsSlice.js
+++ b/src/store/slices/analyticsSlice.js
@@ -2,6 +2,10 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const STORAGE_KEY = 'araviel-analytics';
 const MILESTONES = [10, 50, 100, 500, 1000, 5000];
+// Bounded ring buffer for client-side product telemetry events. Keeps the
+// localStorage payload predictable while still retaining recent history for
+// debugging and downstream aggregation.
+const EVENT_HISTORY_LIMIT = 500;
 
 function loadFromStorage() {
   try {
@@ -48,6 +52,7 @@ const defaultState = {
     latencyCount: 0,
     latencyByModel: {},
     promptSnippets: [],
+    events: [],
   },
   monthlyBudget: null,
   budgetAlertThreshold: 0.8,
@@ -186,15 +191,39 @@ const analyticsSlice = createSlice({
       Object.assign(state, defaultState);
       saveToStorage(state);
     },
+
+    /**
+     * Record a structured product-telemetry event.
+     * Kept deliberately small: a name and a flat bag of properties. The
+     * buffer is capped at EVENT_HISTORY_LIMIT to bound localStorage growth.
+     *
+     * @param {{ name: string, properties?: object, timestamp?: number }} payload
+     */
+    recordEvent(state, action) {
+      const { name, properties, timestamp } = action.payload || {};
+      if (!name) return;
+      const stats = state.lifetimeStats;
+      if (!Array.isArray(stats.events)) stats.events = [];
+      stats.events.push({
+        name,
+        properties: properties || {},
+        timestamp: timestamp || Date.now(),
+      });
+      if (stats.events.length > EVENT_HISTORY_LIMIT) {
+        stats.events = stats.events.slice(-EVENT_HISTORY_LIMIT);
+      }
+      saveToStorage(state);
+    },
   },
 });
 
-export const { recordMessage, setMonthlyBudget, setBudgetAlertThreshold, resetStats } =
+export const { recordMessage, recordEvent, setMonthlyBudget, setBudgetAlertThreshold, resetStats } =
   analyticsSlice.actions;
 
 // Selectors
 export const selectLifetimeStats = (state) => state.analytics.lifetimeStats;
 export const selectMonthlyBudget = (state) => state.analytics.monthlyBudget;
 export const selectBudgetAlertThreshold = (state) => state.analytics.budgetAlertThreshold;
+export const selectRecentEvents = (state) => state.analytics.lifetimeStats.events || [];
 
 export default analyticsSlice.reducer;

--- a/src/store/slices/analyticsSlice.test.js
+++ b/src/store/slices/analyticsSlice.test.js
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import analyticsReducer, {
   recordMessage,
+  recordEvent,
   setMonthlyBudget,
   setBudgetAlertThreshold,
   resetStats,
   selectLifetimeStats,
   selectMonthlyBudget,
   selectBudgetAlertThreshold,
+  selectRecentEvents,
 } from './analyticsSlice';
 
 describe('analyticsSlice', () => {
@@ -128,10 +130,7 @@ describe('analyticsSlice', () => {
     it('does not overwrite firstUsedAt on subsequent messages', () => {
       let state = analyticsReducer(defaultState, recordMessage(basePayload));
       const laterTimestamp = new Date(Date.now() + 10000).toISOString();
-      state = analyticsReducer(
-        state,
-        recordMessage({ ...basePayload, timestamp: laterTimestamp })
-      );
+      state = analyticsReducer(state, recordMessage({ ...basePayload, timestamp: laterTimestamp }));
       expect(state.lifetimeStats.firstUsedAt).toBe(basePayload.timestamp);
     });
 
@@ -192,6 +191,53 @@ describe('analyticsSlice', () => {
     it('sets the threshold', () => {
       const state = analyticsReducer(defaultState, setBudgetAlertThreshold(0.9));
       expect(state.budgetAlertThreshold).toBe(0.9);
+    });
+  });
+
+  describe('recordEvent', () => {
+    it('appends a structured event with default timestamp', () => {
+      const state = analyticsReducer(
+        defaultState,
+        recordEvent({ name: 'quick_prompt_selected', properties: { pill_category: 'code' } })
+      );
+      expect(state.lifetimeStats.events).toHaveLength(1);
+      const evt = state.lifetimeStats.events[0];
+      expect(evt.name).toBe('quick_prompt_selected');
+      expect(evt.properties).toEqual({ pill_category: 'code' });
+      expect(typeof evt.timestamp).toBe('number');
+    });
+
+    it('preserves a provided timestamp', () => {
+      const state = analyticsReducer(
+        defaultState,
+        recordEvent({ name: 'x', properties: {}, timestamp: 1234567890 })
+      );
+      expect(state.lifetimeStats.events[0].timestamp).toBe(1234567890);
+    });
+
+    it('ignores payloads without a name', () => {
+      const state = analyticsReducer(defaultState, recordEvent({ properties: { a: 1 } }));
+      expect(state.lifetimeStats.events).toHaveLength(0);
+    });
+
+    it('defaults properties to an empty object', () => {
+      const state = analyticsReducer(defaultState, recordEvent({ name: 'x' }));
+      expect(state.lifetimeStats.events[0].properties).toEqual({});
+    });
+
+    it('caps the event buffer at 500', () => {
+      let state = defaultState;
+      for (let i = 0; i < 510; i++) {
+        state = analyticsReducer(state, recordEvent({ name: `e${i}`, properties: { i } }));
+      }
+      expect(state.lifetimeStats.events).toHaveLength(500);
+      expect(state.lifetimeStats.events[0].name).toBe('e10');
+      expect(state.lifetimeStats.events[499].name).toBe('e509');
+    });
+
+    it('selectRecentEvents returns the latest event array', () => {
+      const state = analyticsReducer(defaultState, recordEvent({ name: 'a', properties: {} }));
+      expect(selectRecentEvents({ analytics: state })).toHaveLength(1);
     });
   });
 

--- a/src/store/slices/chatSlice.js
+++ b/src/store/slices/chatSlice.js
@@ -32,6 +32,12 @@ const initialState = {
   pendingModality: null, // null = default 'text', or 'image' when prompt originates from image view
   selectedModality: 'text', // 'text' | 'image' — user-selected modality in ModalityBar
   imageQuality: 'standard', // 'standard' | 'hd' | 'ultra'
+  // One-shot override triggered by the Image quick-prompt pill. When set, the
+  // modality/quality are forced to image + tier default for the next message,
+  // then reverted to `previousModality` / `previousQuality` after submit. Any
+  // manual change to a *different* value clears the override so the user's
+  // explicit choice wins.
+  quickPromptImageOverride: null, // { previousModality, previousQuality } | null
   creditBalance: null, // { monthly, packs, combined, tier, cycleResetsAt } — fetched from backend
   activeProjectId: null, // set when starting a chat from a project workspace
   // Imported conversation context for continuing imported chats
@@ -125,6 +131,7 @@ const chatSlice = createSlice({
       state.pendingModality = null;
       state.selectedModality = 'text';
       state.imageQuality = 'standard';
+      state.quickPromptImageOverride = null;
       state.activeProjectId = null;
       state.importedContext = null;
     },
@@ -141,10 +148,48 @@ const chatSlice = createSlice({
       state.pendingModality = action.payload;
     },
     setSelectedModality: (state, action) => {
-      state.selectedModality = action.payload;
+      const next = action.payload;
+      // A real value change (not a no-op re-select) counts as the user taking
+      // manual control and cancels any pending quick-prompt one-shot.
+      if (state.quickPromptImageOverride && next !== state.selectedModality) {
+        state.quickPromptImageOverride = null;
+      }
+      state.selectedModality = next;
     },
     setImageQuality: (state, action) => {
-      state.imageQuality = action.payload;
+      const next = action.payload;
+      if (state.quickPromptImageOverride && next !== state.imageQuality) {
+        state.quickPromptImageOverride = null;
+      }
+      state.imageQuality = next;
+    },
+    /**
+     * Apply the Image quick-prompt one-shot override. Saves the current
+     * modality + quality (only the first time, so repeated clicks don't
+     * overwrite the original), then forces modality to 'image' and quality
+     * to the supplied tier default.
+     */
+    applyImageQuickPromptOverride: (state, action) => {
+      const tierDefaultQuality = action.payload;
+      if (!state.quickPromptImageOverride) {
+        state.quickPromptImageOverride = {
+          previousModality: state.selectedModality,
+          previousQuality: state.imageQuality,
+        };
+      }
+      state.selectedModality = 'image';
+      state.imageQuality = tierDefaultQuality;
+    },
+    /**
+     * Revert the Image quick-prompt one-shot override. Called after the
+     * next message has been submitted so the modality bounces back to
+     * whatever it was before the pill was clicked.
+     */
+    revertQuickPromptImageOverride: (state) => {
+      if (!state.quickPromptImageOverride) return;
+      state.selectedModality = state.quickPromptImageOverride.previousModality;
+      state.imageQuality = state.quickPromptImageOverride.previousQuality;
+      state.quickPromptImageOverride = null;
     },
     setCreditBalance: (state, action) => {
       state.creditBalance = action.payload;
@@ -201,6 +246,8 @@ export const {
   setPendingModality,
   setSelectedModality,
   setImageQuality,
+  applyImageQuickPromptOverride,
+  revertQuickPromptImageOverride,
   setCreditBalance,
   setActiveProjectId,
   setImportedContext,
@@ -228,6 +275,7 @@ export const selectPendingAutoSubmit = (state) => state.chat.pendingAutoSubmit;
 export const selectPendingModality = (state) => state.chat.pendingModality;
 export const selectSelectedModality = (state) => state.chat.selectedModality;
 export const selectImageQuality = (state) => state.chat.imageQuality;
+export const selectQuickPromptImageOverride = (state) => state.chat.quickPromptImageOverride;
 export const selectCreditBalance = (state) => state.chat.creditBalance;
 export const selectActiveProjectId = (state) => state.chat.activeProjectId;
 export const selectConversations = (state) => state.chat.conversations;

--- a/src/store/slices/chatSlice.test.js
+++ b/src/store/slices/chatSlice.test.js
@@ -21,6 +21,8 @@ import chatReducer, {
   setPendingModality,
   setSelectedModality,
   setImageQuality,
+  applyImageQuickPromptOverride,
+  revertQuickPromptImageOverride,
   setCreditBalance,
   setActiveProjectId,
   setImportedContext,
@@ -46,6 +48,7 @@ import chatReducer, {
   selectPendingModality,
   selectSelectedModality,
   selectImageQuality,
+  selectQuickPromptImageOverride,
   selectCreditBalance,
   selectActiveProjectId,
   selectConversations,
@@ -83,6 +86,7 @@ describe('chatSlice', () => {
       expect(defaultState.isProcessing).toBe(false);
       expect(defaultState.selectedModality).toBe('text');
       expect(defaultState.imageQuality).toBe('standard');
+      expect(defaultState.quickPromptImageOverride).toBeNull();
       expect(defaultState.creditBalance).toBeNull();
       expect(defaultState.conversations).toEqual([]);
     });
@@ -302,6 +306,91 @@ describe('chatSlice', () => {
     });
   });
 
+  describe('quick-prompt image override', () => {
+    it('applyImageQuickPromptOverride saves previous values and switches to image + tier default', () => {
+      const state = chatReducer(defaultState, applyImageQuickPromptOverride('hd'));
+      expect(state.selectedModality).toBe('image');
+      expect(state.imageQuality).toBe('hd');
+      expect(state.quickPromptImageOverride).toEqual({
+        previousModality: 'text',
+        previousQuality: 'standard',
+      });
+    });
+
+    it('repeated applyImageQuickPromptOverride does not overwrite the original previous values', () => {
+      let state = chatReducer(defaultState, applyImageQuickPromptOverride('hd'));
+      // Simulate a second click, which should keep the original previous values.
+      state = chatReducer(state, applyImageQuickPromptOverride('ultra'));
+      expect(state.quickPromptImageOverride).toEqual({
+        previousModality: 'text',
+        previousQuality: 'standard',
+      });
+      expect(state.imageQuality).toBe('ultra');
+    });
+
+    it('revertQuickPromptImageOverride restores previous modality and quality and clears the override', () => {
+      let state = chatReducer(defaultState, applyImageQuickPromptOverride('ultra'));
+      state = chatReducer(state, revertQuickPromptImageOverride());
+      expect(state.selectedModality).toBe('text');
+      expect(state.imageQuality).toBe('standard');
+      expect(state.quickPromptImageOverride).toBeNull();
+    });
+
+    it('revertQuickPromptImageOverride is a no-op when no override is active', () => {
+      const state = chatReducer(defaultState, revertQuickPromptImageOverride());
+      expect(state).toEqual(defaultState);
+    });
+
+    it('a manual setSelectedModality to a different value clears the override (user wins)', () => {
+      let state = chatReducer(defaultState, applyImageQuickPromptOverride('hd'));
+      state = chatReducer(state, setSelectedModality('text'));
+      expect(state.selectedModality).toBe('text');
+      expect(state.quickPromptImageOverride).toBeNull();
+    });
+
+    it('a manual setImageQuality to a different value clears the override (user wins)', () => {
+      let state = chatReducer(defaultState, applyImageQuickPromptOverride('hd'));
+      state = chatReducer(state, setImageQuality('ultra'));
+      expect(state.imageQuality).toBe('ultra');
+      expect(state.quickPromptImageOverride).toBeNull();
+    });
+
+    it('a no-op manual setSelectedModality (same value) keeps the one-shot alive', () => {
+      let state = chatReducer(defaultState, applyImageQuickPromptOverride('hd'));
+      // User reselects "image" — already set by the override, no actual change.
+      state = chatReducer(state, setSelectedModality('image'));
+      expect(state.quickPromptImageOverride).toEqual({
+        previousModality: 'text',
+        previousQuality: 'standard',
+      });
+    });
+
+    it('a no-op manual setImageQuality (same value) keeps the one-shot alive', () => {
+      let state = chatReducer(defaultState, applyImageQuickPromptOverride('hd'));
+      state = chatReducer(state, setImageQuality('hd'));
+      expect(state.quickPromptImageOverride).toEqual({
+        previousModality: 'text',
+        previousQuality: 'standard',
+      });
+    });
+
+    it('createNewChat clears any active override', () => {
+      let state = chatReducer(defaultState, applyImageQuickPromptOverride('ultra'));
+      state = chatReducer(state, createNewChat());
+      expect(state.quickPromptImageOverride).toBeNull();
+      expect(state.selectedModality).toBe('text');
+      expect(state.imageQuality).toBe('standard');
+    });
+
+    it('selectQuickPromptImageOverride returns the current override shape', () => {
+      const state = chatReducer(defaultState, applyImageQuickPromptOverride('hd'));
+      expect(selectQuickPromptImageOverride({ chat: state })).toEqual({
+        previousModality: 'text',
+        previousQuality: 'standard',
+      });
+    });
+  });
+
   describe('setCreditBalance', () => {
     it('sets the credit balance', () => {
       const balance = { monthly: 100, packs: 20 };
@@ -347,10 +436,7 @@ describe('chatSlice', () => {
         defaultState,
         setConversations({ conversations: [{ id: '1' }], total: 3 })
       );
-      state = chatReducer(
-        state,
-        appendConversations({ conversations: [{ id: '2' }], total: 3 })
-      );
+      state = chatReducer(state, appendConversations({ conversations: [{ id: '2' }], total: 3 }));
       expect(state.conversations).toHaveLength(2);
       expect(state.conversationsTotal).toBe(3);
     });

--- a/src/utils/quickPromptHandler.js
+++ b/src/utils/quickPromptHandler.js
@@ -1,0 +1,61 @@
+import { setInputValue, applyImageQuickPromptOverride } from '../store/slices/chatSlice';
+import { recordEvent } from '../store/slices/analyticsSlice';
+import { getDefaultImageQualityForTier } from '../config/credits';
+import { promptsData, IMAGE_QUICK_PROMPT_KEY } from './quickPromptsData';
+
+/**
+ * Resolve the prompt item for a given pill + index.
+ * Returns null when the pill or index is unknown.
+ *
+ * @param {string} pillKey
+ * @param {number} itemIndex
+ * @returns {{ text: string, icon: Function } | null}
+ */
+export const getQuickPromptItem = (pillKey, itemIndex) =>
+  promptsData[pillKey]?.items?.[itemIndex] ?? null;
+
+/**
+ * Dispatch the full side-effect chain triggered by selecting a quick-prompt
+ * dropdown item. Extracted so the flow is unit-testable without having to
+ * render the MainContent component tree.
+ *
+ * Side effects, in order:
+ *   1. Prefill the chat input with the prompt text (+ trailing space).
+ *   2. For the Image pill, fire the one-shot modality + quality override
+ *      using the user's tier-appropriate default quality.
+ *   3. Emit a `quick_prompt_selected` telemetry event.
+ *
+ * @param {object} params
+ * @param {Function} params.dispatch - Redux dispatch.
+ * @param {string} params.pillKey - e.g. 'code', 'image'.
+ * @param {number} params.itemIndex - 0-based index within the pill.
+ * @param {string | null | undefined} params.currentTier - 'free' | 'lite' | 'pro'.
+ * @returns {{ text: string, isImagePill: boolean } | null}
+ *   The prompt metadata applied, or null if the selection was invalid.
+ */
+export function handleQuickPromptSelection({ dispatch, pillKey, itemIndex, currentTier }) {
+  const item = getQuickPromptItem(pillKey, itemIndex);
+  if (!item) return null;
+
+  const isImagePill = pillKey === IMAGE_QUICK_PROMPT_KEY;
+
+  dispatch(setInputValue(item.text + ' '));
+
+  if (isImagePill) {
+    dispatch(applyImageQuickPromptOverride(getDefaultImageQualityForTier(currentTier)));
+  }
+
+  dispatch(
+    recordEvent({
+      name: 'quick_prompt_selected',
+      properties: {
+        pill_category: pillKey,
+        prompt_index: itemIndex,
+        user_tier: currentTier || 'guest',
+        prompt_type_set: isImagePill ? 'image' : 'text',
+      },
+    })
+  );
+
+  return { text: item.text, isImagePill };
+}

--- a/src/utils/quickPromptHandler.test.js
+++ b/src/utils/quickPromptHandler.test.js
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import chatReducer, {
+  selectInputValue,
+  selectSelectedModality,
+  selectImageQuality,
+  selectQuickPromptImageOverride,
+  setImageQuality,
+  setSelectedModality,
+  revertQuickPromptImageOverride,
+} from '../store/slices/chatSlice';
+import analyticsReducer, { selectRecentEvents } from '../store/slices/analyticsSlice';
+import { handleQuickPromptSelection, getQuickPromptItem } from './quickPromptHandler';
+import { promptsData, quickPromptKeys, IMAGE_QUICK_PROMPT_KEY } from './quickPromptsData';
+
+vi.mock('../data/models', () => ({
+  isModelAccessible: vi.fn(() => true),
+}));
+
+const buildStore = () =>
+  configureStore({
+    reducer: {
+      chat: chatReducer,
+      analytics: analyticsReducer,
+    },
+  });
+
+describe('handleQuickPromptSelection — quick prompt flow', () => {
+  let store;
+
+  beforeEach(() => {
+    localStorage.clear();
+    store = buildStore();
+  });
+
+  describe('non-image pills', () => {
+    for (const pillKey of quickPromptKeys.filter((k) => k !== IMAGE_QUICK_PROMPT_KEY)) {
+      it(`${pillKey}: sets input text and keeps modality as text`, () => {
+        const pill = promptsData[pillKey];
+        for (let index = 0; index < pill.items.length; index++) {
+          const scopedStore = buildStore();
+          const item = pill.items[index];
+          const result = handleQuickPromptSelection({
+            dispatch: scopedStore.dispatch,
+            pillKey,
+            itemIndex: index,
+            currentTier: 'free',
+          });
+
+          expect(result).toEqual({ text: item.text, isImagePill: false });
+          expect(selectInputValue(scopedStore.getState())).toBe(item.text + ' ');
+          expect(selectSelectedModality(scopedStore.getState())).toBe('text');
+          expect(selectImageQuality(scopedStore.getState())).toBe('standard');
+          expect(selectQuickPromptImageOverride(scopedStore.getState())).toBeNull();
+        }
+      });
+    }
+  });
+
+  describe('image pill', () => {
+    const tierExpectations = [
+      { tier: 'free', expected: 'standard' },
+      { tier: 'lite', expected: 'hd' },
+      { tier: 'pro', expected: 'ultra' },
+    ];
+
+    for (const { tier, expected } of tierExpectations) {
+      it(`applies the image one-shot for ${tier} tier (quality: ${expected})`, () => {
+        const result = handleQuickPromptSelection({
+          dispatch: store.dispatch,
+          pillKey: IMAGE_QUICK_PROMPT_KEY,
+          itemIndex: 0,
+          currentTier: tier,
+        });
+
+        const expectedText = promptsData[IMAGE_QUICK_PROMPT_KEY].items[0].text;
+        expect(result).toEqual({ text: expectedText, isImagePill: true });
+
+        const state = store.getState();
+        // Both input text AND prompt type state must update (not one or the other).
+        expect(selectInputValue(state)).toBe(expectedText + ' ');
+        expect(selectSelectedModality(state)).toBe('image');
+        expect(selectImageQuality(state)).toBe(expected);
+        expect(selectQuickPromptImageOverride(state)).toEqual({
+          previousModality: 'text',
+          previousQuality: 'standard',
+        });
+      });
+    }
+
+    it('falls back to the lowest-quality default for an unknown tier', () => {
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: IMAGE_QUICK_PROMPT_KEY,
+        itemIndex: 0,
+        currentTier: null,
+      });
+      expect(selectImageQuality(store.getState())).toBe('standard');
+      expect(selectSelectedModality(store.getState())).toBe('image');
+    });
+
+    it('revert on submit restores the previous modality and quality', () => {
+      // User was on text + standard. Pick an image prompt → override kicks in.
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: IMAGE_QUICK_PROMPT_KEY,
+        itemIndex: 1,
+        currentTier: 'pro',
+      });
+      expect(selectSelectedModality(store.getState())).toBe('image');
+      expect(selectImageQuality(store.getState())).toBe('ultra');
+
+      // Simulate the submit-time revert wired into handleSubmit.
+      store.dispatch(revertQuickPromptImageOverride());
+
+      const state = store.getState();
+      expect(selectSelectedModality(state)).toBe('text');
+      expect(selectImageQuality(state)).toBe('standard');
+      expect(selectQuickPromptImageOverride(state)).toBeNull();
+    });
+
+    it('manual modality override beats the one-shot: revert becomes a no-op', () => {
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: IMAGE_QUICK_PROMPT_KEY,
+        itemIndex: 0,
+        currentTier: 'lite',
+      });
+      // User manually flips back to text via the ModalityBar.
+      store.dispatch(setSelectedModality('text'));
+      expect(selectSelectedModality(store.getState())).toBe('text');
+      expect(selectQuickPromptImageOverride(store.getState())).toBeNull();
+
+      // Later submit would revert — but override is gone, so the user's choice stands.
+      store.dispatch(revertQuickPromptImageOverride());
+      expect(selectSelectedModality(store.getState())).toBe('text');
+      expect(selectImageQuality(store.getState())).toBe('hd');
+    });
+
+    it('manual quality change beats the one-shot modality revert', () => {
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: IMAGE_QUICK_PROMPT_KEY,
+        itemIndex: 0,
+        currentTier: 'free',
+      });
+      // User bumps quality from standard (tier default) to ultra themselves.
+      store.dispatch(setImageQuality('ultra'));
+      expect(selectImageQuality(store.getState())).toBe('ultra');
+      expect(selectQuickPromptImageOverride(store.getState())).toBeNull();
+
+      // After submit, quality stays ultra, modality stays image.
+      store.dispatch(revertQuickPromptImageOverride());
+      expect(selectImageQuality(store.getState())).toBe('ultra');
+      expect(selectSelectedModality(store.getState())).toBe('image');
+    });
+  });
+
+  describe('telemetry', () => {
+    it('emits quick_prompt_selected with the expected shape for an image prompt', () => {
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: IMAGE_QUICK_PROMPT_KEY,
+        itemIndex: 2,
+        currentTier: 'pro',
+      });
+      const events = selectRecentEvents(store.getState());
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        name: 'quick_prompt_selected',
+        properties: {
+          pill_category: 'image',
+          prompt_index: 2,
+          user_tier: 'pro',
+          prompt_type_set: 'image',
+        },
+      });
+    });
+
+    it('emits quick_prompt_selected with prompt_type_set=text for non-image pills', () => {
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: 'code',
+        itemIndex: 1,
+        currentTier: 'lite',
+      });
+      const events = selectRecentEvents(store.getState());
+      expect(events[0].properties).toEqual({
+        pill_category: 'code',
+        prompt_index: 1,
+        user_tier: 'lite',
+        prompt_type_set: 'text',
+      });
+    });
+
+    it('falls back to user_tier=guest when the tier is missing', () => {
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: 'write',
+        itemIndex: 0,
+        currentTier: null,
+      });
+      expect(selectRecentEvents(store.getState())[0].properties.user_tier).toBe('guest');
+    });
+  });
+
+  describe('invalid selection', () => {
+    it('returns null and dispatches nothing when the pill key is unknown', () => {
+      const result = handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: 'not-a-pill',
+        itemIndex: 0,
+        currentTier: 'pro',
+      });
+      expect(result).toBeNull();
+      expect(selectInputValue(store.getState())).toBe('');
+      expect(selectRecentEvents(store.getState())).toHaveLength(0);
+    });
+
+    it('returns null when the item index is out of range', () => {
+      const result = handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: 'code',
+        itemIndex: 99,
+        currentTier: 'pro',
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getQuickPromptItem', () => {
+    it('returns the matching item for valid coordinates', () => {
+      const item = getQuickPromptItem('code', 0);
+      expect(item?.text).toBe('Debug a React TypeError');
+    });
+
+    it('returns null for invalid coordinates', () => {
+      expect(getQuickPromptItem('missing', 0)).toBeNull();
+      expect(getQuickPromptItem('code', -1)).toBeNull();
+    });
+  });
+});

--- a/src/utils/quickPromptsData.js
+++ b/src/utils/quickPromptsData.js
@@ -3,21 +3,26 @@ import {
   PenIcon,
   SearchIcon,
   ChartIcon,
-  SparkleIcon,
-  BookIcon,
+  PhotoIcon,
   BugIcon,
-  LightbulbIcon,
   ZapIcon,
+  LayersIcon,
+  CheckIcon,
   MailIcon,
   FileTextIcon,
-  CopyIcon,
+  EditIcon,
+  SparkleIcon,
   TrendingUpIcon,
+  BookIcon,
+  CameraIcon,
+  PaletteIcon,
   ClipboardIcon,
-  EyeIcon,
-  PuzzleIcon,
-  LayersIcon,
-  HelpCircleIcon,
 } from '../components/Icons';
+
+// Quick-prompt pill key for the Image pill. Centralised so call-sites that
+// need to trigger image-specific behaviour (modality switch, telemetry) can
+// compare against a single symbol instead of a magic string.
+export const IMAGE_QUICK_PROMPT_KEY = 'image';
 
 export const promptsData = {
   code: {
@@ -25,61 +30,51 @@ export const promptsData = {
     icon: CodeIcon,
     items: [
       { text: 'Debug a React TypeError', icon: BugIcon },
-      { text: 'Clean a CSV with Python pandas', icon: CodeIcon },
-      { text: 'Explain JavaScript closures', icon: LightbulbIcon },
-      { text: 'Optimise an API for 10k requests', icon: ZapIcon },
+      { text: 'Refactor this function for performance', icon: ZapIcon },
+      { text: 'Explain this codebase architecture', icon: LayersIcon },
+      { text: 'Write tests for this module', icon: CheckIcon },
     ],
   },
   write: {
     title: 'Write',
     icon: PenIcon,
     items: [
-      { text: 'Draft a team project update email', icon: MailIcon },
-      { text: 'Summarise an article into key points', icon: FileTextIcon },
-      { text: 'Write SaaS landing page copy', icon: CopyIcon },
-      { text: 'Write REST API documentation', icon: ClipboardIcon },
+      { text: 'Draft a follow-up email to a recruiter', icon: MailIcon },
+      { text: 'Write a LinkedIn post about a product launch', icon: SparkleIcon },
+      { text: 'Outline a blog article on a given topic', icon: FileTextIcon },
+      { text: 'Rewrite this paragraph more concisely', icon: EditIcon },
     ],
   },
   research: {
     title: 'Research',
     icon: SearchIcon,
     items: [
-      { text: 'Latest LLM breakthroughs', icon: SearchIcon },
-      { text: 'Compare React vs Vue vs Svelte', icon: LayersIcon },
-      { text: 'AI startup landscape 2026', icon: TrendingUpIcon },
-      { text: "Cloud computing's environmental impact", icon: ClipboardIcon },
+      { text: 'What happened in AI this week', icon: SparkleIcon },
+      { text: 'Compare the top 3 project management tools in 2026', icon: LayersIcon },
+      { text: 'Find recent studies on intermittent fasting', icon: BookIcon },
+      { text: "Summarise today's market movements", icon: TrendingUpIcon },
+    ],
+  },
+  [IMAGE_QUICK_PROMPT_KEY]: {
+    title: 'Image',
+    icon: PhotoIcon,
+    items: [
+      { text: 'A minimalist logo for a fintech startup', icon: SparkleIcon },
+      { text: 'Cinematic photo of a London street at dusk', icon: CameraIcon },
+      { text: 'Infographic showing the AI provider landscape', icon: ChartIcon },
+      { text: 'Watercolour illustration of a coastal village', icon: PaletteIcon },
     ],
   },
   analyze: {
     title: 'Analyse',
     icon: ChartIcon,
     items: [
-      { text: 'Find top customer churn factors', icon: EyeIcon },
-      { text: "Predict next quarter's sales trends", icon: PuzzleIcon },
-      { text: 'Actionable insights from user metrics', icon: LightbulbIcon },
-      { text: 'Competitive analysis report', icon: ClipboardIcon },
-    ],
-  },
-  create: {
-    title: 'Create',
-    icon: SparkleIcon,
-    items: [
-      { text: 'AI + healthcare startup ideas', icon: LightbulbIcon },
-      { text: 'Design a project management dashboard', icon: PuzzleIcon },
-      { text: 'Spec a habit-tracking mobile app', icon: LayersIcon },
-      { text: 'Plan a 12-post tech blog calendar', icon: SparkleIcon },
-    ],
-  },
-  learn: {
-    title: 'Learn',
-    icon: BookIcon,
-    items: [
-      { text: 'How backpropagation works', icon: LightbulbIcon },
-      { text: 'Distributed systems & CAP theorem', icon: BookIcon },
-      { text: 'Git branching strategies compared', icon: LayersIcon },
-      { text: 'Quiz me on data structures', icon: HelpCircleIcon },
+      { text: 'Analyse this CSV and find trends', icon: TrendingUpIcon },
+      { text: 'Summarise this PDF in 5 bullets', icon: FileTextIcon },
+      { text: 'Extract action items from these meeting notes', icon: ClipboardIcon },
+      { text: 'Compare these two contracts', icon: LayersIcon },
     ],
   },
 };
 
-export const quickPromptKeys = ['code', 'write', 'research', 'analyze', 'create', 'learn'];
+export const quickPromptKeys = ['code', 'write', 'research', IMAGE_QUICK_PROMPT_KEY, 'analyze'];

--- a/src/utils/quickPromptsData.test.js
+++ b/src/utils/quickPromptsData.test.js
@@ -1,16 +1,28 @@
 import { describe, it, expect } from 'vitest';
-import { promptsData, quickPromptKeys } from './quickPromptsData';
+import { promptsData, quickPromptKeys, IMAGE_QUICK_PROMPT_KEY } from './quickPromptsData';
 
 describe('quickPromptsData', () => {
-  it('exports exactly 6 prompt categories', () => {
-    expect(Object.keys(promptsData)).toHaveLength(6);
+  it('exports exactly 5 prompt categories', () => {
+    expect(Object.keys(promptsData)).toHaveLength(5);
   });
 
-  it('quickPromptKeys matches the keys in promptsData', () => {
-    expect(quickPromptKeys).toEqual(['code', 'write', 'research', 'analyze', 'create', 'learn']);
+  it('quickPromptKeys matches the keys in promptsData in the expected order', () => {
+    expect(quickPromptKeys).toEqual(['code', 'write', 'research', 'image', 'analyze']);
     for (const key of quickPromptKeys) {
       expect(promptsData[key]).toBeDefined();
     }
+  });
+
+  it('no longer exposes the Learn or Create pills', () => {
+    expect(promptsData.learn).toBeUndefined();
+    expect(promptsData.create).toBeUndefined();
+    expect(quickPromptKeys).not.toContain('learn');
+    expect(quickPromptKeys).not.toContain('create');
+  });
+
+  it('exposes the image pill key constant matching the data key', () => {
+    expect(IMAGE_QUICK_PROMPT_KEY).toBe('image');
+    expect(promptsData[IMAGE_QUICK_PROMPT_KEY]).toBeDefined();
   });
 
   it('each category has a title, icon, and items array', () => {
@@ -44,8 +56,40 @@ describe('quickPromptsData', () => {
     expect(promptsData.code.title).toBe('Code');
     expect(promptsData.write.title).toBe('Write');
     expect(promptsData.research.title).toBe('Research');
+    expect(promptsData.image.title).toBe('Image');
     expect(promptsData.analyze.title).toBe('Analyse');
-    expect(promptsData.create.title).toBe('Create');
-    expect(promptsData.learn.title).toBe('Learn');
+  });
+
+  it('ships the requested prompt texts for each pill', () => {
+    expect(promptsData.code.items.map((i) => i.text)).toEqual([
+      'Debug a React TypeError',
+      'Refactor this function for performance',
+      'Explain this codebase architecture',
+      'Write tests for this module',
+    ]);
+    expect(promptsData.write.items.map((i) => i.text)).toEqual([
+      'Draft a follow-up email to a recruiter',
+      'Write a LinkedIn post about a product launch',
+      'Outline a blog article on a given topic',
+      'Rewrite this paragraph more concisely',
+    ]);
+    expect(promptsData.research.items.map((i) => i.text)).toEqual([
+      'What happened in AI this week',
+      'Compare the top 3 project management tools in 2026',
+      'Find recent studies on intermittent fasting',
+      "Summarise today's market movements",
+    ]);
+    expect(promptsData.image.items.map((i) => i.text)).toEqual([
+      'A minimalist logo for a fintech startup',
+      'Cinematic photo of a London street at dusk',
+      'Infographic showing the AI provider landscape',
+      'Watercolour illustration of a coastal village',
+    ]);
+    expect(promptsData.analyze.items.map((i) => i.text)).toEqual([
+      'Analyse this CSV and find trends',
+      'Summarise this PDF in 5 bullets',
+      'Extract action items from these meeting notes',
+      'Compare these two contracts',
+    ]);
   });
 });


### PR DESCRIPTION
Replace the Learn + Create pills with a single Image pill (order: Code, Write, Research, Image, Analyse) and swap every prompt to the new copy. Selecting an Image prompt now flips selectedModality to image and sets the tier-appropriate default quality (free/standard, lite/hd, pro/ultra) as a one-shot that reverts on submit. Manual ModalityBar changes to a different value cancel the one-shot so the user's choice wins. Emits quick_prompt_selected telemetry through a new analyticsSlice recordEvent action.