### PR TITLE
feat(chat): update conversation title in place from inline SSE title …

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -40,6 +40,7 @@ import {
   selectConversations,
   selectConversationsTotal,
   setConversations,
+  updateConversationTitle,
   selectSelectedModality,
   selectImageQuality,
   selectCreditBalance,
@@ -1753,6 +1754,18 @@ export default function MainContent() {
                 dispatch(updateLastMessage({ generatedImages: newImages }));
                 accumulatedImages = newImages;
               }
+            } else if (type === 'title') {
+              if (
+                data?.conversationId &&
+                typeof data?.title === 'string' &&
+                data.title.length > 0
+              ) {
+                // Sidebar reflects the new title instantly via Redux; breadcrumb
+                // is updated in place since this handler already short-circuits
+                // on abort above (so the user is still viewing this chat).
+                dispatch(updateConversationTitle({ id: data.conversationId, title: data.title }));
+                setConversationTitle(data.title);
+              }
             } else if (type === 'followups') {
               if (assistantMsgAdded && data.suggestions) {
                 dispatch(updateLastMessage({ followUps: data.suggestions }));
@@ -2652,7 +2665,14 @@ export default function MainContent() {
                 aria-expanded={showProjectDropdown}
                 aria-label="Conversation options"
               >
-                <span className={styles.breadcrumbTitle}>{conversationTitle}</span>
+                <span
+                  key={conversationTitle}
+                  className={styles.breadcrumbTitle}
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  {conversationTitle}
+                </span>
                 <ChevronDownIcon />
               </button>
             )}

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -187,6 +187,24 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  animation: breadcrumbTitleSwap 180ms ease-out;
+}
+
+@keyframes breadcrumbTitleSwap {
+  from {
+    opacity: 0;
+    transform: translateY(-1px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .breadcrumbTitle {
+    animation: none;
+  }
 }
 
 /* Inline rename input */

--- a/src/store/slices/chatSlice.js
+++ b/src/store/slices/chatSlice.js
@@ -216,6 +216,14 @@ const chatSlice = createSlice({
     setConversationsLoading: (state, action) => {
       state.conversationsLoading = action.payload;
     },
+    updateConversationTitle: (state, action) => {
+      const { id, title } = action.payload ?? {};
+      if (!id || typeof title !== 'string' || title.length === 0) return;
+      const conv = state.conversations.find((c) => c.id === id);
+      if (conv) {
+        conv.title = title;
+      }
+    },
     resetChatState: (state) => {
       // Preserve user's model preference (persisted in localStorage), reset everything else
       const selectedModelId = state.selectedModelId;
@@ -255,6 +263,7 @@ export const {
   setConversations,
   appendConversations,
   setConversationsLoading,
+  updateConversationTitle,
   resetChatState,
 } = chatSlice.actions;
 

--- a/src/store/slices/chatSlice.test.js
+++ b/src/store/slices/chatSlice.test.js
@@ -30,6 +30,7 @@ import chatReducer, {
   setConversations,
   appendConversations,
   setConversationsLoading,
+  updateConversationTitle,
   resetChatState,
   selectInputValue,
   selectMode,
@@ -444,6 +445,42 @@ describe('chatSlice', () => {
     it('setConversationsLoading sets loading state', () => {
       const state = chatReducer(defaultState, setConversationsLoading(true));
       expect(state.conversationsLoading).toBe(true);
+    });
+
+    it('updateConversationTitle updates a matching conversation title', () => {
+      let state = chatReducer(
+        defaultState,
+        setConversations({
+          conversations: [
+            { id: 'c1', title: 'Old...' },
+            { id: 'c2', title: 'Other' },
+          ],
+          total: 2,
+        })
+      );
+      state = chatReducer(state, updateConversationTitle({ id: 'c1', title: 'Fresh title' }));
+      expect(state.conversations[0].title).toBe('Fresh title');
+      expect(state.conversations[1].title).toBe('Other');
+    });
+
+    it('updateConversationTitle is a no-op for unknown ids', () => {
+      let state = chatReducer(
+        defaultState,
+        setConversations({ conversations: [{ id: 'c1', title: 'Old' }], total: 1 })
+      );
+      state = chatReducer(state, updateConversationTitle({ id: 'missing', title: 'Nope' }));
+      expect(state.conversations[0].title).toBe('Old');
+    });
+
+    it('updateConversationTitle ignores empty or missing titles', () => {
+      let state = chatReducer(
+        defaultState,
+        setConversations({ conversations: [{ id: 'c1', title: 'Old' }], total: 1 })
+      );
+      state = chatReducer(state, updateConversationTitle({ id: 'c1', title: '' }));
+      state = chatReducer(state, updateConversationTitle({ id: 'c1' }));
+      state = chatReducer(state, updateConversationTitle());
+      expect(state.conversations[0].title).toBe('Old');
     });
   });
 


### PR DESCRIPTION
…event

Handle the new `type: 'title'` SSE event the API now emits just ahead of the first visible delta on a new conversation. Dispatch a new `updateConversationTitle` Redux action so the sidebar entry re-renders instantly (no refetch) and sync the breadcrumb's local state since the stream handler already aborts on navigation. Add aria-live announcement and a 180ms fade on the breadcrumb title (respecting prefers-reduced-motion) so the swap is accessible and not jarring. Covers the new reducer with unit tests.