### PR TITLE
fix(image-gallery): remove text-align:center inheritance source

### DIFF
--- a/src/components/ImageGalleryView/ImageGalleryView.module.css
+++ b/src/components/ImageGalleryView/ImageGalleryView.module.css
@@ -20,7 +20,6 @@
 
 /* ===== Hero ===== */
 .heroSection {
-  text-align: center;
   margin-bottom: 56px;
 }
 
@@ -31,6 +30,7 @@
   letter-spacing: -0.04em;
   margin-bottom: 10px;
   line-height: 1.15;
+  text-align: center;
 }
 
 .heroSubtitle {
@@ -39,6 +39,7 @@
   margin-bottom: 32px;
   line-height: 1.5;
   opacity: 0.8;
+  text-align: center;
 }
 
 /* ===== Prompt ===== */


### PR DESCRIPTION
The previous fix added text-align:left to .promptInput, but the issue persisted because .heroSection was still cascading text-align:center to every descendant — including the MarkdownTextarea wrap/mirror, which have higher-specificity selectors than the .promptInput class override.

Move text-align:center off .heroSection and onto .heroTitle and .heroSubtitle directly. The form and its descendants now inherit the default start alignment, so the prompt textarea and markdown mirror both render left-aligned without relying on a downstream override.