### PR TITLE
feat(settings): subscription section under settings; reasoning off by…

### DIFF
--- a/src/components/SettingsView/SettingsView.jsx
+++ b/src/components/SettingsView/SettingsView.jsx
@@ -37,6 +37,7 @@ import { useToast } from '../Toast/Toast';
 import { logger } from '../../lib/logger';
 import ConfirmPackModal from '../ConfirmPackModal/ConfirmPackModal';
 import { GuestGate } from '../GuestGate';
+import SubscriptionSummary from '../SubscriptionView/SubscriptionSummary';
 import {
   ChevronLeftIcon,
   SunIcon,
@@ -55,6 +56,7 @@ const SECTIONS = [
   { id: 'appearance', label: 'Appearance' },
   { id: 'personalization', label: 'Personalization' },
   { id: 'models', label: 'Model preferences' },
+  { id: 'subscription', label: 'Subscription' },
   { id: 'usage', label: 'Usage & credits' },
   { id: 'notifications', label: 'Notifications' },
   { id: 'data', label: 'Data & privacy' },
@@ -942,6 +944,19 @@ export default function SettingsView() {
                       />
                     </div>
                   </div>
+                </section>
+              )}
+
+              {/* ═══ SUBSCRIPTION ═══ */}
+              {activeSection === 'subscription' && (
+                <section className={styles.section}>
+                  <div className={styles.sectionHeader}>
+                    <h2 className={styles.sectionTitle}>Subscription</h2>
+                    <p className={styles.sectionDesc}>
+                      Manage your plan, monitor credit usage, and access billing.
+                    </p>
+                  </div>
+                  <SubscriptionSummary />
                 </section>
               )}
 

--- a/src/components/SubscriptionView/SubscriptionSummary.jsx
+++ b/src/components/SubscriptionView/SubscriptionSummary.jsx
@@ -1,0 +1,293 @@
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import {
+  selectCurrentTier,
+  selectBillingCycle,
+  selectIsFirstMonth,
+  selectPeriodEnd,
+  selectCancelAtPeriodEnd,
+  selectSubscriptionStatus,
+  selectTextCredits,
+  selectImageCredits,
+  selectPortalLoading,
+  fetchSubscriptionThunk,
+  createPortalThunk,
+} from '../../store/slices/subscriptionSlice';
+import { selectIsAuthenticated } from '../../store/slices/authSlice';
+import { getTierById, getDisplayPrice, SubscriptionTier } from '../../config/subscription';
+import styles from './SubscriptionView.module.css';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getStatusLabel(tier, cancelAtPeriodEnd) {
+  if (tier === SubscriptionTier.Free) return { label: 'Free tier', className: styles.statusActive };
+  if (cancelAtPeriodEnd) return { label: 'Cancelling', className: styles.statusCancelled };
+  return { label: 'Active', className: styles.statusActive };
+}
+
+function getCreditColor(remaining, limit) {
+  if (limit === 0) return styles.creditHealthy;
+  const ratio = remaining / limit;
+  if (ratio > 0.5) return styles.creditHealthy;
+  if (ratio > 0.2) return styles.creditLow;
+  return styles.creditCritical;
+}
+
+function getCreditPct(remaining, limit) {
+  if (limit === 0) return 0;
+  return Math.min(100, Math.round((remaining / limit) * 100));
+}
+
+function formatDate(dateStr) {
+  if (!dateStr) return null;
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+function formatTime(dateStr) {
+  if (!dateStr) return null;
+  return new Date(dateStr).toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Plan overview + quick actions + credit usage — the shared body of the
+ * standalone `/subscription` page and the `subscription` section inside
+ * Settings. Keeps layout wrapping (headers, hero, page chrome) out of scope
+ * so host components can place this in either a full-page or section context.
+ *
+ * Fetches subscription data on mount when the user is authenticated and no
+ * load has happened yet. Subsequent mounts rely on the Redux cache.
+ *
+ * @param {object} props
+ * @param {string} [props.usageLinkTo='/settings/usage'] - Route the "View
+ *   detailed usage" button navigates to. Overridable for hosts that want to
+ *   link elsewhere or omit the button entirely.
+ * @param {boolean} [props.showUsageLink=true] - Whether to render the
+ *   "View detailed usage" quick-action button.
+ */
+export default function SubscriptionSummary({
+  usageLinkTo = '/settings/usage',
+  showUsageLink = true,
+}) {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const currentTier = useSelector(selectCurrentTier);
+  const billingCycle = useSelector(selectBillingCycle);
+  const isFirstMonth = useSelector(selectIsFirstMonth);
+  const periodEnd = useSelector(selectPeriodEnd);
+  const cancelAtPeriodEnd = useSelector(selectCancelAtPeriodEnd);
+  const subscriptionStatus = useSelector(selectSubscriptionStatus);
+  const textCredits = useSelector(selectTextCredits);
+  const imageCredits = useSelector(selectImageCredits);
+  const portalLoading = useSelector(selectPortalLoading);
+
+  useEffect(() => {
+    if (isAuthenticated && subscriptionStatus === 'idle') {
+      dispatch(fetchSubscriptionThunk());
+    }
+  }, [isAuthenticated, subscriptionStatus, dispatch]);
+
+  if (subscriptionStatus === 'loading') {
+    return (
+      <div className={styles.loading} role="status" aria-live="polite">
+        <div className={styles.loadingSpinner} aria-hidden="true" />
+        <span>Loading subscription...</span>
+      </div>
+    );
+  }
+
+  const tierInfo = getTierById(currentTier);
+  const tierName =
+    tierInfo?.name || currentTier?.charAt(0).toUpperCase() + currentTier?.slice(1) || 'Free';
+  const isFree = currentTier === SubscriptionTier.Free;
+  const isPaid = !isFree;
+  const status = getStatusLabel(currentTier, cancelAtPeriodEnd);
+  const price = tierInfo ? getDisplayPrice(tierInfo, billingCycle) : 0;
+
+  // Text credits
+  const monthlyLimit = textCredits?.monthlyLimit || 0;
+  const monthlyUsed = textCredits?.monthlyUsed || 0;
+  const monthlyRemaining = Math.max(0, monthlyLimit - monthlyUsed);
+
+  // 3-hour session window
+  const windowLimit = textCredits?.windowLimit || 0;
+  const windowUsed = textCredits?.windowUsed || 0;
+  const windowRemaining = Math.max(0, windowLimit - windowUsed);
+  const windowResetAt = textCredits?.windowResetAt;
+
+  // Image credits
+  const imgRemaining = imageCredits?.remaining || 0;
+  const imgLimit = imageCredits?.limit || 0;
+  const packRemaining = imageCredits?.packRemaining || 0;
+  const cycleResetsAt = imageCredits?.cycleResetsAt;
+
+  const tierBadgeClass =
+    currentTier === 'pro'
+      ? styles.tierBadgePro
+      : currentTier === 'lite'
+      ? styles.tierBadgeLite
+      : styles.tierBadgeFree;
+
+  return (
+    <>
+      {/* ── Plan overview ── */}
+      <div className={styles.planCard}>
+        <div className={styles.planCardHeader}>
+          <div className={styles.planCardLeft}>
+            <span className={`${styles.tierBadge} ${tierBadgeClass}`}>{tierName}</span>
+            <span className={`${styles.statusBadge} ${status.className}`}>{status.label}</span>
+          </div>
+          {isFirstMonth && <span className={styles.firstMonthTag}>First month bonus</span>}
+        </div>
+
+        <div className={styles.planDetails}>
+          <div className={styles.planDetailItem}>
+            <span className={styles.planDetailLabel}>Plan</span>
+            <span className={styles.planDetailValue}>{tierName}</span>
+          </div>
+          <div className={styles.planDetailItem}>
+            <span className={styles.planDetailLabel}>Price</span>
+            <span className={styles.planDetailValue}>{price === 0 ? 'Free' : `£${price}/mo`}</span>
+          </div>
+          {isPaid && (
+            <div className={styles.planDetailItem}>
+              <span className={styles.planDetailLabel}>Billing</span>
+              <span className={styles.planDetailValue}>
+                {billingCycle === 'annual' ? 'Annual' : 'Monthly'}
+              </span>
+            </div>
+          )}
+          {isPaid && periodEnd && (
+            <div className={styles.planDetailItem}>
+              <span className={styles.planDetailLabel}>
+                {cancelAtPeriodEnd ? 'Expires' : 'Next billing'}
+              </span>
+              <span className={styles.planDetailValue}>{formatDate(periodEnd)}</span>
+            </div>
+          )}
+          {isPaid && !cancelAtPeriodEnd && price > 0 && (
+            <div className={styles.planDetailItem}>
+              <span className={styles.planDetailLabel}>Next amount</span>
+              <span className={styles.planDetailValue}>
+                £{billingCycle === 'annual' ? tierInfo?.annualPricePerMonth * 12 : price}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {cancelAtPeriodEnd && (
+          <div className={styles.cancelNotice}>
+            Your plan will be cancelled at the end of the current billing period. You can reactivate
+            anytime before then.
+          </div>
+        )}
+      </div>
+
+      {/* ── Quick Actions ── */}
+      <div className={styles.actionsCard}>
+        <div className={styles.actions}>
+          {isPaid && (
+            <button
+              className={styles.primaryBtn}
+              onClick={() => dispatch(createPortalThunk())}
+              disabled={portalLoading}
+            >
+              {portalLoading ? 'Opening...' : 'Manage Subscription'}
+            </button>
+          )}
+          {(isFree || currentTier === SubscriptionTier.Lite) && (
+            <button
+              className={isFree ? styles.primaryBtn : styles.secondaryBtn}
+              onClick={() => navigate('/plans')}
+            >
+              Upgrade Plan
+            </button>
+          )}
+          {showUsageLink && (
+            <button className={styles.secondaryBtn} onClick={() => navigate(usageLinkTo)}>
+              View detailed usage
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Credit usage ── */}
+      <h2 className={styles.sectionTitle}>Credit Usage</h2>
+      <div className={styles.creditsCard}>
+        <div className={styles.creditSections}>
+          {/* Text credits (monthly) */}
+          <div className={styles.creditSection}>
+            <div className={styles.creditHeader}>
+              <span className={styles.creditLabel}>Text credits</span>
+              <span className={styles.creditCount}>
+                {monthlyRemaining} / {monthlyLimit} remaining
+              </span>
+            </div>
+            <div className={styles.creditBar}>
+              <div
+                className={`${styles.creditFill} ${getCreditColor(monthlyRemaining, monthlyLimit)}`}
+                style={{ width: `${getCreditPct(monthlyRemaining, monthlyLimit)}%` }}
+              />
+            </div>
+          </div>
+
+          {/* 3-hour session window */}
+          <div className={styles.creditSection}>
+            <div className={styles.creditHeader}>
+              <span className={styles.creditLabel}>Session window</span>
+              <span className={styles.creditCount}>
+                {windowRemaining} / {windowLimit} remaining
+              </span>
+            </div>
+            <div className={styles.creditBar}>
+              <div
+                className={`${styles.creditFill} ${getCreditColor(windowRemaining, windowLimit)}`}
+                style={{ width: `${getCreditPct(windowRemaining, windowLimit)}%` }}
+              />
+            </div>
+            {windowResetAt && (
+              <span className={styles.creditMeta}>Resets at {formatTime(windowResetAt)}</span>
+            )}
+          </div>
+
+          <div className={styles.creditDivider} />
+
+          {/* Image credits */}
+          <div className={styles.creditSection}>
+            <div className={styles.creditHeader}>
+              <span className={styles.creditLabel}>Image credits</span>
+              <span className={styles.creditCount}>
+                {imgRemaining} / {imgLimit} remaining
+              </span>
+            </div>
+            <div className={styles.creditBar}>
+              <div
+                className={`${styles.creditFill} ${getCreditColor(imgRemaining, imgLimit)}`}
+                style={{ width: `${getCreditPct(imgRemaining, imgLimit)}%` }}
+              />
+            </div>
+            {cycleResetsAt && (
+              <span className={styles.creditMeta}>Resets {formatDate(cycleResetsAt)}</span>
+            )}
+          </div>
+
+          {/* Pack credits */}
+          {packRemaining > 0 && (
+            <div className={styles.packCredits}>
+              <span>Credit pack balance</span>
+              <span className={styles.packCreditsValue}>{packRemaining} credits</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/SubscriptionView/SubscriptionView.jsx
+++ b/src/components/SubscriptionView/SubscriptionView.jsx
@@ -1,83 +1,19 @@
-import { useSelector, useDispatch } from 'react-redux';
-import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import {
-  selectCurrentTier,
-  selectBillingCycle,
-  selectIsFirstMonth,
-  selectPeriodEnd,
-  selectCancelAtPeriodEnd,
-  selectSubscriptionStatus,
-  selectTextCredits,
-  selectImageCredits,
-  selectPortalLoading,
-  fetchSubscriptionThunk,
-  createPortalThunk,
-} from '../../store/slices/subscriptionSlice';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
-import { getTierById, getDisplayPrice, SubscriptionTier } from '../../config/subscription';
 import GuestGate from '../GuestGate/GuestGate';
+import SubscriptionSummary from './SubscriptionSummary';
 import styles from './SubscriptionView.module.css';
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function getStatusLabel(tier, cancelAtPeriodEnd) {
-  if (tier === SubscriptionTier.Free) return { label: 'Free tier', className: styles.statusActive };
-  if (cancelAtPeriodEnd) return { label: 'Cancelling', className: styles.statusCancelled };
-  return { label: 'Active', className: styles.statusActive };
-}
-
-function getCreditColor(remaining, limit) {
-  if (limit === 0) return styles.creditHealthy;
-  const ratio = remaining / limit;
-  if (ratio > 0.5) return styles.creditHealthy;
-  if (ratio > 0.2) return styles.creditLow;
-  return styles.creditCritical;
-}
-
-function getCreditPct(remaining, limit) {
-  if (limit === 0) return 0;
-  return Math.min(100, Math.round((remaining / limit) * 100));
-}
-
-function formatDate(dateStr) {
-  if (!dateStr) return null;
-  return new Date(dateStr).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-}
-
-function formatTime(dateStr) {
-  if (!dateStr) return null;
-  return new Date(dateStr).toLocaleTimeString(undefined, {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
-// ─── Component ────────────────────────────────────────────────────────────────
-
+/**
+ * Standalone "/subscription" page — a thin wrapper around SubscriptionSummary
+ * providing the full-page chrome (header, back button, hero). The same
+ * summary is embedded in `/settings/subscription` so users can access it
+ * from either the profile dropdown or the Settings nav.
+ */
 export default function SubscriptionView() {
-  const dispatch = useDispatch();
   const navigate = useNavigate();
   const isAuthenticated = useSelector(selectIsAuthenticated);
-  const currentTier = useSelector(selectCurrentTier);
-  const billingCycle = useSelector(selectBillingCycle);
-  const isFirstMonth = useSelector(selectIsFirstMonth);
-  const periodEnd = useSelector(selectPeriodEnd);
-  const cancelAtPeriodEnd = useSelector(selectCancelAtPeriodEnd);
-  const subscriptionStatus = useSelector(selectSubscriptionStatus);
-  const textCredits = useSelector(selectTextCredits);
-  const imageCredits = useSelector(selectImageCredits);
-  const portalLoading = useSelector(selectPortalLoading);
-
-  useEffect(() => {
-    if (isAuthenticated && subscriptionStatus === 'idle') {
-      dispatch(fetchSubscriptionThunk());
-    }
-  }, [isAuthenticated, subscriptionStatus, dispatch]);
 
   if (!isAuthenticated) {
     return (
@@ -93,42 +29,9 @@ export default function SubscriptionView() {
     );
   }
 
-  const tierInfo = getTierById(currentTier);
-  const tierName =
-    tierInfo?.name || currentTier?.charAt(0).toUpperCase() + currentTier?.slice(1) || 'Free';
-  const isFree = currentTier === SubscriptionTier.Free;
-  const isPaid = !isFree;
-  const status = getStatusLabel(currentTier, cancelAtPeriodEnd);
-  const price = tierInfo ? getDisplayPrice(tierInfo, billingCycle) : 0;
-
-  // Text credits
-  const monthlyLimit = textCredits?.monthlyLimit || 0;
-  const monthlyUsed = textCredits?.monthlyUsed || 0;
-  const monthlyRemaining = Math.max(0, monthlyLimit - monthlyUsed);
-
-  // 3-hour window
-  const windowLimit = textCredits?.windowLimit || 0;
-  const windowUsed = textCredits?.windowUsed || 0;
-  const windowRemaining = Math.max(0, windowLimit - windowUsed);
-  const windowResetAt = textCredits?.windowResetAt;
-
-  // Image credits
-  const imgRemaining = imageCredits?.remaining || 0;
-  const imgLimit = imageCredits?.limit || 0;
-  const packRemaining = imageCredits?.packRemaining || 0;
-  const cycleResetsAt = imageCredits?.cycleResetsAt;
-
-  const tierBadgeClass =
-    currentTier === 'pro'
-      ? styles.tierBadgePro
-      : currentTier === 'lite'
-      ? styles.tierBadgeLite
-      : styles.tierBadgeFree;
-
   return (
     <div className={styles.container}>
       <div className={styles.inner}>
-        {/* Header */}
         <div className={styles.header}>
           <button
             className={styles.backBtn}
@@ -144,6 +47,7 @@ export default function SubscriptionView() {
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
+              aria-hidden="true"
             >
               <polyline points="15 18 9 12 15 6" />
             </svg>
@@ -151,7 +55,6 @@ export default function SubscriptionView() {
           </button>
         </div>
 
-        {/* Hero */}
         <div className={styles.hero}>
           <h1 className={styles.heroTitle}>My Subscription</h1>
           <p className={styles.heroSubtitle}>
@@ -159,176 +62,7 @@ export default function SubscriptionView() {
           </p>
         </div>
 
-        {subscriptionStatus === 'loading' ? (
-          <div className={styles.loading}>
-            <div className={styles.loadingSpinner} />
-            <span>Loading subscription...</span>
-          </div>
-        ) : (
-          <>
-            {/* ── Plan overview ── */}
-            <div className={styles.planCard}>
-              <div className={styles.planCardHeader}>
-                <div className={styles.planCardLeft}>
-                  <span className={`${styles.tierBadge} ${tierBadgeClass}`}>{tierName}</span>
-                  <span className={`${styles.statusBadge} ${status.className}`}>
-                    {status.label}
-                  </span>
-                </div>
-                {isFirstMonth && <span className={styles.firstMonthTag}>First month bonus</span>}
-              </div>
-
-              <div className={styles.planDetails}>
-                <div className={styles.planDetailItem}>
-                  <span className={styles.planDetailLabel}>Plan</span>
-                  <span className={styles.planDetailValue}>{tierName}</span>
-                </div>
-                <div className={styles.planDetailItem}>
-                  <span className={styles.planDetailLabel}>Price</span>
-                  <span className={styles.planDetailValue}>
-                    {price === 0 ? 'Free' : `£${price}/mo`}
-                  </span>
-                </div>
-                {isPaid && (
-                  <div className={styles.planDetailItem}>
-                    <span className={styles.planDetailLabel}>Billing</span>
-                    <span className={styles.planDetailValue}>
-                      {billingCycle === 'annual' ? 'Annual' : 'Monthly'}
-                    </span>
-                  </div>
-                )}
-                {isPaid && periodEnd && (
-                  <div className={styles.planDetailItem}>
-                    <span className={styles.planDetailLabel}>
-                      {cancelAtPeriodEnd ? 'Expires' : 'Next billing'}
-                    </span>
-                    <span className={styles.planDetailValue}>{formatDate(periodEnd)}</span>
-                  </div>
-                )}
-                {isPaid && !cancelAtPeriodEnd && price > 0 && (
-                  <div className={styles.planDetailItem}>
-                    <span className={styles.planDetailLabel}>Next amount</span>
-                    <span className={styles.planDetailValue}>
-                      £{billingCycle === 'annual' ? tierInfo?.annualPricePerMonth * 12 : price}
-                    </span>
-                  </div>
-                )}
-              </div>
-
-              {cancelAtPeriodEnd && (
-                <div className={styles.cancelNotice}>
-                  Your plan will be cancelled at the end of the current billing period. You can
-                  reactivate anytime before then.
-                </div>
-              )}
-            </div>
-
-            {/* ── Quick Actions ── */}
-            <div className={styles.actionsCard}>
-              <div className={styles.actions}>
-                {isPaid && (
-                  <button
-                    className={styles.primaryBtn}
-                    onClick={() => dispatch(createPortalThunk())}
-                    disabled={portalLoading}
-                  >
-                    {portalLoading ? 'Opening...' : 'Manage Subscription'}
-                  </button>
-                )}
-                {(isFree || currentTier === SubscriptionTier.Lite) && (
-                  <button
-                    className={isFree ? styles.primaryBtn : styles.secondaryBtn}
-                    onClick={() => navigate('/plans')}
-                  >
-                    Upgrade Plan
-                  </button>
-                )}
-                <button
-                  className={styles.secondaryBtn}
-                  onClick={() => navigate('/settings/usage')}
-                >
-                  View Detailed Usage
-                </button>
-              </div>
-            </div>
-
-            {/* ── Credit usage ── */}
-            <h2 className={styles.sectionTitle}>Credit Usage</h2>
-            <div className={styles.creditsCard}>
-              <div className={styles.creditSections}>
-                {/* Text credits (monthly) */}
-                <div className={styles.creditSection}>
-                  <div className={styles.creditHeader}>
-                    <span className={styles.creditLabel}>Text credits</span>
-                    <span className={styles.creditCount}>
-                      {monthlyRemaining} / {monthlyLimit} remaining
-                    </span>
-                  </div>
-                  <div className={styles.creditBar}>
-                    <div
-                      className={`${styles.creditFill} ${getCreditColor(
-                        monthlyRemaining,
-                        monthlyLimit
-                      )}`}
-                      style={{ width: `${getCreditPct(monthlyRemaining, monthlyLimit)}%` }}
-                    />
-                  </div>
-                </div>
-
-                {/* 3-hour session window */}
-                <div className={styles.creditSection}>
-                  <div className={styles.creditHeader}>
-                    <span className={styles.creditLabel}>Session window</span>
-                    <span className={styles.creditCount}>
-                      {windowRemaining} / {windowLimit} remaining
-                    </span>
-                  </div>
-                  <div className={styles.creditBar}>
-                    <div
-                      className={`${styles.creditFill} ${getCreditColor(
-                        windowRemaining,
-                        windowLimit
-                      )}`}
-                      style={{ width: `${getCreditPct(windowRemaining, windowLimit)}%` }}
-                    />
-                  </div>
-                  {windowResetAt && (
-                    <span className={styles.creditMeta}>Resets at {formatTime(windowResetAt)}</span>
-                  )}
-                </div>
-
-                <div className={styles.creditDivider} />
-
-                {/* Image credits */}
-                <div className={styles.creditSection}>
-                  <div className={styles.creditHeader}>
-                    <span className={styles.creditLabel}>Image credits</span>
-                    <span className={styles.creditCount}>
-                      {imgRemaining} / {imgLimit} remaining
-                    </span>
-                  </div>
-                  <div className={styles.creditBar}>
-                    <div
-                      className={`${styles.creditFill} ${getCreditColor(imgRemaining, imgLimit)}`}
-                      style={{ width: `${getCreditPct(imgRemaining, imgLimit)}%` }}
-                    />
-                  </div>
-                  {cycleResetsAt && (
-                    <span className={styles.creditMeta}>Resets {formatDate(cycleResetsAt)}</span>
-                  )}
-                </div>
-
-                {/* Pack credits */}
-                {packRemaining > 0 && (
-                  <div className={styles.packCredits}>
-                    <span>Credit pack balance</span>
-                    <span className={styles.packCreditsValue}>{packRemaining} credits</span>
-                  </div>
-                )}
-              </div>
-            </div>
-          </>
-        )}
+        <SubscriptionSummary />
       </div>
     </div>
   );

--- a/src/services/settings.js
+++ b/src/services/settings.js
@@ -17,7 +17,7 @@ export const DEFAULT_SETTINGS = {
   answerFont: 'system',
   sendWithEnter: true,
   defaultModel: 'auto',
-  enableReasoning: true,
+  enableReasoning: false,
   webSearchDefault: 'auto',
   imageQualityDefault: 'standard',
   enableFollowUps: true,

--- a/src/services/settings.test.js
+++ b/src/services/settings.test.js
@@ -54,7 +54,7 @@ describe('settings service', () => {
 
     it('has boolean settings with correct defaults', () => {
       expect(DEFAULT_SETTINGS.sendWithEnter).toBe(true);
-      expect(DEFAULT_SETTINGS.enableReasoning).toBe(true);
+      expect(DEFAULT_SETTINGS.enableReasoning).toBe(false);
       expect(DEFAULT_SETTINGS.enableFollowUps).toBe(true);
       expect(DEFAULT_SETTINGS.saveHistory).toBe(true);
       expect(DEFAULT_SETTINGS.enableAnalytics).toBe(true);


### PR DESCRIPTION
… default

- Extract SubscriptionSummary (plan card, quick actions, credit bars) from SubscriptionView so both the standalone /subscription page and the new /settings/subscription section can share a single source of truth.
- Add "Subscription" as a section in SettingsView; sidebar profile dropdown still navigates to /subscription so both access paths work.
- Flip enableReasoning default from true to false. Extended thinking is opt-in going forward; existing user rows are untouched so users who explicitly turned it on keep their choice.