### PR TITLE
fix(sources): dedupe citations in the Sources panel

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -71,6 +71,7 @@ import ArtifactBlock from '../ArtifactBlock/ArtifactBlock';
 import WeatherCard from '../WeatherCard';
 import { detectWeatherResponse, extractWeatherData } from '../WeatherCard/weatherParser';
 import { generateAndDownload } from '../../services/fileGenerator';
+import { dedupeCitations } from '../../utils/dedupeCitations';
 import styles from './MessageList.module.css';
 
 // Initialize mermaid with sensible defaults
@@ -5858,6 +5859,11 @@ function SourcesSidePanel({ citations, onClose, panelRef }) {
     return () => document.removeEventListener('keydown', handleEsc);
   }, [onClose]);
 
+  // Defensive dedup: historical messages and some providers hand us the same
+  // URL multiple times. Collapse by normalized URL so the list and count both
+  // reflect unique sources.
+  const uniqueCitations = useMemo(() => dedupeCitations(citations), [citations]);
+
   return (
     <div className={styles.sourcesPanel} ref={panelRef}>
       <div className={styles.sourcesPanelHeader}>
@@ -5874,10 +5880,10 @@ function SourcesSidePanel({ citations, onClose, panelRef }) {
         </button>
       </div>
       <div className={styles.sourcesPanelSubheader}>
-        {citations.length} source{citations.length !== 1 ? 's' : ''} found
+        {uniqueCitations.length} source{uniqueCitations.length !== 1 ? 's' : ''} found
       </div>
       <div className={styles.sourcesPanelList}>
-        {citations.map((citation, idx) => {
+        {uniqueCitations.map((citation, idx) => {
           let favicon = '';
           let hostname = '';
           let sourceName = '';

--- a/src/utils/dedupeCitations.js
+++ b/src/utils/dedupeCitations.js
@@ -1,0 +1,52 @@
+/**
+ * Normalizes a citation URL for duplicate detection.
+ *
+ * Strips protocol, a leading "www.", trailing slashes, and the URL fragment,
+ * and lowercases the host. The query string is preserved because distinct
+ * queries identify distinct pages (e.g. YouTube video ids).
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+export function normalizeCitationUrl(raw) {
+  if (!raw || typeof raw !== 'string') return '';
+  const trimmed = raw.trim();
+  try {
+    const url = new URL(trimmed);
+    const host = url.host.replace(/^www\./, '').toLowerCase();
+    const path = url.pathname.replace(/\/+$/, '');
+    return `${host}${path}${url.search}`;
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
+ * Returns a new array containing the first occurrence of each citation,
+ * deduplicated by normalized URL. Order is preserved. When duplicates are
+ * merged, a later entry with a non-empty snippet or a more descriptive title
+ * upgrades the kept record.
+ *
+ * @param {Array<{url: string, title?: string, snippet?: string}>} citations
+ * @returns {Array<{url: string, title?: string, snippet?: string}>}
+ */
+export function dedupeCitations(citations) {
+  if (!Array.isArray(citations) || citations.length === 0) return [];
+  const byKey = new Map();
+  for (const c of citations) {
+    if (!c || typeof c.url !== 'string' || c.url.length === 0) continue;
+    const key = normalizeCitationUrl(c.url);
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, { ...c });
+      continue;
+    }
+    if (!existing.snippet && c.snippet) {
+      existing.snippet = c.snippet;
+    }
+    if ((!existing.title || existing.title === existing.url) && c.title && c.title !== c.url) {
+      existing.title = c.title;
+    }
+  }
+  return Array.from(byKey.values());
+}

--- a/src/utils/dedupeCitations.test.js
+++ b/src/utils/dedupeCitations.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { dedupeCitations, normalizeCitationUrl } from './dedupeCitations';
+
+describe('normalizeCitationUrl', () => {
+  it('returns empty string for empty or non-string input', () => {
+    expect(normalizeCitationUrl('')).toBe('');
+    expect(normalizeCitationUrl(null)).toBe('');
+    expect(normalizeCitationUrl(undefined)).toBe('');
+  });
+
+  it('strips protocol and leading www.', () => {
+    expect(normalizeCitationUrl('https://www.example.com/page')).toBe('example.com/page');
+    expect(normalizeCitationUrl('http://example.com/page')).toBe('example.com/page');
+  });
+
+  it('strips trailing slashes on the path', () => {
+    expect(normalizeCitationUrl('https://example.com/page/')).toBe('example.com/page');
+    expect(normalizeCitationUrl('https://example.com/')).toBe('example.com');
+  });
+
+  it('lowercases the host but preserves path casing', () => {
+    expect(normalizeCitationUrl('https://Example.COM/MyPage')).toBe('example.com/MyPage');
+  });
+
+  it('drops the fragment but keeps the query', () => {
+    expect(normalizeCitationUrl('https://example.com/a?x=1#section')).toBe('example.com/a?x=1');
+  });
+});
+
+describe('dedupeCitations', () => {
+  it('returns an empty array for empty or invalid input', () => {
+    expect(dedupeCitations([])).toEqual([]);
+    expect(dedupeCitations(null)).toEqual([]);
+    expect(dedupeCitations(undefined)).toEqual([]);
+  });
+
+  it('collapses exact-duplicate URLs to one entry', () => {
+    const out = dedupeCitations([
+      { url: 'https://example.com/a', title: 'A' },
+      { url: 'https://example.com/a', title: 'A' },
+      { url: 'https://example.com/a', title: 'A' },
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('treats protocol, www, and trailing-slash variants as duplicates', () => {
+    const out = dedupeCitations([
+      { url: 'https://example.com/page', title: 'Example' },
+      { url: 'http://www.example.com/page/', title: 'Example' },
+      { url: 'https://EXAMPLE.com/page', title: 'Example' },
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('preserves insertion order of first occurrence', () => {
+    const out = dedupeCitations([
+      { url: 'https://a.com', title: 'A' },
+      { url: 'https://b.com', title: 'B' },
+      { url: 'https://a.com', title: 'A' },
+      { url: 'https://c.com', title: 'C' },
+    ]);
+    expect(out.map((c) => c.url)).toEqual(['https://a.com', 'https://b.com', 'https://c.com']);
+  });
+
+  it('upgrades the kept record with a snippet from a later duplicate', () => {
+    const out = dedupeCitations([
+      { url: 'https://example.com/a', title: 'A' },
+      { url: 'https://example.com/a', title: 'A', snippet: 'extra' },
+    ]);
+    expect(out[0].snippet).toBe('extra');
+  });
+
+  it('skips records with missing or empty URLs', () => {
+    const out = dedupeCitations([
+      { url: '', title: 'empty' },
+      { url: 'https://example.com/a', title: 'A' },
+    ]);
+    expect(out).toHaveLength(1);
+  });
+
+  it('collapses a highly inflated citation list', () => {
+    const base = Array.from({ length: 12 }, (_, i) => ({
+      url: `https://araveil.com/page-${i}`,
+      title: 'Araveil',
+    }));
+    const inflated = Array(246)
+      .fill(null)
+      .flatMap(() => base);
+    expect(inflated).toHaveLength(2952);
+    const out = dedupeCitations(inflated);
+    expect(out).toHaveLength(12);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [
+      { url: 'https://example.com/a', title: 'A' },
+      { url: 'https://example.com/a', title: 'A' },
+    ];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    dedupeCitations(input);
+    expect(input).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
Defence-in-depth for historical messages and any provider that surfaces the same URL multiple times: the Sources side panel now collapses its input by normalized URL before rendering, so the visible count and list reflect unique sources instead of repeating the same link.

Adds a small dedupeCitations helper with unit tests covering the protocol/www/trailing-slash equivalence class, preserved insertion order, snippet upgrades, and the pathological inflated-count case.