### PR TITLE
fix(apex): revert image modality when switching to a non-image quick …

### DIFF
--- a/src/utils/quickPromptHandler.js
+++ b/src/utils/quickPromptHandler.js
@@ -1,4 +1,8 @@
-import { setInputValue, applyImageQuickPromptOverride } from '../store/slices/chatSlice';
+import {
+  setInputValue,
+  applyImageQuickPromptOverride,
+  revertQuickPromptImageOverride,
+} from '../store/slices/chatSlice';
 import { recordEvent } from '../store/slices/analyticsSlice';
 import { getDefaultImageQualityForTier } from '../config/credits';
 import { promptsData, IMAGE_QUICK_PROMPT_KEY } from './quickPromptsData';
@@ -43,6 +47,11 @@ export function handleQuickPromptSelection({ dispatch, pillKey, itemIndex, curre
 
   if (isImagePill) {
     dispatch(applyImageQuickPromptOverride(getDefaultImageQualityForTier(currentTier)));
+  } else {
+    // Picking a non-image prompt after an image one cancels the pending
+    // one-shot so the modality bounces back to whatever it was before the
+    // Image pill was clicked. A no-op when no override is active.
+    dispatch(revertQuickPromptImageOverride());
   }
 
   dispatch(

--- a/src/utils/quickPromptHandler.test.js
+++ b/src/utils/quickPromptHandler.test.js
@@ -137,6 +137,49 @@ describe('handleQuickPromptSelection — quick prompt flow', () => {
       expect(selectImageQuality(store.getState())).toBe('hd');
     });
 
+    it('selecting a non-image prompt after an image one reverts modality to text', () => {
+      // 1. Pick an image prompt — modality flips to image.
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: IMAGE_QUICK_PROMPT_KEY,
+        itemIndex: 0,
+        currentTier: 'pro',
+      });
+      expect(selectSelectedModality(store.getState())).toBe('image');
+      expect(selectImageQuality(store.getState())).toBe('ultra');
+
+      // 2. Pick a Code prompt — modality must bounce back to text immediately,
+      //    without needing a submit. Input text updates too.
+      const codeItem = promptsData.code.items[0];
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: 'code',
+        itemIndex: 0,
+        currentTier: 'pro',
+      });
+      const state = store.getState();
+      expect(selectInputValue(state)).toBe(codeItem.text + ' ');
+      expect(selectSelectedModality(state)).toBe('text');
+      expect(selectImageQuality(state)).toBe('standard');
+      expect(selectQuickPromptImageOverride(state)).toBeNull();
+    });
+
+    it('switching between non-image pills never touches modality', () => {
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: 'write',
+        itemIndex: 1,
+        currentTier: 'lite',
+      });
+      handleQuickPromptSelection({
+        dispatch: store.dispatch,
+        pillKey: 'research',
+        itemIndex: 2,
+        currentTier: 'lite',
+      });
+      expect(selectSelectedModality(store.getState())).toBe('text');
+    });
+
     it('manual quality change beats the one-shot modality revert', () => {
       handleQuickPromptSelection({
         dispatch: store.dispatch,


### PR DESCRIPTION
…prompt

Previously, after selecting an Image quick prompt, picking a Code/Write/ Research/Analyse prompt left the modality stuck on 'image' until submit. Non-image pills now dispatch revertQuickPromptImageOverride, which is a no-op when no override is active and otherwise restores the previous modality and quality immediately.

https://claude.ai/code/session_019Lno2EzMpFRgSP8HzHxQiC