### PR TITLE
fix(image-gallery): left-align prompt input text

### DIFF
--- a/src/components/ImageGalleryView/ImageGalleryView.module.css
+++ b/src/components/ImageGalleryView/ImageGalleryView.module.css
@@ -77,6 +77,9 @@
   max-height: 120px;
   overflow-y: auto;
   scrollbar-width: none;
+  /* Hero section sets text-align: center; override here so prompt text
+     (and the markdown mirror) flow left-to-right inside the input. */
+  text-align: left;
 }
 
 .promptInput::-webkit-scrollbar {


### PR DESCRIPTION
The .heroSection wrapper sets text-align: center, which inherits into the prompt textarea and its markdown mirror. Multi-line text from quick prompts therefore appeared centered with visible padding on each line. Pin text-align: left on .promptInput so typed and populated prompt text flows left-to-right.