### PR TITLE
fix(web): stabilize mobile viewport with dvh + safe-area tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
     <!-- Canonical branding + theme. Route-level SEO tags are injected at
          runtime by `useSEO`; the tags below are stable across the whole

--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,6 @@
 .app {
   display: flex;
-  height: 100vh;
+  height: var(--app-height);
   width: 100%;
   max-width: 100vw;
   overflow: hidden;

--- a/src/components/ErrorBoundary/ErrorFallback.module.css
+++ b/src/components/ErrorBoundary/ErrorFallback.module.css
@@ -1,5 +1,5 @@
 .page {
-  min-height: 100vh;
+  min-height: var(--app-height);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/ImageGalleryView/ImageGalleryView.module.css
+++ b/src/components/ImageGalleryView/ImageGalleryView.module.css
@@ -1212,7 +1212,7 @@
 
 .detailImage {
   max-width: 80vw;
-  max-height: calc(100vh - 260px);
+  max-height: calc(var(--app-height) - 260px);
   border-radius: 14px;
   object-fit: contain;
   box-shadow: 0 16px 56px rgba(0, 0, 0, 0.5);
@@ -1366,7 +1366,7 @@
 
   .detailImage {
     max-width: 95vw;
-    max-height: calc(100vh - 240px);
+    max-height: calc(var(--app-height) - 240px);
   }
 
   .detailTopBar {

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -45,8 +45,8 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  padding: 0 16px;
-  height: 52px;
+  padding: var(--safe-area-top) 16px 0;
+  height: calc(52px + var(--safe-area-top));
   z-index: 10;
   pointer-events: none;
   background-color: var(--bg-primary);
@@ -1316,7 +1316,7 @@
 .containerBottom {
   max-width: 768px;
   margin: 0 auto;
-  padding: 0 24px 24px;
+  padding: 0 24px calc(24px + var(--safe-area-bottom));
   flex-shrink: 0;
 }
 
@@ -2165,7 +2165,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  max-height: calc(100vh - 160px);
+  max-height: calc(var(--app-height) - 160px);
   min-height: 200px;
   overflow: hidden;
 }
@@ -2620,7 +2620,7 @@
   }
 
   .containerBottom {
-    padding: 0 16px 16px;
+    padding: 0 16px calc(16px + var(--safe-area-bottom));
   }
 
   .greeting {
@@ -2709,8 +2709,8 @@
   }
 
   .topNav {
-    padding: 0 12px;
-    height: 56px;
+    padding: var(--safe-area-top) 12px 0;
+    height: calc(56px + var(--safe-area-top));
   }
 
   .breadcrumb {

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1294,7 +1294,7 @@
 
 .genLightboxImg {
   max-width: 80vw;
-  max-height: calc(100vh - 220px);
+  max-height: calc(var(--app-height) - 220px);
   border-radius: 14px;
   object-fit: contain;
   box-shadow: 0 16px 56px rgba(0, 0, 0, 0.5);
@@ -4626,7 +4626,7 @@
     transform: translate(-50%, -50%);
     width: calc(100vw - 40px);
     max-width: 400px;
-    max-height: calc(100dvh - 80px);
+    max-height: calc(var(--app-height) - 80px);
     border: 1px solid var(--border-color);
     border-radius: 16px;
     box-shadow: 0 24px 80px rgba(0, 0, 0, 0.2), 0 8px 24px rgba(0, 0, 0, 0.1);
@@ -5792,7 +5792,7 @@
 .modelInfoPopup {
   width: 440px;
   max-width: calc(100vw - 32px);
-  max-height: calc(100vh - 64px);
+  max-height: calc(var(--app-height) - 64px);
   overflow-y: auto;
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
@@ -6111,7 +6111,7 @@
 .upgradePopup {
   width: 380px;
   max-width: calc(100vw - 32px);
-  max-height: calc(100vh - 64px);
+  max-height: calc(var(--app-height) - 64px);
   overflow: hidden;
   border-radius: 20px;
   background: var(--bg-primary);

--- a/src/components/SharedConversationView/SharedConversationView.module.css
+++ b/src/components/SharedConversationView/SharedConversationView.module.css
@@ -4,7 +4,7 @@
  */
 
 .page {
-  min-height: 100vh;
+  min-height: var(--app-height);
   width: 100%;
   background-color: var(--bg-primary);
   color: var(--text-primary);

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -2,8 +2,8 @@
 .mobileMenuBtn {
   display: none;
   position: fixed;
-  top: 16px;
-  left: 16px;
+  top: calc(16px + var(--safe-area-top));
+  left: calc(16px + var(--safe-area-left));
   z-index: 1001;
   width: 36px;
   height: 36px;
@@ -1338,11 +1338,10 @@
     position: fixed;
     top: 0;
     left: 0;
-    height: 100vh;
-    height: 100dvh;
+    height: var(--app-height);
     width: 300px;
     margin: 0;
-    padding: 16px 12px;
+    padding: calc(16px + var(--safe-area-top)) 12px calc(16px + var(--safe-area-bottom));
     border-radius: 0 16px 16px 0;
     border-left: none;
     transform: translateX(-100%);

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,20 @@
   --shadow: 0 1px 3px rgba(61, 53, 40, 0.06);
   --shadow-lg: 0 4px 12px rgba(61, 53, 40, 0.08);
   --emboss-highlight: rgba(255, 253, 246, 0.65);
+
+  /* Visible viewport height. Tracks iOS Safari's address bar on modern
+     browsers so fixed-shell layouts don't push the nav or input off-screen. */
+  --app-height: 100dvh;
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
+}
+
+@supports not (height: 100dvh) {
+  :root {
+    --app-height: 100vh;
+  }
 }
 
 /* Answer font presets — applied by <html data-answer-font="..."> */
@@ -85,6 +99,7 @@ body {
   transition: background-color 0.2s ease, color 0.2s ease;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overscroll-behavior: none;
 }
 
 button {


### PR DESCRIPTION
iOS Safari was oscillating between hiding the top nav or the chat input depending on the address bar state, because the app shell used 100vh. Centralize viewport sizing on new :root tokens (--app-height, and four --safe-area-*) so every full-height surface follows the dynamic viewport and reserves room for the notch/home indicator.

- opt in to safe areas via viewport-fit=cover
- body overscroll-behavior: none to kill iOS rubber-band
- @supports fallback preserves 100vh on pre-dvh browsers