### PR TITLE
fix(comparison): drop gradient bar and flow cards with auto-fit grid

### DIFF
--- a/src/components/ComparisonBlock/ComparisonBlock.module.css
+++ b/src/components/ComparisonBlock/ComparisonBlock.module.css
@@ -27,7 +27,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(var(--comparison-cols, 2), minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
   gap: 14px;
 }
 
@@ -42,6 +42,7 @@
   border: 1px solid var(--border-color);
   box-shadow: 0 1px 0 var(--card-ring);
   overflow: hidden;
+  min-width: 0;
   isolation: isolate;
   transition: transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1), box-shadow 220ms ease,
     border-color 220ms ease, background-color 220ms ease;
@@ -49,31 +50,11 @@
   animation-delay: calc(var(--comparison-index, 0) * 70ms);
 }
 
-.card::before {
-  content: '';
-  position: absolute;
-  inset: 0 0 auto 0;
-  height: 2px;
-  background: linear-gradient(
-    90deg,
-    var(--pro-accent) 0%,
-    var(--feature-accent) 55%,
-    var(--con-accent) 100%
-  );
-  opacity: 0.55;
-  transition: opacity 220ms ease;
-  pointer-events: none;
-}
-
 .card:hover {
   transform: translateY(-2px);
   border-color: var(--border-input);
   box-shadow: var(--shadow-lg);
   background: var(--bg-input);
-}
-
-.card:hover::before {
-  opacity: 0.9;
 }
 
 .cardHeader {
@@ -321,7 +302,16 @@
 }
 
 @media (max-width: 640px) {
-  .grid {
-    grid-template-columns: 1fr !important;
+  .wrapper {
+    margin: 14px 0 18px;
+  }
+
+  .card {
+    padding: 16px 14px 18px;
+    border-radius: 14px;
+  }
+
+  .cardName {
+    font-size: 14px;
   }
 }


### PR DESCRIPTION
The top accent bar read as AI-template styling, and forcing a column count made narrow viewports squeeze cards instead of wrapping cleanly. Now the grid wraps naturally at small widths and each card keeps its own shape.