### PR TITLE
refactor(home): use universal, grammar-safe prose for the subtitle

### DIFF
--- a/src/components/DynamicSubtitle/DynamicSubtitle.jsx
+++ b/src/components/DynamicSubtitle/DynamicSubtitle.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { selectConversations, selectInputValue } from '../../store/slices/chatSlice';
 import { fetchConversationMessages } from '../../services/api';
-import { buildSubtitle, inferIntent, summariseTitle } from '../../utils/conversationIntent';
+import { buildSubtitle, summariseTitle } from '../../utils/conversationIntent';
 import styles from './DynamicSubtitle.module.css';
 
 const STALE_WINDOW_MS = 48 * 60 * 60 * 1000;
@@ -79,14 +79,13 @@ export default function DynamicSubtitle({ onOpen, isInputActive = false }) {
   const subject = summariseTitle(sourceText);
   if (!subject) return null;
 
-  const intent = inferIntent(sourceText);
-  const cacheKey = `${candidate.id}::${intent}::${subject}`;
+  const cacheKey = `${candidate.id}::${subject}`;
   let prose;
   let cta;
   if (cacheRef.current.key === cacheKey) {
     ({ prose, cta } = cacheRef.current);
   } else {
-    const built = buildSubtitle(intent, subject, candidate.id);
+    const built = buildSubtitle(subject, candidate.id);
     prose = built.prose;
     cta = built.cta;
     cacheRef.current = { key: cacheKey, prose, cta };

--- a/src/utils/conversationIntent.js
+++ b/src/utils/conversationIntent.js
@@ -2,12 +2,16 @@
  * Pure helpers for the dynamic homepage subtitle.
  *
  * Given a recent conversation's title (or its first user message as a
- * fallback), we infer an intent, trim the subject into a readable phrase,
- * and build a prose + CTA pair deterministically — the same conversation
- * always renders the same sentence, but different conversations get
- * meaningful variety. Templates are intentionally short, sentence-cased,
- * and free of em-dashes / hyphens so the line reads naturally on a
- * single row.
+ * fallback) we trim it into a short subject phrase and build a
+ * deterministic prose + CTA pair. The same conversation always renders
+ * the same sentence; different conversations get subtle variety.
+ *
+ * Grammar safety: every template treats `{subject}` as the object of a
+ * preposition ("on {subject}", "with {subject}", "about {subject}"),
+ * never as the grammatical subject of the sentence. That keeps the
+ * line readable for *any* conversation title, whether it's a verb
+ * phrase ("Draft a launch email"), a noun phrase ("Group trip plan
+ * and budget") or a question ("What is vector search?").
  */
 
 /**
@@ -23,47 +27,6 @@ export function hashString(input) {
     hash = Math.imul(hash, 0x01000193);
   }
   return hash >>> 0;
-}
-
-const INTENT_KEYWORDS = [
-  [
-    'coding',
-    /\b(code|coding|bug|debug|error|stack ?trace|function|api|endpoint|refactor|typescript|javascript|python|react|vue|svelte|rust|go(?:lang)?|java|kotlin|swift|sql|regex|compile|build|deploy|docker|kubernetes|k8s|test suite|unit test|jest|vitest|pytest|npm|yarn|webpack|vite)\b/i,
-  ],
-  [
-    'writing',
-    /\b(write|writing|draft|drafting|rewrite|edit|editing|copy|essay|blog|post|article|email|letter|newsletter|caption|tagline|headline|bio|memoir|poem|story|script|pitch|proofread|polish|outline)\b/i,
-  ],
-  [
-    'research',
-    /\b(research|compare|comparison|sources|citations|literature|study|studies|evidence|versus|what is|why does|how does|pros and cons|difference between|explain the)\b/i,
-  ],
-  [
-    'planning',
-    /\b(plan|planning|itinerary|schedule|agenda|roadmap|timeline|budget|trip|travel|vacation|holiday|wedding|launch|strategy|goals|calendar|checklist)\b/i,
-  ],
-  [
-    'analysis',
-    /\b(analyse|analyze|analysis|breakdown|review|audit|critique|evaluate|assess|interpret|unpack|dissect|deep dive|summarise|summarize|tldr)\b/i,
-  ],
-  [
-    'image',
-    /\b(image|picture|photo|photograph|illustration|logo|icon|wallpaper|artwork|painting|sketch|render|generate|diffusion|midjourney|dalle|stable diffusion)\b/i,
-  ],
-];
-
-/**
- * Infer a high-level intent from free-form conversation text.
- * Falls back to 'general' when nothing matches.
- * @param {string} text
- * @returns {'writing'|'research'|'planning'|'coding'|'analysis'|'image'|'general'}
- */
-export function inferIntent(text) {
-  if (!text || typeof text !== 'string') return 'general';
-  for (const [intent, pattern] of INTENT_KEYWORDS) {
-    if (pattern.test(text)) return intent;
-  }
-  return 'general';
 }
 
 /**
@@ -87,133 +50,39 @@ export function summariseTitle(text, maxChars = 36) {
 }
 
 /**
- * Prose bank. Each intent has at least 12 short, dash-free variants —
- * one complete sentence ending in a full stop. The CTA word is rendered
- * separately so the full line reads as either one sentence + imperative
- * or as a pair of micro-sentences.
+ * Universal prose bank. Every template reads naturally for any
+ * conversation title because `{subject}` is always the object of a
+ * preposition rather than the grammatical subject.
  */
-export const PROSE = {
-  writing: [
-    'You were drafting {subject}.',
-    'Your {subject} draft is still resting.',
-    'Your draft of {subject} is waiting.',
-    'You were mid sentence on {subject}.',
-    'That {subject} piece is unfinished.',
-    'You were polishing {subject}.',
-    'Your {subject} draft is half written.',
-    'You were rewriting {subject}.',
-    '{subject} was almost there.',
-    'You were shaping the voice of {subject}.',
-    'You were editing {subject}.',
-    'Your {subject} is ready for one more pass.',
-  ],
-  research: [
-    'You were digging into {subject}.',
-    'You were chasing sources on {subject}.',
-    'You had a few threads open on {subject}.',
-    'Your {subject} research is still open.',
-    'You were comparing notes on {subject}.',
-    'You had questions about {subject}.',
-    'You were gathering context on {subject}.',
-    '{subject} still has loose ends.',
-    'You were cross checking {subject}.',
-    'You were mapping {subject}.',
-    'You were weighing the angles on {subject}.',
-    '{subject} still has open questions.',
-  ],
-  planning: [
-    'You were mapping out {subject}.',
-    'Your {subject} is still taking shape.',
-    'You were sketching {subject}.',
-    'You were lining up the pieces of {subject}.',
-    'Your {subject} is still in draft.',
-    'You were weighing options for {subject}.',
-    '{subject} has decisions still to make.',
-    'You were outlining {subject}.',
-    'Your {subject} is almost ready.',
-    'You were pacing out {subject}.',
-    'You had {subject} half built.',
-    '{subject} is one detail away from done.',
-  ],
-  coding: [
-    'You were mid flow on {subject}.',
-    'You were deep in {subject}.',
-    '{subject} was almost passing.',
-    'You were debugging {subject}.',
-    'Your work on {subject} is still open.',
-    'You were refactoring {subject}.',
-    'You had the shape of {subject}.',
-    'You were wiring up {subject}.',
-    'You were tracing through {subject}.',
-    '{subject} is one step from green.',
-    'You were shipping {subject}.',
-    'Your {subject} fix is one edit away.',
-  ],
-  analysis: [
-    'You were unpacking {subject}.',
-    'You were pulling {subject} apart.',
-    'You were following the thread on {subject}.',
-    'You were breaking down {subject}.',
-    'You were weighing {subject}.',
-    'Your review of {subject} is still open.',
-    'You were reading between the lines of {subject}.',
-    '{subject} has more angles to consider.',
-    'You were tracing the logic of {subject}.',
-    'You were stress testing {subject}.',
-    '{subject} still has more to say.',
-    'You were laying out {subject} piece by piece.',
-  ],
-  image: [
-    'Your {subject} session is still open.',
-    'You were iterating on {subject}.',
-    'You were refining {subject}.',
-    'You were dialling in the look of {subject}.',
-    'Your {subject} was almost there.',
-    'You were tweaking {subject}.',
-    'You were reshaping {subject}.',
-    '{subject} just needs one more pass.',
-    'You were exploring variations of {subject}.',
-    'You were composing {subject}.',
-    'You were colouring in {subject}.',
-    '{subject} is one render away.',
-  ],
-  general: [
-    'You were chatting about {subject}.',
-    'That {subject} thread is still open.',
-    'You had more to say about {subject}.',
-    'You were circling {subject}.',
-    '{subject} was on your mind.',
-    'You were working through {subject}.',
-    'You left off on {subject}.',
-    '{subject} is still in motion.',
-    'You were picking apart {subject}.',
-    '{subject} is sitting with you.',
-    'You were mulling over {subject}.',
-    'You were sitting with {subject}.',
-  ],
-};
+export const PROSE = [
+  'Pick up where you left off on {subject}.',
+  'Continue where you left off on {subject}.',
+  'You left off on {subject}.',
+  'Your thread on {subject} is still open.',
+  'Your chat about {subject} is still open.',
+  "Come back to {subject} when you're ready.",
+  'Carry on with {subject}.',
+];
 
 /**
- * Shared CTA bank. Picked independently of the prose so the imperative
- * varies in lockstep with the sentence.
+ * Short CTA imperatives. Paired with any prose above without creating
+ * redundancy or grammar clashes.
  */
-export const CTAS = ['Continue', 'Pick it up', 'Keep going', 'Jump back in', 'Resume', 'Open it'];
+export const CTAS = ['Continue', 'Resume', 'Pick it up', 'Open it'];
 
 /**
- * Build a deterministic { prose, cta } pair for the given intent + subject.
+ * Build a deterministic { prose, cta } pair for a subject.
  * Selection is indexed by hashString(seed::subject) — pass the
  * conversation id as the seed so the same conversation always renders
  * the same sentence.
  *
- * @param {string} intent
  * @param {string} subject
- * @param {string} [seed] — conversation id or any stable identifier
+ * @param {string} [seed]
  * @returns {{ prose: string; cta: string }}
  */
-export function buildSubtitle(intent, subject, seed = '') {
-  const bank = PROSE[intent] || PROSE.general;
+export function buildSubtitle(subject, seed = '') {
   const hash = hashString(`${seed}::${subject}`);
-  const prose = bank[hash % bank.length].replace(/\{subject\}/g, subject);
+  const prose = PROSE[hash % PROSE.length].replace(/\{subject\}/g, subject);
   const cta = CTAS[hash % CTAS.length];
   return { prose, cta };
 }

--- a/src/utils/conversationIntent.test.js
+++ b/src/utils/conversationIntent.test.js
@@ -1,12 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  hashString,
-  inferIntent,
-  summariseTitle,
-  buildSubtitle,
-  PROSE,
-  CTAS,
-} from './conversationIntent';
+import { hashString, summariseTitle, buildSubtitle, PROSE, CTAS } from './conversationIntent';
 
 describe('hashString', () => {
   it('returns a stable unsigned 32-bit integer', () => {
@@ -24,31 +17,6 @@ describe('hashString', () => {
   it('handles nullish input without throwing', () => {
     expect(() => hashString(undefined)).not.toThrow();
     expect(() => hashString(null)).not.toThrow();
-  });
-});
-
-describe('inferIntent', () => {
-  it.each([
-    ['Draft a launch email', 'writing'],
-    ['Rewrite my bio', 'writing'],
-    ['Compare vector databases', 'research'],
-    ['What is vector search?', 'research'],
-    ['Paris itinerary for October', 'planning'],
-    ['Budget for wedding venue', 'planning'],
-    ['Refactor auth middleware', 'coding'],
-    ['Fix the typescript error in the API', 'coding'],
-    ['Analyse quarterly revenue', 'analysis'],
-    ['Breakdown the investor memo', 'analysis'],
-    ['Generate a logo for the brand', 'image'],
-    ['Midjourney prompt for wallpaper', 'image'],
-  ])('classifies %p as %p', (text, intent) => {
-    expect(inferIntent(text)).toBe(intent);
-  });
-
-  it('falls back to general for unknown topics', () => {
-    expect(inferIntent('Weekend thoughts')).toBe('general');
-    expect(inferIntent('')).toBe('general');
-    expect(inferIntent(undefined)).toBe('general');
   });
 });
 
@@ -86,75 +54,87 @@ describe('buildSubtitle', () => {
   const subject = 'launch email';
 
   it('returns a prose string containing the subject and a CTA from the shared bank', () => {
-    const { prose, cta } = buildSubtitle('writing', subject, 'conv-1');
+    const { prose, cta } = buildSubtitle(subject, 'conv-1');
     expect(prose).toContain(subject);
     expect(CTAS).toContain(cta);
   });
 
   it('is deterministic for the same seed + subject', () => {
-    const a = buildSubtitle('research', subject, 'conv-42');
-    const b = buildSubtitle('research', subject, 'conv-42');
+    const a = buildSubtitle(subject, 'conv-42');
+    const b = buildSubtitle(subject, 'conv-42');
     expect(a).toEqual(b);
   });
 
-  it('varies across different seeds for the same intent', () => {
+  it('varies across different seeds', () => {
     const seeds = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
-    const proses = new Set(seeds.map((s) => buildSubtitle('writing', subject, s).prose));
+    const proses = new Set(seeds.map((s) => buildSubtitle(subject, s).prose));
     expect(proses.size).toBeGreaterThan(1);
   });
 
   it('never renders an unresolved token', () => {
-    for (const intent of Object.keys(PROSE)) {
-      for (const seed of ['x', 'y', 'z', '1', '2', '3']) {
-        const { prose } = buildSubtitle(intent, subject, seed);
-        expect(prose).not.toMatch(/\{[^}]+\}/);
-      }
+    for (const seed of ['x', 'y', 'z', '1', '2', '3']) {
+      const { prose } = buildSubtitle(subject, seed);
+      expect(prose).not.toMatch(/\{[^}]+\}/);
     }
   });
 
-  it('always returns a sentence ending in a full stop', () => {
-    for (const intent of Object.keys(PROSE)) {
-      for (const seed of ['1', '2', '3', '4', '5']) {
-        const { prose } = buildSubtitle(intent, subject, seed);
-        expect(prose.trim().endsWith('.')).toBe(true);
-      }
+  it('reads as a complete sentence ending in a full stop', () => {
+    for (const seed of ['1', '2', '3', '4', '5']) {
+      const { prose } = buildSubtitle(subject, seed);
+      expect(prose.trim().endsWith('.')).toBe(true);
     }
   });
 
-  it('unknown intent falls back to general without throwing', () => {
-    const { prose } = buildSubtitle('nonsense', subject, 'seed');
-    expect(prose).toContain(subject);
+  it('reads naturally for any kind of subject phrase', () => {
+    const subjects = [
+      'Group trip plan and budget',
+      'Launch email',
+      'Refactor auth middleware',
+      'What is vector search?',
+      'Paris itinerary for October',
+      'Draft a launch email',
+    ];
+    for (const s of subjects) {
+      for (let i = 0; i < PROSE.length; i += 1) {
+        const { prose } = buildSubtitle(s, `seed-${i}`);
+        expect(prose).toContain(s);
+        expect(prose).not.toMatch(/[-\u2013\u2014]/);
+      }
+    }
   });
 });
 
-describe('PROSE banks', () => {
-  it('each intent has at least 12 variants', () => {
-    for (const intent of Object.keys(PROSE)) {
-      expect(PROSE[intent].length).toBeGreaterThanOrEqual(12);
-    }
+describe('PROSE bank', () => {
+  it('exposes at least 5 universal variants', () => {
+    expect(PROSE.length).toBeGreaterThanOrEqual(5);
   });
 
   it('every template contains {subject}', () => {
-    for (const intent of Object.keys(PROSE)) {
-      for (const template of PROSE[intent]) {
-        expect(template).toContain('{subject}');
-      }
+    for (const template of PROSE) {
+      expect(template).toContain('{subject}');
     }
   });
 
   it('no template contains a hyphen, en dash, or em dash', () => {
-    for (const intent of Object.keys(PROSE)) {
-      for (const template of PROSE[intent]) {
-        expect(template).not.toMatch(/[-\u2013\u2014]/);
-      }
+    for (const template of PROSE) {
+      expect(template).not.toMatch(/[-\u2013\u2014]/);
     }
   });
 
   it('every template ends with a full stop', () => {
-    for (const intent of Object.keys(PROSE)) {
-      for (const template of PROSE[intent]) {
-        expect(template.trim().endsWith('.')).toBe(true);
-      }
+    for (const template of PROSE) {
+      expect(template.trim().endsWith('.')).toBe(true);
+    }
+  });
+
+  it('treats {subject} as the object of a preposition for grammar safety', () => {
+    // Each template should introduce the subject with a preposition
+    // ("on", "to", "with", "about") so the line reads correctly
+    // regardless of whether the title is a noun phrase, verb phrase
+    // or question.
+    const safeLeadIns = / (on|to|with|about) \{subject\}/;
+    for (const template of PROSE) {
+      expect(template).toMatch(safeLeadIns);
     }
   });
 });


### PR DESCRIPTION
Intent-based verbs produced wording that did not always fit the subject ("You were sketching Group trip plan and budget."). The fix is to drop intent classification entirely and use a small bank of universal templates where {subject} is always the object of a preposition ("on", "to", "with", "about"). That keeps the line readable for any conversation title — noun phrase, verb phrase or question — without trying to match verbs to topics.

Also removes the now-unused inferIntent helper and INTENT_KEYWORDS table to keep the module single-purpose.

https://claude.ai/code/session_017NLjMz9YdTKPksk5XkACyX