### PR TITLE
feat(chat): update conversation title in place from SSE title event

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -40,6 +40,7 @@ import {
   selectConversations,
   selectConversationsTotal,
   setConversations,
+  updateConversationTitle,
   selectSelectedModality,
   selectImageQuality,
   selectCreditBalance,
@@ -1761,6 +1762,25 @@ export default function MainContent() {
               if (assistantMsgAdded && data.questions) {
                 dispatch(updateLastMessage({ questions: data.questions }));
               }
+            } else if (type === 'title') {
+              // LLM-generated conversation title arrived from the backend.
+              // Update Redux (drives the sidebar re-render) and the header
+              // local state if the user is currently viewing this chat.
+              if (
+                data?.conversationId &&
+                typeof data?.title === 'string' &&
+                data.title.length > 0
+              ) {
+                dispatch(
+                  updateConversationTitle({
+                    id: data.conversationId,
+                    title: data.title,
+                  })
+                );
+                if (data.conversationId === currentChatId) {
+                  setConversationTitle(data.title);
+                }
+              }
             } else if (type === 'done') {
               receivedDone = true;
               const totalDuration = ((Date.now() - routingStart) / 1000).toFixed(1);
@@ -2652,7 +2672,14 @@ export default function MainContent() {
                 aria-expanded={showProjectDropdown}
                 aria-label="Conversation options"
               >
-                <span className={styles.breadcrumbTitle}>{conversationTitle}</span>
+                <span
+                  key={conversationTitle}
+                  className={styles.breadcrumbTitle}
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  {conversationTitle}
+                </span>
                 <ChevronDownIcon />
               </button>
             )}

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -187,6 +187,25 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* Subtle fade when the title swaps in (e.g. LLM-generated title replaces placeholder). */
+  animation: breadcrumbTitleSwap 180ms ease-out;
+}
+
+@keyframes breadcrumbTitleSwap {
+  from {
+    opacity: 0;
+    transform: translateY(-1px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumbTitle {
+    animation: none;
+  }
 }
 
 /* Inline rename input */

--- a/src/store/slices/chatSlice.js
+++ b/src/store/slices/chatSlice.js
@@ -216,6 +216,14 @@ const chatSlice = createSlice({
     setConversationsLoading: (state, action) => {
       state.conversationsLoading = action.payload;
     },
+    updateConversationTitle: (state, action) => {
+      const { id, title } = action.payload ?? {};
+      if (!id || typeof title !== 'string' || title.length === 0) return;
+      const conv = state.conversations.find((c) => c.id === id);
+      if (conv) {
+        conv.title = title;
+      }
+    },
     resetChatState: (state) => {
       // Preserve user's model preference (persisted in localStorage), reset everything else
       const selectedModelId = state.selectedModelId;
@@ -255,6 +263,7 @@ export const {
   setConversations,
   appendConversations,
   setConversationsLoading,
+  updateConversationTitle,
   resetChatState,
 } = chatSlice.actions;
 

--- a/src/store/slices/chatSlice.test.js
+++ b/src/store/slices/chatSlice.test.js
@@ -30,6 +30,7 @@ import chatReducer, {
   setConversations,
   appendConversations,
   setConversationsLoading,
+  updateConversationTitle,
   resetChatState,
   selectInputValue,
   selectMode,
@@ -444,6 +445,53 @@ describe('chatSlice', () => {
     it('setConversationsLoading sets loading state', () => {
       const state = chatReducer(defaultState, setConversationsLoading(true));
       expect(state.conversationsLoading).toBe(true);
+    });
+
+    describe('updateConversationTitle', () => {
+      it('updates the title of a matching conversation', () => {
+        let state = chatReducer(
+          defaultState,
+          setConversations({
+            conversations: [
+              { id: 'a', title: 'placeholder...' },
+              { id: 'b', title: 'other' },
+            ],
+            total: 2,
+          })
+        );
+        state = chatReducer(
+          state,
+          updateConversationTitle({ id: 'a', title: 'Clean descriptive title' })
+        );
+        expect(state.conversations).toEqual([
+          { id: 'a', title: 'Clean descriptive title' },
+          { id: 'b', title: 'other' },
+        ]);
+      });
+
+      it('is a no-op when the conversation id is unknown', () => {
+        const initial = {
+          ...defaultState,
+          conversations: [{ id: 'a', title: 'placeholder...' }],
+        };
+        const state = chatReducer(
+          initial,
+          updateConversationTitle({ id: 'missing', title: 'New' })
+        );
+        expect(state.conversations).toEqual([{ id: 'a', title: 'placeholder...' }]);
+      });
+
+      it('ignores empty or missing title', () => {
+        const initial = {
+          ...defaultState,
+          conversations: [{ id: 'a', title: 'placeholder...' }],
+        };
+        const noTitle = chatReducer(initial, updateConversationTitle({ id: 'a', title: '' }));
+        expect(noTitle.conversations[0].title).toBe('placeholder...');
+
+        const noPayload = chatReducer(initial, updateConversationTitle());
+        expect(noPayload.conversations[0].title).toBe('placeholder...');
+      });
     });
   });
 


### PR DESCRIPTION
Handle the new `type: 'title'` SSE event from the API: dispatch a new `updateConversationTitle` Redux action so the sidebar entry re-renders instantly (no refetch), and update the conversation header's local state when the event is for the currently-open chat. Add aria-live announcement and a subtle 180ms fade (respecting prefers-reduced-motion) so the swap is accessible and not jarring. Covers the new reducer with unit tests.