### PR TITLE
style(home): thicker greeting and subtitle, still quiet

### DIFF
--- a/src/components/DynamicSubtitle/DynamicSubtitle.module.css
+++ b/src/components/DynamicSubtitle/DynamicSubtitle.module.css
@@ -8,7 +8,7 @@
   padding: 0 24px;
   margin: 0 0 32px;
   font-size: 15px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1.4;
   letter-spacing: 0;
   color: var(--text-muted);

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -1322,9 +1322,9 @@
 
 .greeting {
   font-size: 36px;
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: -0.01em;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   margin-bottom: 12px;
   text-align: center;
 }


### PR DESCRIPTION
Bumps the greeting from 600/muted to 700/secondary so it carries more presence without tipping into shouty primary contrast, and nudges the subtitle prose from 500 to 600 weight while keeping the muted colour so it still reads as a soft embossed layer beneath the greeting.

https://claude.ai/code/session_017NLjMz9YdTKPksk5XkACyX