### PR TITLE
feat(composer): syntax-highlight markdown across every prompt input

### DIFF
--- a/src/components/ImageGalleryView/ImageGalleryView.jsx
+++ b/src/components/ImageGalleryView/ImageGalleryView.jsx
@@ -51,6 +51,7 @@ import {
 } from '../Icons';
 import ModelSelector from '../ModelSelector/ModelSelector';
 import styles from './ImageGalleryView.module.css';
+import MarkdownTextarea from '../MarkdownTextarea/MarkdownTextarea';
 
 const PAGE_SIZE = 9;
 
@@ -431,7 +432,7 @@ export default function ImageGalleryView() {
                   : ''
               }`}
             >
-              <textarea
+              <MarkdownTextarea
                 ref={promptInputRef}
                 className={styles.promptInput}
                 placeholder="Describe an image..."
@@ -439,6 +440,7 @@ export default function ImageGalleryView() {
                 onChange={handlePromptInputChange}
                 onKeyDown={handlePromptKeyDown}
                 rows={1}
+                aria-label="Image prompt input"
               />
               <div className={styles.promptActions}>
                 <div className={styles.promptActionsLeft} ref={attachMenuRef}>

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -103,6 +103,7 @@ import {
 } from '../Icons';
 import ModelSelector from '../ModelSelector/ModelSelector';
 import MessageList from '../MessageList/MessageList';
+import MarkdownTextarea from '../MarkdownTextarea/MarkdownTextarea';
 import {
   sendMessage,
   consumeSSEStream,
@@ -3242,7 +3243,7 @@ export default function MainContent() {
                   </span>
                 </div>
               )}
-              <textarea
+              <MarkdownTextarea
                 ref={textareaRef}
                 className={styles.input}
                 placeholder={hasMessages ? 'Reply...' : 'Ask anything...'}

--- a/src/components/MarkdownTextarea/MarkdownTextarea.jsx
+++ b/src/components/MarkdownTextarea/MarkdownTextarea.jsx
@@ -1,0 +1,171 @@
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
+import styles from './MarkdownTextarea.module.css';
+import { tokenize, splitLink, markerWidth } from './tokenize';
+
+/**
+ * Render one tokenizer output as React children. Colour-only decoration keeps
+ * the mirror character-aligned with the transparent textarea above it.
+ *
+ * @param {Array<{ type: string, text: string }>} tokens
+ * @returns {import('react').ReactNode[]}
+ */
+function renderTokens(tokens) {
+  return tokens.map((tok, i) => {
+    const key = i;
+    switch (tok.type) {
+      case 'text':
+      case 'fenceBody':
+        return tok.type === 'fenceBody' ? (
+          <span key={key} className={styles.fenceBody}>
+            {tok.text}
+          </span>
+        ) : (
+          tok.text
+        );
+
+      case 'marker':
+      case 'fence':
+        return (
+          <span key={key} className={styles.muted}>
+            {tok.text}
+          </span>
+        );
+
+      case 'hr':
+        return (
+          <span key={key} className={styles.hr}>
+            {tok.text}
+          </span>
+        );
+
+      case 'bold':
+      case 'italic':
+      case 'strike': {
+        const width = markerWidth(tok.type);
+        const open = tok.text.slice(0, width);
+        const content = tok.text.slice(width, tok.text.length - width);
+        const close = tok.text.slice(tok.text.length - width);
+        const className = tok.type === 'strike' ? styles.strike : undefined;
+        return (
+          <span key={key} className={className}>
+            <span className={styles.muted}>{open}</span>
+            {content}
+            <span className={styles.muted}>{close}</span>
+          </span>
+        );
+      }
+
+      case 'code': {
+        const content = tok.text.slice(1, -1);
+        return (
+          <span key={key} className={styles.code}>
+            <span className={styles.muted}>`</span>
+            {content}
+            <span className={styles.muted}>`</span>
+          </span>
+        );
+      }
+
+      case 'link': {
+        const parts = splitLink(tok.text);
+        if (!parts) return tok.text;
+        return (
+          <span key={key}>
+            <span className={styles.muted}>{parts.open}</span>
+            <span className={styles.linkText}>{parts.label}</span>
+            <span className={styles.muted}>{parts.mid}</span>
+            <span className={styles.linkUrl}>{parts.url}</span>
+            <span className={styles.muted}>{parts.close}</span>
+          </span>
+        );
+      }
+
+      default:
+        return tok.text;
+    }
+  });
+}
+
+/**
+ * MarkdownTextarea is a drop-in replacement for `<textarea>` that highlights
+ * markdown syntax as the user types. It layers a transparent textarea over a
+ * style-synced mirror; the textarea owns selection, caret, IME, and paste
+ * behaviour, while the mirror paints token-aware colour decoration.
+ *
+ * Contract with callers:
+ *   - Receives the same `className` the call site previously applied to its
+ *     textarea. That class must declare font-family/size/line-height/padding
+ *     and min/max height — we forward it to BOTH the mirror and the textarea
+ *     so both layers size and flow identically.
+ *   - Forwards the imperative textarea handle via `ref`, so existing code
+ *     that calls `.focus()`, `.style.height = 'auto'`, or reads `.value`
+ *     keeps working unchanged.
+ *   - All other props (value, onChange, onKeyDown, placeholder, disabled,
+ *     rows, aria-label, etc.) pass through to the underlying textarea.
+ *
+ * Accessibility: the mirror is marked `aria-hidden` so assistive tech only
+ * sees the textarea. Spell-check and autocomplete remain native.
+ */
+const MarkdownTextarea = forwardRef(function MarkdownTextarea(props, ref) {
+  const { value = '', className = '', onScroll, ...rest } = props;
+
+  const textareaRef = useRef(null);
+  const mirrorRef = useRef(null);
+
+  useImperativeHandle(ref, () => textareaRef.current, []);
+
+  const tokens = useMemo(() => tokenize(value), [value]);
+  const rendered = useMemo(() => renderTokens(tokens), [tokens]);
+
+  // Keep the mirror's scroll position in sync with the textarea so long
+  // content stays aligned when the user scrolls the composer.
+  const handleScroll = useCallback(
+    (event) => {
+      const mirror = mirrorRef.current;
+      const textarea = textareaRef.current;
+      if (mirror && textarea) {
+        mirror.scrollTop = textarea.scrollTop;
+        mirror.scrollLeft = textarea.scrollLeft;
+      }
+      if (onScroll) onScroll(event);
+    },
+    [onScroll]
+  );
+
+  // Re-sync scroll after any value change — auto-resize or external updates
+  // can shift scrollTop by a fraction of a line.
+  useLayoutEffect(() => {
+    const mirror = mirrorRef.current;
+    const textarea = textareaRef.current;
+    if (mirror && textarea) {
+      mirror.scrollTop = textarea.scrollTop;
+    }
+  }, [value]);
+
+  const endsWithNewline = value.length > 0 && value.endsWith('\n');
+
+  return (
+    <div className={styles.wrap}>
+      <div ref={mirrorRef} className={`${styles.mirror} ${className}`} aria-hidden="true">
+        {rendered}
+        {endsWithNewline && <span className={styles.trailingNewline} />}
+      </div>
+      <textarea
+        {...rest}
+        ref={textareaRef}
+        value={value}
+        onScroll={handleScroll}
+        className={`${styles.textarea} ${className}`}
+      />
+    </div>
+  );
+});
+
+export default MarkdownTextarea;

--- a/src/components/MarkdownTextarea/MarkdownTextarea.module.css
+++ b/src/components/MarkdownTextarea/MarkdownTextarea.module.css
@@ -1,0 +1,150 @@
+/**
+ * MarkdownTextarea overlays a highlight mirror under a transparent textarea.
+ *
+ * Hard constraints to keep caret/selection aligned with the mirror:
+ *   - All font metrics (family, size, weight, style, letter-spacing, line-height)
+ *     must be IDENTICAL between .textarea and .mirror. We therefore only style
+ *     tokens with colour, background, and text-decoration — never font-weight,
+ *     font-style, or font-family.
+ *   - Padding, border, width, min/max-height come from the parent's className,
+ *     which we apply to BOTH the textarea and the mirror. The wrapper itself
+ *     is a contentless positioning context.
+ *
+ * Specificity note: we intentionally prefix the critical rules with `.wrap`
+ * so the compiled selectors have specificity (0,2,0). That beats any single-
+ * class caller rule (0,1,0) regardless of stylesheet source order, which is
+ * what guarantees the textarea text stays transparent and the mirror stays
+ * coloured no matter what the parent's class declares.
+ */
+
+.wrap {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+/*
+ * Mirror: the visible highlighted text. Absolutely positioned, pointer-events
+ * disabled so clicks pass through to the textarea below. `inset: 0` makes it
+ * fill the wrap, which sizes itself from the textarea's layout height.
+ */
+.wrap .mirror {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  user-select: none;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  color: var(--text-primary);
+  /* The parent's class supplies font-size, line-height, padding, and overflow
+     behaviour — we inherit overflow so the mirror's content can scroll in
+     lockstep with the textarea below. Box-sizing is pinned to match the
+     browser-default textarea box so padding doesn't misalign the two layers. */
+  box-sizing: border-box;
+  /* Hide the mirror's scrollbar — only the textarea surfaces one to the user.
+     The mirror's scrollTop is synced from the textarea via JS. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  /* Neutralise any min/max height the caller set for the textarea — the
+     mirror must size from the wrap (and therefore the textarea) only. */
+  min-height: 0 !important;
+  max-height: none !important;
+}
+
+.wrap .mirror::-webkit-scrollbar {
+  display: none;
+}
+
+/*
+ * Textarea: the interactive layer. Text is transparent so only the caret and
+ * selection show through; the mirror paints the styled glyphs underneath.
+ */
+.wrap .textarea {
+  position: relative;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  caret-color: var(--text-primary);
+  background: transparent;
+  box-sizing: border-box;
+}
+
+/* Keep the placeholder visible on the textarea (the mirror is empty then). */
+.wrap .textarea::placeholder {
+  color: var(--text-muted);
+  -webkit-text-fill-color: var(--text-muted);
+  opacity: 1;
+}
+
+/*
+ * Selection highlight: browsers render the textarea's selection rectangle
+ * on top of the mirror. The textarea's text is transparent, so we override
+ * ::selection to show a tinted rectangle without painting invisible glyphs.
+ */
+.wrap .textarea::selection {
+  background-color: color-mix(in srgb, var(--text-primary) 22%, transparent);
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
+[data-theme='dark'] .wrap .textarea::selection {
+  background-color: color-mix(in srgb, var(--text-primary) 28%, transparent);
+}
+
+/*
+ * Token styles. Colour-only — no metric-affecting properties allowed.
+ */
+.muted {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.code {
+  background-color: color-mix(in srgb, var(--text-muted) 14%, transparent);
+  border-radius: 3px;
+  /* box-shadow acts as a "padding-free" inset rim that won't shift layout. */
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-muted) 18%, transparent);
+}
+
+[data-theme='dark'] .code {
+  background-color: color-mix(in srgb, var(--text-muted) 22%, transparent);
+}
+
+.linkText {
+  color: var(--accent-primary, #8b5cf6);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--accent-primary, #8b5cf6) 50%, transparent);
+  text-underline-offset: 2px;
+}
+
+.linkUrl {
+  color: var(--text-muted);
+}
+
+.strike {
+  text-decoration: line-through;
+  text-decoration-thickness: 1.5px;
+  text-decoration-color: color-mix(in srgb, var(--text-muted) 70%, transparent);
+}
+
+.fenceBody {
+  background-color: color-mix(in srgb, var(--text-muted) 10%, transparent);
+}
+
+[data-theme='dark'] .fenceBody {
+  background-color: color-mix(in srgb, var(--text-muted) 18%, transparent);
+}
+
+.hr {
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+
+/*
+ * Trailing caret row: when the textarea ends in a newline it reserves a blank
+ * line for the caret. A <div>'s final \n alone doesn't produce that line, so
+ * we render a zero-width placeholder to guarantee a matching row height.
+ */
+.trailingNewline::after {
+  content: '\200B';
+}

--- a/src/components/MarkdownTextarea/MarkdownTextarea.test.jsx
+++ b/src/components/MarkdownTextarea/MarkdownTextarea.test.jsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MarkdownTextarea from './MarkdownTextarea';
+
+describe('MarkdownTextarea', () => {
+  it('forwards the textarea ref so call sites can still auto-resize', () => {
+    const ref = createRef();
+    render(<MarkdownTextarea ref={ref} value="" onChange={() => {}} />);
+    expect(ref.current).toBeInstanceOf(HTMLTextAreaElement);
+  });
+
+  it('calls onChange with the user input', () => {
+    const onChange = vi.fn();
+    render(<MarkdownTextarea value="" onChange={onChange} aria-label="composer" />);
+    const textarea = screen.getByLabelText('composer');
+    fireEvent.change(textarea, { target: { value: 'hi' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through arbitrary textarea props', () => {
+    render(
+      <MarkdownTextarea value="" onChange={() => {}} placeholder="Ask anything" rows={2} disabled />
+    );
+    const textarea = screen.getByPlaceholderText('Ask anything');
+    expect(textarea).toBeDisabled();
+    expect(textarea.rows).toBe(2);
+  });
+
+  it('applies the caller className to both the mirror and the textarea so metrics align', () => {
+    const { container } = render(
+      <MarkdownTextarea value="" onChange={() => {}} className="custom" />
+    );
+    const styled = container.querySelectorAll('.custom');
+    expect(styled.length).toBe(2);
+  });
+
+  it('renders the mirror with aria-hidden so screen readers only see the textarea', () => {
+    const { container } = render(<MarkdownTextarea value="# Heading" onChange={() => {}} />);
+    const mirror = container.querySelector('[aria-hidden="true"]');
+    expect(mirror).not.toBeNull();
+  });
+
+  it('mirrors the current value in the DOM', () => {
+    const { container } = render(
+      <MarkdownTextarea value="Hello **bold** world" onChange={() => {}} />
+    );
+    const mirror = container.querySelector('[aria-hidden="true"]');
+    expect(mirror.textContent).toContain('Hello');
+    expect(mirror.textContent).toContain('**bold**');
+    expect(mirror.textContent).toContain('world');
+  });
+
+  it('invokes forwarded onScroll and keeps the mirror in sync', () => {
+    const onScroll = vi.fn();
+    const { container } = render(
+      <MarkdownTextarea
+        value={'line\n'.repeat(50)}
+        onChange={() => {}}
+        onScroll={onScroll}
+        aria-label="composer"
+      />
+    );
+    const textarea = screen.getByLabelText('composer');
+    fireEvent.scroll(textarea, { target: { scrollTop: 120 } });
+    expect(onScroll).toHaveBeenCalledTimes(1);
+    const mirror = container.querySelector('[aria-hidden="true"]');
+    expect(mirror.scrollTop).toBe(textarea.scrollTop);
+  });
+});

--- a/src/components/MarkdownTextarea/tokenize.js
+++ b/src/components/MarkdownTextarea/tokenize.js
@@ -1,0 +1,185 @@
+/**
+ * Tokenize markdown text for the in-composer syntax-highlight mirror.
+ *
+ * Returns a flat list of `{ type, text }` tokens. Consumers render each token
+ * with a CSS class to visually distinguish markers (#, **, `, etc.) from their
+ * content. Whitespace — including the newlines between lines — is preserved
+ * exactly in the token stream so `white-space: pre-wrap` rendering matches the
+ * source textarea character for character.
+ *
+ * Design constraint: this tokenizer is lenient — unclosed markers (e.g. `**foo`
+ * with no closing `**`) fall through as plain text, so the user sees their
+ * in-progress typing without a premature highlight.
+ */
+
+// Block-level patterns (anchored to line start).
+const FENCE_RE = /^```/;
+const HEADING_RE = /^(#{1,6})(\s+)(.*)$/;
+const UL_RE = /^([-*+])(\s+)(.*)$/;
+const OL_RE = /^(\d+\.)(\s+)(.*)$/;
+const BQ_RE = /^(>)(\s?)(.*)$/;
+const HR_RE = /^(?:---|\*\*\*|___)\s*$/;
+
+// Inline patterns. Order matters: code first so *foo* inside `code` isn't
+// mistaken for italic. Each pattern is self-contained (no line crossings)
+// and requires a closing marker — unclosed tokens stay as plain text.
+const INLINE_RE =
+  /(`[^`\n]+?`|\*\*[^*\n]+?\*\*|__[^_\n]+?__|\*[^*\n]+?\*|(?<![A-Za-z0-9_])_[^_\n]+?_(?![A-Za-z0-9_])|~~[^~\n]+?~~|\[[^\]\n]+?\]\([^)\n]+?\))/;
+
+/**
+ * Classify a single inline match into its token type.
+ * @param {string} s - A string matched by INLINE_RE.
+ * @returns {'code'|'bold'|'italic'|'strike'|'link'}
+ */
+function classifyInline(s) {
+  if (s.startsWith('`')) return 'code';
+  if (s.startsWith('**') || s.startsWith('__')) return 'bold';
+  if (s.startsWith('~~')) return 'strike';
+  if (s.startsWith('[')) return 'link';
+  return 'italic';
+}
+
+/**
+ * Tokenize inline content (a single line, no newlines inside).
+ * @param {string} line
+ * @returns {Array<{ type: string, text: string }>}
+ */
+function tokenizeInline(line) {
+  if (!line) return [];
+  const parts = line.split(INLINE_RE);
+  const out = [];
+  for (const part of parts) {
+    if (!part) continue;
+    if (INLINE_RE.test(part) && part.length >= 2) {
+      out.push({ type: classifyInline(part), text: part });
+    } else {
+      out.push({ type: 'text', text: part });
+    }
+  }
+  return out;
+}
+
+/**
+ * Append `\n` to the last token's text (folding newlines into the preceding
+ * token keeps the token list short and preserves `white-space: pre-wrap`).
+ * If the last token is a marker (which shouldn't absorb trailing whitespace,
+ * e.g. an HR line), push a dedicated text token instead.
+ * @param {Array<{ type: string, text: string }>} tokens
+ */
+function appendNewline(tokens) {
+  if (tokens.length === 0) {
+    tokens.push({ type: 'text', text: '\n' });
+    return;
+  }
+  const last = tokens[tokens.length - 1];
+  if (last.type === 'text') {
+    last.text += '\n';
+  } else {
+    tokens.push({ type: 'text', text: '\n' });
+  }
+}
+
+/**
+ * Tokenize a full markdown source string.
+ * @param {string} text
+ * @returns {Array<{ type: string, text: string }>}
+ */
+export function tokenize(text) {
+  if (!text) return [];
+  const lines = text.split('\n');
+  const tokens = [];
+  let inFence = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const isLast = i === lines.length - 1;
+
+    if (FENCE_RE.test(line)) {
+      tokens.push({ type: 'fence', text: line });
+      inFence = !inFence;
+      if (!isLast) appendNewline(tokens);
+      continue;
+    }
+
+    if (inFence) {
+      if (line.length > 0) tokens.push({ type: 'fenceBody', text: line });
+      if (!isLast) appendNewline(tokens);
+      continue;
+    }
+
+    if (HR_RE.test(line)) {
+      tokens.push({ type: 'hr', text: line });
+      if (!isLast) appendNewline(tokens);
+      continue;
+    }
+
+    const heading = HEADING_RE.exec(line);
+    if (heading) {
+      tokens.push({ type: 'marker', text: heading[1] + heading[2] });
+      tokens.push(...tokenizeInline(heading[3]));
+      if (!isLast) appendNewline(tokens);
+      continue;
+    }
+
+    const ul = UL_RE.exec(line);
+    if (ul) {
+      tokens.push({ type: 'marker', text: ul[1] + ul[2] });
+      tokens.push(...tokenizeInline(ul[3]));
+      if (!isLast) appendNewline(tokens);
+      continue;
+    }
+
+    const ol = OL_RE.exec(line);
+    if (ol) {
+      tokens.push({ type: 'marker', text: ol[1] + ol[2] });
+      tokens.push(...tokenizeInline(ol[3]));
+      if (!isLast) appendNewline(tokens);
+      continue;
+    }
+
+    const bq = BQ_RE.exec(line);
+    if (bq) {
+      tokens.push({ type: 'marker', text: bq[1] + bq[2] });
+      tokens.push(...tokenizeInline(bq[3]));
+      if (!isLast) appendNewline(tokens);
+      continue;
+    }
+
+    tokens.push(...tokenizeInline(line));
+    if (!isLast) appendNewline(tokens);
+  }
+
+  return tokens;
+}
+
+/**
+ * Split a `[text](url)` token into its five structural parts so the renderer
+ * can style them differently (markers muted, link text accented, url faint).
+ * @param {string} raw - The full `[text](url)` literal.
+ * @returns {{ open: string, label: string, mid: string, url: string, close: string } | null}
+ */
+export function splitLink(raw) {
+  const m = /^(\[)([^\]\n]+?)(\]\()([^)\n]+?)(\))$/.exec(raw);
+  if (!m) return null;
+  return { open: m[1], label: m[2], mid: m[3], url: m[4], close: m[5] };
+}
+
+/**
+ * Return the marker width for inline tokens so the renderer can slice content
+ * out of bracketed spans without reparsing (e.g. `**foo**` → marker=2).
+ * @param {string} type
+ * @returns {number}
+ */
+export function markerWidth(type) {
+  switch (type) {
+    case 'code':
+      return 1;
+    case 'italic':
+      return 1;
+    case 'bold':
+    case 'strike':
+      return 2;
+    default:
+      return 0;
+  }
+}

--- a/src/components/MarkdownTextarea/tokenize.test.js
+++ b/src/components/MarkdownTextarea/tokenize.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { tokenize, splitLink, markerWidth } from './tokenize';
+
+/**
+ * Concatenate token text back to source — the tokenizer must be lossless so
+ * the mirror aligns with the textarea character-for-character.
+ */
+const reassemble = (tokens) => tokens.map((t) => t.text).join('');
+
+describe('tokenize()', () => {
+  it('returns an empty list for empty input', () => {
+    expect(tokenize('')).toEqual([]);
+  });
+
+  it('is lossless — reassembled tokens equal the source', () => {
+    const samples = [
+      'plain text',
+      '# Heading\n\nBody with **bold** and *italic*.',
+      '- one\n- two\n- three',
+      '> quoted\n> second line',
+      '```js\nconst x = 1;\n```',
+      'See [docs](https://example.com) for more.',
+      'Mix `code` and **bold** and _italic_ on one line.',
+    ];
+    for (const s of samples) {
+      expect(reassemble(tokenize(s))).toBe(s);
+    }
+  });
+
+  it('marks headings with a marker token', () => {
+    const tokens = tokenize('# Hello');
+    expect(tokens[0]).toEqual({ type: 'marker', text: '# ' });
+    expect(tokens[1]).toEqual({ type: 'text', text: 'Hello' });
+  });
+
+  it('handles H1 through H6', () => {
+    for (let level = 1; level <= 6; level++) {
+      const hashes = '#'.repeat(level);
+      const tokens = tokenize(`${hashes} Title`);
+      expect(tokens[0].type).toBe('marker');
+      expect(tokens[0].text).toBe(`${hashes} `);
+    }
+  });
+
+  it('does NOT treat 7+ hashes as a heading', () => {
+    const tokens = tokenize('####### not a heading');
+    expect(tokens.find((t) => t.type === 'marker')).toBeUndefined();
+  });
+
+  it('tokenizes bold with **', () => {
+    const tokens = tokenize('say **hello** world');
+    const bold = tokens.find((t) => t.type === 'bold');
+    expect(bold).toEqual({ type: 'bold', text: '**hello**' });
+  });
+
+  it('tokenizes bold with __', () => {
+    const tokens = tokenize('__strong__');
+    expect(tokens).toContainEqual({ type: 'bold', text: '__strong__' });
+  });
+
+  it('tokenizes italic with *', () => {
+    const tokens = tokenize('*em*');
+    expect(tokens).toContainEqual({ type: 'italic', text: '*em*' });
+  });
+
+  it('tokenizes italic with _ but NOT inside words (snake_case)', () => {
+    const tokens = tokenize('my_variable_name');
+    expect(tokens.every((t) => t.type === 'text')).toBe(true);
+  });
+
+  it('tokenizes standalone italic with _', () => {
+    const tokens = tokenize('it is _emphasized_ here');
+    expect(tokens).toContainEqual({ type: 'italic', text: '_emphasized_' });
+  });
+
+  it('tokenizes inline code', () => {
+    const tokens = tokenize('run `npm install` first');
+    expect(tokens).toContainEqual({ type: 'code', text: '`npm install`' });
+  });
+
+  it('tokenizes strikethrough', () => {
+    const tokens = tokenize('~~gone~~');
+    expect(tokens).toContainEqual({ type: 'strike', text: '~~gone~~' });
+  });
+
+  it('tokenizes links', () => {
+    const tokens = tokenize('see [docs](https://example.com)');
+    expect(tokens).toContainEqual({
+      type: 'link',
+      text: '[docs](https://example.com)',
+    });
+  });
+
+  it('leaves unclosed bold as plain text', () => {
+    const tokens = tokenize('**unclosed bold');
+    expect(tokens).toEqual([{ type: 'text', text: '**unclosed bold' }]);
+  });
+
+  it('leaves unclosed inline code as plain text', () => {
+    const tokens = tokenize('`unclosed');
+    expect(tokens).toEqual([{ type: 'text', text: '`unclosed' }]);
+  });
+
+  it('does NOT highlight inline tokens inside a code fence', () => {
+    const tokens = tokenize('```\nconst **not_bold** = 1;\n```');
+    const fenceBody = tokens.find((t) => t.type === 'fenceBody');
+    expect(fenceBody).toBeDefined();
+    expect(fenceBody.text).toBe('const **not_bold** = 1;');
+    // No bold/italic tokens from inside the fence.
+    expect(tokens.some((t) => t.type === 'bold' || t.type === 'italic')).toBe(false);
+  });
+
+  it('handles code fence with language', () => {
+    const tokens = tokenize('```js\nconst x = 1;\n```');
+    expect(tokens[0]).toEqual({ type: 'fence', text: '```js' });
+    expect(tokens.find((t) => t.type === 'fenceBody')).toEqual({
+      type: 'fenceBody',
+      text: 'const x = 1;',
+    });
+  });
+
+  it('tokenizes unordered list markers', () => {
+    const tokens = tokenize('- item one\n* item two\n+ item three');
+    const markers = tokens.filter((t) => t.type === 'marker');
+    expect(markers.map((m) => m.text)).toEqual(['- ', '* ', '+ ']);
+  });
+
+  it('tokenizes ordered list markers', () => {
+    const tokens = tokenize('1. first\n2. second\n10. tenth');
+    const markers = tokens.filter((t) => t.type === 'marker');
+    expect(markers.map((m) => m.text)).toEqual(['1. ', '2. ', '10. ']);
+  });
+
+  it('tokenizes blockquotes', () => {
+    const tokens = tokenize('> quoted text');
+    expect(tokens[0]).toEqual({ type: 'marker', text: '> ' });
+  });
+
+  it('tokenizes horizontal rules', () => {
+    expect(tokenize('---')).toEqual([{ type: 'hr', text: '---' }]);
+    expect(tokenize('***')).toEqual([{ type: 'hr', text: '***' }]);
+    expect(tokenize('___')).toEqual([{ type: 'hr', text: '___' }]);
+  });
+
+  it('preserves trailing newlines', () => {
+    const tokens = tokenize('hello\n');
+    expect(reassemble(tokens)).toBe('hello\n');
+  });
+
+  it('preserves empty lines', () => {
+    const tokens = tokenize('a\n\nb');
+    expect(reassemble(tokens)).toBe('a\n\nb');
+  });
+
+  it('combines heading + inline markup', () => {
+    const tokens = tokenize('# Title with **bold**');
+    expect(tokens[0]).toEqual({ type: 'marker', text: '# ' });
+    expect(tokens).toContainEqual({ type: 'bold', text: '**bold**' });
+  });
+
+  it('does not misfire on a lone asterisk', () => {
+    const tokens = tokenize('2 * 3 = 6');
+    expect(tokens).toEqual([{ type: 'text', text: '2 * 3 = 6' }]);
+  });
+});
+
+describe('splitLink()', () => {
+  it('splits a well-formed link into parts', () => {
+    expect(splitLink('[docs](https://example.com)')).toEqual({
+      open: '[',
+      label: 'docs',
+      mid: '](',
+      url: 'https://example.com',
+      close: ')',
+    });
+  });
+
+  it('returns null for malformed links', () => {
+    expect(splitLink('[broken')).toBeNull();
+    expect(splitLink('no-brackets')).toBeNull();
+  });
+});
+
+describe('markerWidth()', () => {
+  it('returns correct widths for inline types', () => {
+    expect(markerWidth('code')).toBe(1);
+    expect(markerWidth('italic')).toBe(1);
+    expect(markerWidth('bold')).toBe(2);
+    expect(markerWidth('strike')).toBe(2);
+    expect(markerWidth('text')).toBe(0);
+  });
+});

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -73,6 +73,7 @@ import { detectWeatherResponse, extractWeatherData } from '../WeatherCard/weathe
 import { generateAndDownload } from '../../services/fileGenerator';
 import { dedupeCitations } from '../../utils/dedupeCitations';
 import styles from './MessageList.module.css';
+import MarkdownTextarea from '../MarkdownTextarea/MarkdownTextarea';
 
 // Initialize mermaid with sensible defaults
 mermaid.initialize({
@@ -3618,7 +3619,7 @@ function SubConversationPanel({
         <div className={styles.subConvInputSection}>
           <form className={styles.subConvInputContainer} onSubmit={handleSubmit}>
             <div className={styles.subConvInputWrapper}>
-              <textarea
+              <MarkdownTextarea
                 ref={textareaRef}
                 className={styles.subConvTextarea}
                 placeholder="Ask about this..."
@@ -3630,6 +3631,7 @@ function SubConversationPanel({
                 onKeyDown={handleKeyDown}
                 disabled={isSending}
                 rows={1}
+                aria-label="Follow-up input"
               />
               <div className={styles.subConvInputActions}>
                 <button

--- a/src/components/ProjectsView/ProjectsView.jsx
+++ b/src/components/ProjectsView/ProjectsView.jsx
@@ -55,6 +55,7 @@ import {
 import ModelSelector from '../ModelSelector/ModelSelector';
 import ModalityBar from '../ModalityBar/ModalityBar';
 import styles from './ProjectsView.module.css';
+import MarkdownTextarea from '../MarkdownTextarea/MarkdownTextarea';
 
 const FILTER_TABS = [
   { id: 'all', label: 'All' },
@@ -411,7 +412,7 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
                   ))}
                 </div>
               )}
-              <textarea
+              <MarkdownTextarea
                 ref={textareaRef}
                 className={styles.wsChatInput}
                 value={chatInput}
@@ -419,6 +420,7 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
                 onKeyDown={handleKeyDown}
                 placeholder={`Ask anything about ${project.name}...`}
                 rows={1}
+                aria-label={`Project ${project.name} input`}
               />
               <div className={styles.wsChatActions}>
                 <div className={styles.wsChatLeft}>


### PR DESCRIPTION
Introduces <MarkdownTextarea>, a drop-in <textarea> replacement that layers a transparent textarea over a style-synced highlight mirror. Raw markdown tokens (**bold**, # heading, `code`, [link](url), lists, blockquotes, code fences) now read as intentional structure instead of bare symbols — the textarea keeps native paste, IME, caret, selection, and mobile-keyboard behaviour untouched.

The mirror uses colour-and-decoration only (no font-weight, font-family, or font-size changes), which is what guarantees the caret stays pixel- aligned to the glyph it's sitting next to. Selection colours and scroll position sync across the two layers.

Swapped in at all four prompt surfaces:
  - Main chat composer (MainContent)
  - Sub-conversation follow-up (MessageList)
  - Image prompt composer (ImageGalleryView)
  - Project workspace composer (ProjectsView)

Tokenizer is a pure, lossless function covered by 28 unit tests; the component layer has 7 integration tests asserting ref forwarding, change propagation, class pass-through, aria-hidden mirror, and scroll sync.