### PR TITLE
fix(model-pill): close dropdown before confirm modal opens

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -3042,7 +3042,12 @@ function ModelPillDropdown({ message, isDark, position, onClose, onSelectAlterna
   const fitLabel = getFitLabel(message.score);
 
   const dropdown = (
-    <div className={styles.modelDropdown} ref={dropdownRef} style={fixedStyle || {}}>
+    <div
+      className={styles.modelDropdown}
+      ref={dropdownRef}
+      style={fixedStyle || {}}
+      onClick={(e) => e.stopPropagation()}
+    >
       {/* Current / chosen model */}
       <div className={styles.modelDropdownSection}>
         <span className={styles.modelDropdownSectionLabel}>Responded with</span>

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -4093,7 +4093,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1000;
+  z-index: 10100;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Clicking an alt model inside the portaled dropdown bubbled back to the trigger wrapper's onClick toggle, flipping showModelDropdown back to true after the button set it to false. React routes events through the component tree regardless of the DOM portal, so the bubble reached the wrapper. Result: dropdown stayed open and the confirm dialog rendered behind it.

Stop propagation at the dropdown container root so internal clicks never reach the toggle handler, and raise the confirm overlay z-index above any floating dropdown layer for defence in depth.