### PR TITLE
feat(home): dynamic, context-aware subtitle on the landing screen

### DIFF
--- a/src/components/DynamicSubtitle/DynamicSubtitle.jsx
+++ b/src/components/DynamicSubtitle/DynamicSubtitle.jsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { selectConversations, selectInputValue } from '../../store/slices/chatSlice';
+import { fetchConversationMessages } from '../../services/api';
+import { buildSubtitle, inferIntent, summariseTitle } from '../../utils/conversationIntent';
+import styles from './DynamicSubtitle.module.css';
+
+const STALE_WINDOW_MS = 48 * 60 * 60 * 1000;
+const UNTITLED = 'New conversation';
+
+function pickCandidate(conversations) {
+  if (!Array.isArray(conversations) || conversations.length === 0) return null;
+  const cutoff = Date.now() - STALE_WINDOW_MS;
+  let best = null;
+  let bestTime = 0;
+  for (const c of conversations) {
+    if (!c || c.isArchived || c.isReported) continue;
+    const ts = new Date(c.updatedAt ?? c.createdAt).getTime();
+    if (!Number.isFinite(ts) || ts < cutoff) continue;
+    if (ts > bestTime) {
+      best = c;
+      bestTime = ts;
+    }
+  }
+  return best;
+}
+
+/**
+ * Homepage subtitle that reflects the user's most recent conversation.
+ * Renders nothing when there is no candidate within the staleness window.
+ * When the main input is focused or has content, the line dims but stays
+ * in the DOM so the layout doesn't shift.
+ */
+export default function DynamicSubtitle({ onOpen, isInputActive = false }) {
+  const conversations = useSelector(selectConversations);
+  const inputValue = useSelector(selectInputValue);
+
+  const candidate = useMemo(() => pickCandidate(conversations), [conversations]);
+
+  const isUntitled = candidate?.title === UNTITLED;
+  const [firstMessageByConvId, setFirstMessageByConvId] = useState({});
+
+  useEffect(() => {
+    if (!candidate || !isUntitled) return undefined;
+    const id = candidate.id;
+    if (firstMessageByConvId[id] !== undefined) return undefined;
+
+    let cancelled = false;
+    fetchConversationMessages(id, 1, 0)
+      .then((data) => {
+        if (cancelled) return;
+        const msgs = Array.isArray(data?.messages) ? data.messages : [];
+        const firstUser = msgs.find((m) => m?.role === 'user') || msgs[0];
+        const content = firstUser && typeof firstUser.content === 'string' ? firstUser.content : '';
+        setFirstMessageByConvId((prev) => ({ ...prev, [id]: content }));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setFirstMessageByConvId((prev) => ({ ...prev, [id]: '' }));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [candidate, isUntitled, firstMessageByConvId]);
+
+  const dimmedState = isInputActive || inputValue.trim().length > 0;
+
+  // Latch the built sentence so it doesn't flicker between renders if the
+  // conversation list is re-sorted with the same leader.
+  const cacheRef = useRef({ key: null, prose: '', cta: '' });
+
+  if (!candidate) return null;
+
+  const sourceText = isUntitled ? firstMessageByConvId[candidate.id] : candidate.title;
+  if (isUntitled && sourceText === undefined) return null; // still loading
+  if (isUntitled && !sourceText) return null; // empty conversation — nothing to reference
+
+  const subject = summariseTitle(sourceText);
+  if (!subject) return null;
+
+  const intent = inferIntent(sourceText);
+  const cacheKey = `${candidate.id}::${intent}::${subject}`;
+  let prose;
+  let cta;
+  if (cacheRef.current.key === cacheKey) {
+    ({ prose, cta } = cacheRef.current);
+  } else {
+    const updatedAt = candidate.updatedAt ? new Date(candidate.updatedAt) : null;
+    const built = buildSubtitle(intent, subject, candidate.id, { updatedAt });
+    prose = built.prose;
+    cta = built.cta;
+    cacheRef.current = { key: cacheKey, prose, cta };
+  }
+
+  const classes = `${styles.line} ${dimmedState ? styles.dimmed : ''}`.trim();
+
+  return (
+    <p className={classes} aria-hidden={dimmedState ? 'true' : undefined}>
+      <span className={styles.prose}>{prose} </span>
+      <button
+        type="button"
+        className={styles.cta}
+        onClick={() => onOpen?.(candidate.id)}
+        tabIndex={dimmedState ? -1 : 0}
+        aria-hidden={dimmedState ? 'true' : undefined}
+        aria-label={`${cta}: ${subject}`}
+      >
+        {cta}
+      </button>
+    </p>
+  );
+}

--- a/src/components/DynamicSubtitle/DynamicSubtitle.module.css
+++ b/src/components/DynamicSubtitle/DynamicSubtitle.module.css
@@ -1,0 +1,74 @@
+.line {
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: 0.005em;
+  color: var(--text-muted);
+  margin: 0 0 32px;
+  text-align: center;
+  /* Embossed letterpress — no borders, no background. */
+  text-shadow: 0 1px 0 var(--emboss-highlight);
+  transition: opacity 150ms ease, filter 150ms ease;
+}
+
+.prose {
+  color: inherit;
+}
+
+.cta {
+  appearance: none;
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: var(--text-secondary);
+  text-shadow: inherit;
+  cursor: pointer;
+  border-bottom: 1px solid transparent;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.cta:hover,
+.cta:focus-visible {
+  color: var(--text-primary);
+  border-bottom-color: currentColor;
+}
+
+.cta:focus {
+  outline: none;
+}
+
+.cta:focus-visible {
+  outline: 2px solid var(--text-secondary);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+/* Dimmed state — active while the main input is focused or has content.
+   The line stays mounted so layout does not shift; it just recedes. */
+.dimmed {
+  opacity: 0.35;
+}
+
+.dimmed .cta {
+  pointer-events: none;
+  cursor: default;
+  border-bottom-color: transparent;
+  color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+  .line {
+    font-size: 17px;
+    margin-bottom: 24px;
+    padding: 0 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .line,
+  .cta {
+    transition: none;
+  }
+}

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -151,6 +151,7 @@ import {
   incrementGuestImageCount,
 } from '../../utils/guestSession';
 import { AuthModal } from '../Auth';
+import DynamicSubtitle from '../DynamicSubtitle/DynamicSubtitle';
 import useUserLocation from '../../hooks/useUserLocation';
 import styles from './MainContent.module.css';
 
@@ -1095,6 +1096,7 @@ export default function MainContent() {
   const [projectSearch, setProjectSearch] = useState('');
   const [isRenamingTitle, setIsRenamingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState('');
+  const [isInputFocused, setIsInputFocused] = useState(false);
   const newProjectInputRef = useRef(null);
   const projectSearchRef = useRef(null);
   const projectDropdownRef = useRef(null);
@@ -2245,6 +2247,15 @@ export default function MainContent() {
     }
   }, []);
 
+  const handleOpenRecent = useCallback(
+    (conversationId) => {
+      if (!conversationId) return;
+      navigate(`/conversations/${conversationId}`);
+      requestAnimationFrame(() => focusInput());
+    },
+    [navigate, focusInput]
+  );
+
   const handleCloseDropdown = () => {
     setActiveDropdown(null);
   };
@@ -3152,7 +3163,7 @@ export default function MainContent() {
         {!hasMessages && (
           <>
             <h1 className={styles.greeting}>{getGreeting()}</h1>
-            <p className={styles.subtitle}>What can I help you orchestrate today?</p>
+            <DynamicSubtitle onOpen={handleOpenRecent} isInputActive={isInputFocused} />
           </>
         )}
 
@@ -3250,6 +3261,8 @@ export default function MainContent() {
                 value={inputValue}
                 onChange={handleInputChange}
                 onKeyDown={handleKeyDown}
+                onFocus={() => setIsInputFocused(true)}
+                onBlur={() => setIsInputFocused(false)}
                 disabled={isProcessing}
                 rows={1}
                 aria-label="Message input"

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -1322,16 +1322,10 @@
 
 .greeting {
   font-size: 36px;
-  font-weight: 700;
+  font-weight: 500;
+  letter-spacing: -0.01em;
   color: var(--text-primary);
-  margin-bottom: 8px;
-  text-align: center;
-}
-
-.subtitle {
-  font-size: 16px;
-  color: var(--text-secondary);
-  margin-bottom: 32px;
+  margin-bottom: 10px;
   text-align: center;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,7 @@
   --border-input: #ddd3c2;
   --shadow: 0 1px 3px rgba(61, 53, 40, 0.06);
   --shadow-lg: 0 4px 12px rgba(61, 53, 40, 0.08);
+  --emboss-highlight: rgba(255, 253, 246, 0.65);
 }
 
 [data-theme='dark'] {
@@ -44,6 +45,7 @@
   --border-input: #3d3d3d;
   --shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.25);
+  --emboss-highlight: rgba(255, 255, 255, 0.04);
 }
 
 html,

--- a/src/utils/conversationIntent.js
+++ b/src/utils/conversationIntent.js
@@ -1,0 +1,287 @@
+/**
+ * Pure helpers for the dynamic homepage subtitle.
+ *
+ * Given a recent conversation's title (or its first user message as a
+ * fallback), we infer an intent, trim the subject into a readable phrase,
+ * and build a prose + CTA pair deterministically — the same conversation
+ * always renders the same sentence, but different conversations get
+ * meaningful variety.
+ */
+
+/**
+ * FNV-1a 32-bit hash. Small, stable, no deps.
+ * @param {string} input
+ * @returns {number} unsigned 32-bit integer
+ */
+export function hashString(input) {
+  let hash = 0x811c9dc5;
+  const str = String(input ?? '');
+  for (let i = 0; i < str.length; i += 1) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+const INTENT_KEYWORDS = [
+  [
+    'coding',
+    /\b(code|coding|bug|debug|error|stack ?trace|function|api|endpoint|refactor|typescript|javascript|python|react|vue|svelte|rust|go(?:lang)?|java|kotlin|swift|sql|regex|compile|build|deploy|docker|kubernetes|k8s|test suite|unit test|jest|vitest|pytest|npm|yarn|package\.json|webpack|vite)\b/i,
+  ],
+  [
+    'writing',
+    /\b(write|writing|draft|drafting|rewrite|edit|editing|copy|essay|blog|post|article|email|letter|newsletter|caption|tagline|headline|bio|memoir|poem|story|script|pitch|proofread|polish|outline)\b/i,
+  ],
+  [
+    'research',
+    /\b(research|compare|comparison|sources|citations|literature|study|studies|evidence|vs\.?|versus|what is|why does|how does|pros and cons|difference between|explain the)\b/i,
+  ],
+  [
+    'planning',
+    /\b(plan|planning|itinerary|schedule|agenda|roadmap|timeline|budget|trip|travel|vacation|holiday|wedding|launch|strategy|goals|calendar|checklist)\b/i,
+  ],
+  [
+    'analysis',
+    /\b(analy[sz]e|analy[sz]is|breakdown|review|audit|critique|evaluate|assess|interpret|unpack|dissect|deep dive|summari[sz]e|tldr)\b/i,
+  ],
+  [
+    'image',
+    /\b(image|picture|photo|photograph|illustration|logo|icon|wallpaper|artwork|painting|sketch|render|generate|diffusion|midjourney|dalle|dall-e|stable diffusion)\b/i,
+  ],
+];
+
+/**
+ * Infer a high-level intent from free-form conversation text.
+ * Falls back to 'general' when nothing matches.
+ * @param {string} text
+ * @returns {'writing'|'research'|'planning'|'coding'|'analysis'|'image'|'general'}
+ */
+export function inferIntent(text) {
+  if (!text || typeof text !== 'string') return 'general';
+  for (const [intent, pattern] of INTENT_KEYWORDS) {
+    if (pattern.test(text)) return intent;
+  }
+  return 'general';
+}
+
+/**
+ * Trim + clean a title or first-message string into a short readable
+ * subject phrase. Strips wrapping quotes, trailing punctuation and
+ * collapses whitespace. Truncates on a word boundary.
+ * @param {string} text
+ * @param {number} [maxChars=48]
+ * @returns {string}
+ */
+export function summariseTitle(text, maxChars = 48) {
+  if (!text || typeof text !== 'string') return '';
+  let out = text.replace(/\s+/g, ' ').trim();
+  out = out.replace(/^["'“”‘’`]+|["'“”‘’`]+$/g, '');
+  out = out.replace(/[.!?,;:\-–—]+$/g, '').trim();
+  if (out.length <= maxChars) return out;
+  const clipped = out.slice(0, maxChars);
+  const lastSpace = clipped.lastIndexOf(' ');
+  const base = lastSpace > maxChars * 0.6 ? clipped.slice(0, lastSpace) : clipped;
+  return `${base.replace(/[.!?,;:\-–—]+$/g, '').trim()}…`;
+}
+
+/**
+ * Prose bank. Each intent has at least 10 variants. Templates may
+ * contain `{subject}` (always resolved) and optional contextual tokens
+ * `{recency}` and `{timeOfDay}`. Templates with an unresolved token are
+ * skipped during selection so we never render dangling phrases.
+ */
+export const PROSE = {
+  writing: [
+    'You were drafting {subject} earlier —',
+    '{subject} was still taking shape when you stepped away —',
+    'Your draft of {subject} is waiting where you left it —',
+    'You were mid-sentence on {subject} —',
+    "That {subject} piece isn't quite finished —",
+    'You were shaping the voice of {subject} —',
+    'Your draft for {subject} is half-written —',
+    '{subject} — you were finding the right opening —',
+    'Your {subject} draft is still resting —',
+    'You were polishing {subject} {recency} —',
+    'You were rewriting {subject} {timeOfDay} —',
+    '{subject} was almost there when you paused —',
+  ],
+  research: [
+    'You were digging into {subject} —',
+    'You were chasing sources on {subject} —',
+    '{subject} — you had a few threads open —',
+    'You were weighing options for {subject} —',
+    'Your {subject} research is still open —',
+    'You were comparing notes on {subject} —',
+    'You were mapping {subject} {recency} —',
+    'You had questions about {subject} —',
+    'You were gathering context on {subject} —',
+    "{subject} — you weren't quite done looking —",
+    'You were cross-checking {subject} {timeOfDay} —',
+    '{subject} still has a few loose ends to tie —',
+  ],
+  planning: [
+    'You were mapping out {subject} —',
+    'Your {subject} plan is still coming together —',
+    '{subject} — you were sketching the shape of it —',
+    'You were lining up the pieces for {subject} —',
+    'Your {subject} is still in draft form —',
+    'You were weighing options for {subject} {recency} —',
+    '{subject} — a few decisions still to make —',
+    'You were outlining {subject} {timeOfDay} —',
+    'Your {subject} plan is almost ready —',
+    'You were pacing out {subject} —',
+    'That {subject} plan is still taking shape —',
+    '{subject} — you had it half-built —',
+  ],
+  coding: [
+    'You were mid-flow on {subject} —',
+    'You were deep in {subject} —',
+    '{subject} was almost passing —',
+    'You were debugging {subject} —',
+    'Your {subject} branch is still open —',
+    'You were refactoring {subject} {recency} —',
+    '{subject} — you had the shape of it —',
+    'You were wiring up {subject} —',
+    'You were tracing through {subject} —',
+    '{subject} was one step from green —',
+    'You were shipping {subject} {timeOfDay} —',
+    'Your {subject} fix is one edit away —',
+  ],
+  analysis: [
+    'You were unpacking {subject} —',
+    'You were pulling {subject} apart —',
+    '{subject} — you were following the thread —',
+    'You were breaking down {subject} —',
+    'You were weighing {subject} {recency} —',
+    'Your {subject} review is still open —',
+    'You were reading between the lines of {subject} —',
+    '{subject} — a few more angles to consider —',
+    'You were tracing the logic of {subject} —',
+    'You were stress-testing {subject} {timeOfDay} —',
+    '{subject} still has more to say —',
+    'You were laying out {subject} piece by piece —',
+  ],
+  image: [
+    'Your {subject} image session is still open —',
+    'You were iterating on {subject} —',
+    'You were refining {subject} —',
+    '{subject} — you were dialling in the look —',
+    'Your {subject} was almost there —',
+    'You were tweaking {subject} {recency} —',
+    'You were reshaping {subject} —',
+    '{subject} — a few more passes and it lands —',
+    'You were exploring variations of {subject} —',
+    'You were composing {subject} {timeOfDay} —',
+    '{subject} just needs one more pass —',
+    'You were colouring in {subject} —',
+  ],
+  general: [
+    'You were chatting about {subject} —',
+    "{subject} — you weren't quite done —",
+    'That {subject} thread is still open —',
+    'You had more to say about {subject} —',
+    'You were circling {subject} {recency} —',
+    '{subject} — you had it on your mind —',
+    'You were working through {subject} —',
+    'You left off on {subject} —',
+    '{subject} was still in motion when you paused —',
+    'You were picking apart {subject} {timeOfDay} —',
+    '{subject} is still sitting with you —',
+    'You were mulling over {subject} —',
+  ],
+};
+
+/**
+ * Shared CTA bank. Picked independently of the prose so intent and CTA
+ * vary in lockstep without feeling patterned.
+ */
+export const CTAS = ['Continue', 'Pick it up', 'Keep going', 'Jump back in', 'Resume', 'Open it'];
+
+/**
+ * Resolve optional contextual tokens based on the "now" reference time
+ * and the conversation's last-updated timestamp.
+ * @param {Date} now
+ * @param {Date|null} updatedAt
+ * @returns {{ recency: string|null; timeOfDay: string }}
+ */
+function resolveTokens(now, updatedAt) {
+  const hour = now.getHours();
+  let timeOfDay;
+  if (hour < 5) timeOfDay = 'last night';
+  else if (hour < 12) timeOfDay = 'this morning';
+  else if (hour < 18) timeOfDay = 'this afternoon';
+  else timeOfDay = 'tonight';
+
+  let recency = null;
+  if (updatedAt instanceof Date && !Number.isNaN(updatedAt.getTime())) {
+    const sameDay =
+      updatedAt.getFullYear() === now.getFullYear() &&
+      updatedAt.getMonth() === now.getMonth() &&
+      updatedAt.getDate() === now.getDate();
+    if (sameDay) {
+      recency = 'earlier today';
+    } else {
+      const yesterday = new Date(now);
+      yesterday.setDate(now.getDate() - 1);
+      const wasYesterday =
+        updatedAt.getFullYear() === yesterday.getFullYear() &&
+        updatedAt.getMonth() === yesterday.getMonth() &&
+        updatedAt.getDate() === yesterday.getDate();
+      if (wasYesterday) recency = 'yesterday';
+    }
+  }
+
+  return { recency, timeOfDay };
+}
+
+function applyTokens(template, subject, tokens) {
+  let out = template.replace(/\{subject\}/g, subject);
+  if (out.includes('{recency}')) {
+    if (!tokens.recency) return null;
+    out = out.replace(/\{recency\}/g, tokens.recency);
+  }
+  if (out.includes('{timeOfDay}')) {
+    out = out.replace(/\{timeOfDay\}/g, tokens.timeOfDay);
+  }
+  return out;
+}
+
+/**
+ * Build a deterministic { prose, cta } pair for the given intent + subject.
+ * Selection is indexed by hashString(seed) — pass the conversation id as
+ * the seed so the same conversation always renders the same sentence.
+ *
+ * @param {string} intent
+ * @param {string} subject
+ * @param {string} [seed] — conversation id or any stable identifier
+ * @param {object} [opts]
+ * @param {Date}   [opts.now=new Date()]
+ * @param {Date|null} [opts.updatedAt=null]
+ * @returns {{ prose: string; cta: string }}
+ */
+export function buildSubtitle(intent, subject, seed = '', opts = {}) {
+  const now = opts.now instanceof Date ? opts.now : new Date();
+  const updatedAt = opts.updatedAt instanceof Date ? opts.updatedAt : null;
+  const tokens = resolveTokens(now, updatedAt);
+
+  const bank = PROSE[intent] || PROSE.general;
+  const hash = hashString(`${seed}::${subject}`);
+
+  let prose = null;
+  for (let i = 0; i < bank.length; i += 1) {
+    const template = bank[(hash + i) % bank.length];
+    const resolved = applyTokens(template, subject, tokens);
+    if (resolved) {
+      prose = resolved;
+      break;
+    }
+  }
+
+  if (!prose) {
+    const fallback = bank.find((t) => !t.includes('{recency}')) || bank[0];
+    prose = applyTokens(fallback, subject, tokens) || fallback.replace(/\{[^}]+\}/g, subject);
+  }
+
+  const cta = CTAS[hash % CTAS.length];
+  return { prose, cta };
+}

--- a/src/utils/conversationIntent.test.js
+++ b/src/utils/conversationIntent.test.js
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import {
+  hashString,
+  inferIntent,
+  summariseTitle,
+  buildSubtitle,
+  PROSE,
+  CTAS,
+} from './conversationIntent';
+
+describe('hashString', () => {
+  it('returns a stable unsigned 32-bit integer', () => {
+    const h = hashString('hello');
+    expect(Number.isInteger(h)).toBe(true);
+    expect(h).toBeGreaterThanOrEqual(0);
+    expect(h).toBeLessThan(2 ** 32);
+    expect(hashString('hello')).toBe(h);
+  });
+
+  it('distinguishes similar inputs', () => {
+    expect(hashString('abc')).not.toBe(hashString('abd'));
+  });
+
+  it('handles nullish input without throwing', () => {
+    expect(() => hashString(undefined)).not.toThrow();
+    expect(() => hashString(null)).not.toThrow();
+  });
+});
+
+describe('inferIntent', () => {
+  it.each([
+    ['Draft a launch email', 'writing'],
+    ['Rewrite my bio', 'writing'],
+    ['Compare vector databases', 'research'],
+    ['What is vector search?', 'research'],
+    ['Paris itinerary for October', 'planning'],
+    ['Budget for wedding venue', 'planning'],
+    ['Refactor auth middleware', 'coding'],
+    ['Fix the typescript error in the API', 'coding'],
+    ['Analyze quarterly revenue', 'analysis'],
+    ['Breakdown the investor memo', 'analysis'],
+    ['Generate a logo for the brand', 'image'],
+    ['Midjourney prompt for wallpaper', 'image'],
+  ])('classifies %p as %p', (text, intent) => {
+    expect(inferIntent(text)).toBe(intent);
+  });
+
+  it('falls back to general for unknown topics', () => {
+    expect(inferIntent('Weekend thoughts')).toBe('general');
+    expect(inferIntent('')).toBe('general');
+    expect(inferIntent(undefined)).toBe('general');
+  });
+});
+
+describe('summariseTitle', () => {
+  it('trims whitespace and collapses spaces', () => {
+    expect(summariseTitle('   hello   world  ')).toBe('hello world');
+  });
+
+  it('strips wrapping quotes and trailing punctuation', () => {
+    expect(summariseTitle('"Launch email draft."')).toBe('Launch email draft');
+    expect(summariseTitle('“Paris itinerary—”')).toBe('Paris itinerary');
+  });
+
+  it('truncates on a word boundary with an ellipsis', () => {
+    const long = 'This is a very long conversation title that keeps going and going';
+    const out = summariseTitle(long, 30);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(31);
+    expect(out).not.toMatch(/\s…$/);
+  });
+
+  it('returns empty string for nullish or non-string input', () => {
+    expect(summariseTitle(undefined)).toBe('');
+    expect(summariseTitle(null)).toBe('');
+    expect(summariseTitle(42)).toBe('');
+  });
+});
+
+describe('buildSubtitle', () => {
+  const subject = 'launch email';
+
+  it('returns a prose string containing the subject and a CTA from the shared bank', () => {
+    const { prose, cta } = buildSubtitle('writing', subject, 'conv-1');
+    expect(prose).toContain(subject);
+    expect(CTAS).toContain(cta);
+  });
+
+  it('is deterministic for the same seed + subject', () => {
+    const a = buildSubtitle('research', subject, 'conv-42');
+    const b = buildSubtitle('research', subject, 'conv-42');
+    expect(a).toEqual(b);
+  });
+
+  it('varies across different seeds for the same intent', () => {
+    const seeds = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    const proses = new Set(seeds.map((s) => buildSubtitle('writing', subject, s).prose));
+    expect(proses.size).toBeGreaterThan(1);
+  });
+
+  it('never renders an unresolved token', () => {
+    for (const intent of Object.keys(PROSE)) {
+      for (const seed of ['x', 'y', 'z', '1', '2', '3']) {
+        const { prose } = buildSubtitle(intent, subject, seed, {
+          now: new Date('2026-04-20T12:00:00Z'),
+          updatedAt: null,
+        });
+        expect(prose).not.toMatch(/\{[^}]+\}/);
+      }
+    }
+  });
+
+  it('expands {recency} when updatedAt is today', () => {
+    const now = new Date('2026-04-20T12:00:00Z');
+    let found = false;
+    for (let i = 0; i < 50; i += 1) {
+      const { prose } = buildSubtitle('writing', subject, `seed-${i}`, {
+        now,
+        updatedAt: new Date('2026-04-20T09:00:00Z'),
+      });
+      if (prose.includes('earlier today')) {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+
+  it('expands {timeOfDay} from the current hour', () => {
+    const morning = new Date('2026-04-20T09:00:00');
+    let found = false;
+    for (let i = 0; i < 50; i += 1) {
+      const { prose } = buildSubtitle('writing', subject, `seed-${i}`, {
+        now: morning,
+        updatedAt: morning,
+      });
+      if (prose.includes('this morning')) {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+
+  it('unknown intent falls back to general without throwing', () => {
+    const { prose } = buildSubtitle('nonsense', subject, 'seed');
+    expect(prose).toContain(subject);
+  });
+});
+
+describe('PROSE banks', () => {
+  it('each intent has at least 10 variants', () => {
+    for (const intent of Object.keys(PROSE)) {
+      expect(PROSE[intent].length).toBeGreaterThanOrEqual(10);
+    }
+  });
+
+  it('every template contains {subject}', () => {
+    for (const intent of Object.keys(PROSE)) {
+      for (const template of PROSE[intent]) {
+        expect(template).toContain('{subject}');
+      }
+    }
+  });
+});
+
+describe('CTAS bank', () => {
+  it('exposes at least 4 unique CTAs', () => {
+    expect(new Set(CTAS).size).toBe(CTAS.length);
+    expect(CTAS.length).toBeGreaterThanOrEqual(4);
+  });
+});


### PR DESCRIPTION
Replaces the static "What can I help you orchestrate today?" with a quiet, human-sounding line that reflects the user's most recent conversation (within a 48h window, excluding archived/reported). Prose varies by inferred intent (writing / research / planning / coding / analysis / image / general) with 10+ variants per intent plus a shared CTA bank, selected deterministically per conversation so the same chat always renders the same sentence.

When the input is focused or has content the line dims rather than unmounting, so the layout stays stable. Greeting weight softens to match the new embossed subtitle.

https://claude.ai/code/session_017NLjMz9YdTKPksk5XkACyX