### PR TITLE
feat(comparison): redesign the comparison infographic

### DIFF
--- a/src/components/ComparisonBlock/ComparisonBlock.jsx
+++ b/src/components/ComparisonBlock/ComparisonBlock.jsx
@@ -1,96 +1,161 @@
 import { useMemo } from 'react';
 import styles from './ComparisonBlock.module.css';
 
+const CheckIcon = () => (
+  <svg
+    viewBox="0 0 16 16"
+    width="12"
+    height="12"
+    aria-hidden="true"
+    focusable="false"
+    className={styles.icon}
+  >
+    <path
+      d="M3.5 8.5l2.8 2.8L12.5 5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const CrossIcon = () => (
+  <svg
+    viewBox="0 0 16 16"
+    width="12"
+    height="12"
+    aria-hidden="true"
+    focusable="false"
+    className={styles.icon}
+  >
+    <path
+      d="M4.5 4.5l7 7M11.5 4.5l-7 7"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+const SparkIcon = () => (
+  <svg
+    viewBox="0 0 16 16"
+    width="12"
+    height="12"
+    aria-hidden="true"
+    focusable="false"
+    className={styles.icon}
+  >
+    <path
+      d="M8 1.6l1.7 3.8 3.8 1.7-3.8 1.7L8 12.6 6.3 8.8 2.5 7.1l3.8-1.7L8 1.6z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 /**
  * Comparison block — renders a side-by-side comparison from a JSON spec.
  * Expects `spec` to be a JSON string:
  * { "items": [{ "name": "A", "pros": [...], "cons": [...], "description": "..." }, ...] }
  */
 export default function ComparisonBlock({ spec, isStreaming = false }) {
-  const data = useMemo(() => {
+  const items = useMemo(() => {
     try {
       const parsed = typeof spec === 'string' ? JSON.parse(spec) : spec;
       if (!parsed || !Array.isArray(parsed.items)) return null;
-      const items = parsed.items.filter((item) => item && item.name);
-      return items.length >= 2 ? items : null;
+      const filtered = parsed.items.filter((item) => item && item.name);
+      return filtered.length >= 2 ? filtered : null;
     } catch {
       return null;
     }
   }, [spec]);
 
-  if (!data) {
+  if (!items) {
     if (isStreaming) {
       return (
-        <div className={styles.wrapper}>
-          <div className={styles.header}>
-            <span className={styles.headerLabel}>Comparison</span>
-            <span className={styles.headerCount}>Loading...</span>
-          </div>
-          <div style={{ padding: '20px', opacity: 0.5, fontSize: '12.5px', color: 'var(--text-muted)' }}>
-            Building comparison...
+        <div className={styles.wrapper} data-testid="comparison-block">
+          <div className={styles.skeleton} role="status" aria-live="polite">
+            <span className={styles.skeletonDot} aria-hidden="true" />
+            Building comparison…
           </div>
         </div>
       );
     }
     return (
-      <div className={styles.error}>
+      <div className={styles.error} role="alert">
         <span>Could not parse comparison data</span>
       </div>
     );
   }
 
   return (
-    <div className={styles.wrapper}>
-      <div className={styles.header}>
-        <span className={styles.headerLabel}>Comparison</span>
-        <span className={styles.headerCount}>{data.length} items</span>
-      </div>
-      <div className={styles.grid} style={{ gridTemplateColumns: `repeat(${data.length}, 1fr)` }}>
-        {data.map((item, idx) => (
-          <div key={idx} className={styles.card}>
-            <div className={styles.cardHeader}>
-              <span className={styles.cardName}>{item.name}</span>
-              {item.description && (
-                <span className={styles.cardDescription}>{item.description}</span>
-              )}
-            </div>
+    <div className={styles.wrapper} data-testid="comparison-block">
+      <div className={styles.grid} style={{ '--comparison-cols': items.length }}>
+        {items.map((item, idx) => (
+          <article key={idx} className={styles.card} style={{ '--comparison-index': idx }}>
+            <header className={styles.cardHeader}>
+              <span className={styles.cardBadge} aria-hidden="true">
+                {String.fromCharCode(65 + idx)}
+              </span>
+              <div className={styles.cardHeadings}>
+                <h3 className={styles.cardName}>{item.name}</h3>
+                {item.description && <p className={styles.cardDescription}>{item.description}</p>}
+              </div>
+            </header>
+
             <div className={styles.cardBody}>
               {item.pros && item.pros.length > 0 && (
-                <div className={styles.section}>
-                  <span className={styles.sectionLabel}>
-                    <span className={styles.prosIcon}>+</span> Pros
-                  </span>
+                <section className={styles.section}>
+                  <span className={`${styles.sectionLabel} ${styles.proLabel}`}>Pros</span>
                   <ul className={styles.list}>
                     {item.pros.map((pro, pi) => (
-                      <li key={pi} className={styles.proItem}>{pro}</li>
+                      <li key={pi} className={styles.proItem}>
+                        <span className={styles.iconWrap}>
+                          <CheckIcon />
+                        </span>
+                        <span className={styles.itemText}>{pro}</span>
+                      </li>
                     ))}
                   </ul>
-                </div>
+                </section>
               )}
+
               {item.cons && item.cons.length > 0 && (
-                <div className={styles.section}>
-                  <span className={styles.sectionLabel}>
-                    <span className={styles.consIcon}>&minus;</span> Cons
-                  </span>
+                <section className={styles.section}>
+                  <span className={`${styles.sectionLabel} ${styles.conLabel}`}>Cons</span>
                   <ul className={styles.list}>
                     {item.cons.map((con, ci) => (
-                      <li key={ci} className={styles.conItem}>{con}</li>
+                      <li key={ci} className={styles.conItem}>
+                        <span className={styles.iconWrap}>
+                          <CrossIcon />
+                        </span>
+                        <span className={styles.itemText}>{con}</span>
+                      </li>
                     ))}
                   </ul>
-                </div>
+                </section>
               )}
+
               {item.features && item.features.length > 0 && (
-                <div className={styles.section}>
-                  <span className={styles.sectionLabel}>Features</span>
+                <section className={styles.section}>
+                  <span className={`${styles.sectionLabel} ${styles.featureLabel}`}>Features</span>
                   <ul className={styles.list}>
                     {item.features.map((feat, fi) => (
-                      <li key={fi} className={styles.featureItem}>{feat}</li>
+                      <li key={fi} className={styles.featureItem}>
+                        <span className={styles.iconWrap}>
+                          <SparkIcon />
+                        </span>
+                        <span className={styles.itemText}>{feat}</span>
+                      </li>
                     ))}
                   </ul>
-                </div>
+                </section>
               )}
             </div>
-          </div>
+          </article>
         ))}
       </div>
     </div>

--- a/src/components/ComparisonBlock/ComparisonBlock.module.css
+++ b/src/components/ComparisonBlock/ComparisonBlock.module.css
@@ -1,160 +1,327 @@
 .wrapper {
-  margin: 14px 0;
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  overflow: hidden;
-  background: var(--bg-primary);
+  margin: 18px 0 22px;
+  --pro-accent: #0f9d7b;
+  --pro-bg: rgba(15, 157, 123, 0.09);
+  --pro-bg-strong: rgba(15, 157, 123, 0.18);
+  --con-accent: #c2554e;
+  --con-bg: rgba(194, 85, 78, 0.09);
+  --con-bg-strong: rgba(194, 85, 78, 0.18);
+  --feature-accent: #c47a1a;
+  --feature-bg: rgba(196, 122, 26, 0.1);
+  --feature-bg-strong: rgba(196, 122, 26, 0.2);
+  --card-ring: rgba(61, 53, 40, 0.06);
 }
 
-.header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 14px;
-  border-bottom: 1px solid var(--border-color);
-  background: var(--bg-secondary);
-}
-
-.headerLabel {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  letter-spacing: 0.01em;
-}
-
-.headerCount {
-  font-size: 11px;
-  color: var(--text-muted);
-  font-weight: 500;
+[data-theme='dark'] .wrapper {
+  --pro-accent: #4bd4a6;
+  --pro-bg: rgba(75, 212, 166, 0.1);
+  --pro-bg-strong: rgba(75, 212, 166, 0.22);
+  --con-accent: #ed8079;
+  --con-bg: rgba(237, 128, 121, 0.1);
+  --con-bg-strong: rgba(237, 128, 121, 0.22);
+  --feature-accent: #f0b159;
+  --feature-bg: rgba(240, 177, 89, 0.1);
+  --feature-bg-strong: rgba(240, 177, 89, 0.22);
+  --card-ring: rgba(0, 0, 0, 0.35);
 }
 
 .grid {
   display: grid;
-  gap: 0;
+  grid-template-columns: repeat(var(--comparison-cols, 2), minmax(0, 1fr));
+  gap: 14px;
 }
 
 .card {
-  border-right: 1px solid var(--border-color);
+  position: relative;
   display: flex;
   flex-direction: column;
+  gap: 14px;
+  padding: 18px 18px 20px;
+  border-radius: 16px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 1px 0 var(--card-ring);
+  overflow: hidden;
+  isolation: isolate;
+  transition: transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1), box-shadow 220ms ease,
+    border-color 220ms ease, background-color 220ms ease;
+  animation: cardRise 480ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  animation-delay: calc(var(--comparison-index, 0) * 70ms);
 }
 
-.card:last-child {
-  border-right: none;
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    var(--pro-accent) 0%,
+    var(--feature-accent) 55%,
+    var(--con-accent) 100%
+  );
+  opacity: 0.55;
+  transition: opacity 220ms ease;
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-input);
+  box-shadow: var(--shadow-lg);
+  background: var(--bg-input);
+}
+
+.card:hover::before {
+  opacity: 0.9;
 }
 
 .cardHeader {
-  padding: 14px 16px 10px;
-  border-bottom: 1px solid var(--border-color);
-  background: var(--bg-secondary);
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+}
+
+.cardBadge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 9px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+
+.cardHeadings {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .cardName {
-  display: block;
-  font-size: 14px;
-  font-weight: 700;
+  margin: 0;
+  font-size: 14.5px;
+  font-weight: 650;
   color: var(--text-primary);
   line-height: 1.3;
+  letter-spacing: -0.005em;
+  overflow-wrap: anywhere;
 }
 
 .cardDescription {
-  display: block;
-  font-size: 12px;
+  margin: 0;
+  font-size: 12.5px;
   color: var(--text-secondary);
-  margin-top: 3px;
-  line-height: 1.4;
+  line-height: 1.45;
 }
 
 .cardBody {
-  padding: 12px 16px 16px;
-  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .section {
-  margin-bottom: 12px;
-}
-
-.section:last-child {
-  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .sectionLabel {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: 11.5px;
-  font-weight: 600;
-  color: var(--text-muted);
+  align-self: flex-start;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin-bottom: 6px;
+  letter-spacing: 0.08em;
+  line-height: 1;
 }
 
-.prosIcon {
-  color: #10b981;
-  font-weight: 700;
-  font-size: 13px;
+.sectionLabel::before {
+  content: '';
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.85;
 }
 
-.consIcon {
-  color: #ef4444;
-  font-weight: 700;
-  font-size: 13px;
+.proLabel {
+  color: var(--pro-accent);
+  background: var(--pro-bg);
+}
+
+.conLabel {
+  color: var(--con-accent);
+  background: var(--con-bg);
+}
+
+.featureLabel {
+  color: var(--feature-accent);
+  background: var(--feature-bg);
 }
 
 .list {
-  list-style: none;
-  padding: 0;
   margin: 0;
+  padding: 0;
+  list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 5px;
 }
 
 .proItem,
 .conItem,
 .featureItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
   font-size: 12.5px;
+  line-height: 1.5;
   color: var(--text-primary);
-  line-height: 1.45;
-  padding: 4px 8px;
-  border-radius: 6px;
-  background: var(--bg-secondary);
+  padding: 7px 10px 7px 8px;
+  border-radius: 10px;
+  transition: background-color 180ms ease;
 }
 
 .proItem {
-  border-left: 2px solid #10b981;
+  background: var(--pro-bg);
 }
 
 .conItem {
-  border-left: 2px solid #ef4444;
+  background: var(--con-bg);
 }
 
 .featureItem {
-  border-left: 2px solid var(--accent-color, #d97706);
+  background: var(--feature-bg);
+}
+
+.card:hover .proItem {
+  background: var(--pro-bg-strong);
+}
+
+.card:hover .conItem {
+  background: var(--con-bg-strong);
+}
+
+.card:hover .featureItem {
+  background: var(--feature-bg-strong);
+}
+
+.iconWrap {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  margin-top: 1px;
+}
+
+.proItem .iconWrap {
+  color: var(--pro-accent);
+  background: var(--pro-bg-strong);
+}
+
+.conItem .iconWrap {
+  color: var(--con-accent);
+  background: var(--con-bg-strong);
+}
+
+.featureItem .iconWrap {
+  color: var(--feature-accent);
+  background: var(--feature-bg-strong);
+}
+
+.icon {
+  display: block;
+}
+
+.itemText {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.skeleton {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border: 1px dashed var(--border-color);
+  border-radius: 12px;
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-size: 12.5px;
+}
+
+.skeletonDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--text-muted);
+  animation: pulse 1.2s ease-in-out infinite;
 }
 
 .error {
   margin: 12px 0;
   padding: 12px 16px;
   border: 1px solid var(--border-color);
-  border-radius: 8px;
+  border-radius: 12px;
   color: var(--text-muted);
   font-size: 12.5px;
+  background: var(--bg-secondary);
 }
 
-/* Stack vertically on narrow containers */
-@media (max-width: 600px) {
+@keyframes cardRise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.2);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card {
+    animation: none;
+  }
+  .card:hover {
+    transform: none;
+  }
+  .skeletonDot {
+    animation: none;
+  }
+}
+
+@media (max-width: 640px) {
   .grid {
     grid-template-columns: 1fr !important;
-  }
-
-  .card {
-    border-right: none;
-    border-bottom: 1px solid var(--border-color);
-  }
-
-  .card:last-child {
-    border-bottom: none;
   }
 }

--- a/src/components/ComparisonBlock/ComparisonBlock.test.jsx
+++ b/src/components/ComparisonBlock/ComparisonBlock.test.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import ComparisonBlock from './ComparisonBlock';
+
+const twoItemSpec = JSON.stringify({
+  items: [
+    {
+      name: 'Portsmouth to Fishbourne',
+      description: 'Most popular vehicle route',
+      pros: ['45-min crossing', 'Frequent sailings'],
+      cons: ['Busy drive through Portsmouth'],
+    },
+    {
+      name: 'Lymington to Yarmouth',
+      description: 'Shortest crossing via the New Forest',
+      pros: ['40-min crossing', 'Scenic drive'],
+      cons: ['Fewer sailings'],
+    },
+  ],
+});
+
+describe('ComparisonBlock', () => {
+  it('renders a card per item with name and description', () => {
+    render(<ComparisonBlock spec={twoItemSpec} />);
+
+    expect(screen.getByRole('heading', { name: 'Portsmouth to Fishbourne' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Lymington to Yarmouth' })).toBeInTheDocument();
+    expect(screen.getByText('Most popular vehicle route')).toBeInTheDocument();
+    expect(screen.getByText('Shortest crossing via the New Forest')).toBeInTheDocument();
+  });
+
+  it('renders pros and cons for every item', () => {
+    render(<ComparisonBlock spec={twoItemSpec} />);
+
+    expect(screen.getAllByText('Pros')).toHaveLength(2);
+    expect(screen.getAllByText('Cons')).toHaveLength(2);
+    expect(screen.getByText('45-min crossing')).toBeInTheDocument();
+    expect(screen.getByText('Frequent sailings')).toBeInTheDocument();
+    expect(screen.getByText('Busy drive through Portsmouth')).toBeInTheDocument();
+    expect(screen.getByText('Fewer sailings')).toBeInTheDocument();
+  });
+
+  it('assigns a sequential letter badge (A, B, C…) to each card', () => {
+    render(<ComparisonBlock spec={twoItemSpec} />);
+    const block = screen.getByTestId('comparison-block');
+    const articles = block.querySelectorAll('article');
+    expect(articles).toHaveLength(2);
+    expect(within(articles[0]).getByText('A')).toBeInTheDocument();
+    expect(within(articles[1]).getByText('B')).toBeInTheDocument();
+  });
+
+  it('renders a features section when provided', () => {
+    const spec = JSON.stringify({
+      items: [
+        { name: 'Plan A', features: ['Fast', 'Reliable'] },
+        { name: 'Plan B', features: ['Cheap'] },
+      ],
+    });
+    render(<ComparisonBlock spec={spec} />);
+    expect(screen.getAllByText('Features')).toHaveLength(2);
+    expect(screen.getByText('Fast')).toBeInTheDocument();
+    expect(screen.getByText('Cheap')).toBeInTheDocument();
+  });
+
+  it('accepts a pre-parsed spec object', () => {
+    const parsed = JSON.parse(twoItemSpec);
+    render(<ComparisonBlock spec={parsed} />);
+    expect(screen.getByRole('heading', { name: 'Portsmouth to Fishbourne' })).toBeInTheDocument();
+  });
+
+  it('shows a skeleton while streaming with invalid JSON', () => {
+    render(<ComparisonBlock spec={'{ bad json '} isStreaming />);
+    expect(screen.getByText(/Building comparison/)).toBeInTheDocument();
+  });
+
+  it('shows an error when a final spec cannot be parsed', () => {
+    render(<ComparisonBlock spec={'nope'} />);
+    expect(screen.getByText('Could not parse comparison data')).toBeInTheDocument();
+  });
+
+  it('shows an error when fewer than two valid items exist', () => {
+    const spec = JSON.stringify({ items: [{ name: 'Only one' }] });
+    render(<ComparisonBlock spec={spec} />);
+    expect(screen.getByText('Could not parse comparison data')).toBeInTheDocument();
+  });
+
+  it('applies the column count as a CSS custom property', () => {
+    render(<ComparisonBlock spec={twoItemSpec} />);
+    const grid = screen.getByTestId('comparison-block').firstChild;
+    expect(grid.style.getPropertyValue('--comparison-cols')).toBe('2');
+  });
+
+  it('omits the pros section when the pros array is empty', () => {
+    const spec = JSON.stringify({
+      items: [
+        { name: 'One', cons: ['bad'] },
+        { name: 'Two', cons: ['worse'] },
+      ],
+    });
+    render(<ComparisonBlock spec={spec} />);
+    expect(screen.queryByText('Pros')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Cons')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Rework ComparisonBlock so it reads as a crafted layout rather than a generic three-column table. Each option now lives on its own softly elevated card with a lettered badge, a tri-color accent strip tuned to the warm/charcoal theme tokens, pill-shaped section labels, and tinted chips that carry an inline SVG icon for pros, cons, and features. Cards gently rise in on mount and lift on hover, and all hues are driven by CSS custom properties so light and dark modes stay coherent with the app's palette.

Add a focused test suite covering badge order, pros/cons/features rendering, streaming skeleton vs. parse-error fallback, pre-parsed spec input, and the grid column CSS variable.

https://claude.ai/code/session_017YhEWE9HiRdr54HYdYtqnC