### PR TITLE
redesign(welcome): collect ambient providers into a centred bottom strip

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -162,34 +162,16 @@ const getGreeting = () => {
   return 'Good evening.';
 };
 
-// Ambient provider badges scattered around the landing screen.
-// Purely decorative; communicates the range of providers Araveil orchestrates.
-// Order matches the visual layout (clockwise from top-left).
+// Ambient provider badges anchored as a horizontal strip near the bottom of
+// the landing screen. Purely decorative; communicates the range of providers
+// Araveil orchestrates. Array order is the visual reading order.
 const AMBIENT_PROVIDERS = [
-  { id: 'anthropic', label: 'Claude', subLabel: 'Opus 4.7', available: true, position: 'topLeft' },
-  { id: 'xai', label: 'Grok', subLabel: 'Coming soon', available: false, position: 'topCenter' },
-  { id: 'openai', label: 'ChatGPT', subLabel: 'GPT-5', available: true, position: 'topRight' },
-  {
-    id: 'perplexity',
-    label: 'Perplexity',
-    subLabel: 'Sonar Large',
-    available: true,
-    position: 'bottomLeft',
-  },
-  {
-    id: 'elevenlabs',
-    label: 'ElevenLabs',
-    subLabel: 'Coming soon',
-    available: false,
-    position: 'bottomCenter',
-  },
-  {
-    id: 'google',
-    label: 'Gemini',
-    subLabel: '2.5 Pro',
-    available: true,
-    position: 'bottomRight',
-  },
+  { id: 'anthropic', label: 'Claude', subLabel: 'Opus 4.7', available: true },
+  { id: 'xai', label: 'Grok', subLabel: 'Coming soon', available: false },
+  { id: 'openai', label: 'ChatGPT', subLabel: 'GPT-5', available: true },
+  { id: 'perplexity', label: 'Perplexity', subLabel: 'Sonar Large', available: true },
+  { id: 'elevenlabs', label: 'ElevenLabs', subLabel: 'Coming soon', available: false },
+  { id: 'google', label: 'Gemini', subLabel: '2.5 Pro', available: true },
 ];
 
 const MODE_CONFIG = [
@@ -3653,13 +3635,12 @@ export default function MainContent() {
 
       {!hasMessages && (
         <div className={styles.ambientProviders} aria-hidden="true">
-          {AMBIENT_PROVIDERS.map(({ id, label, subLabel, available, position }) => {
+          {AMBIENT_PROVIDERS.map(({ id, label, subLabel, available }) => {
             const Logo = getProviderLogo(id);
-            const positionClass = styles[`ambientProvider_${position}`];
             return (
               <div
                 key={id}
-                className={`${styles.ambientProvider} ${positionClass} ${
+                className={`${styles.ambientProvider} ${
                   available ? '' : styles.ambientProviderComingSoon
                 }`}
               >

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -2904,34 +2904,64 @@
   font-weight: 500;
 }
 
-/* Ambient provider field — faded provider badges scattered across the
-   landing backdrop. Decorative only; pointer-events: none on the layer so
-   they never intercept clicks on the real UI underneath. */
+/* Ambient provider strip — a single horizontal centred row anchored near
+   the bottom of the main area. Decorative; communicates the range of
+   providers Araveil orchestrates without competing with the welcome stack.
+   The wrapper is non-interactive; only the badges opt back in for hover. */
 .ambientProviders {
   position: absolute;
-  inset: 0;
-  overflow: hidden;
-  pointer-events: none;
+  left: 0;
+  right: 0;
+  bottom: calc(28px + var(--safe-area-bottom));
   z-index: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 18px 24px;
+  padding: 0 24px;
+  pointer-events: none;
   opacity: 0;
   animation: ambientProvidersIn 0.7s cubic-bezier(0.2, 0, 0, 1) 0.2s forwards;
 }
 
 .ambientProvider {
-  position: absolute;
   display: inline-flex;
   align-items: center;
   gap: 10px;
   white-space: nowrap;
   user-select: none;
-  opacity: 0.55;
-  transition: opacity 0.35s ease;
   pointer-events: auto;
   cursor: default;
+  opacity: 0.55;
+  animation: ambientProviderPulse 5.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  transition: opacity 0.35s ease;
+}
+
+/* Stagger the pulse so the strip breathes as a calm shimmer, not in
+   unison. Six providers at 0.55s steps spread across a 5.5s cycle. */
+.ambientProvider:nth-child(1) {
+  animation-delay: 0s;
+}
+.ambientProvider:nth-child(2) {
+  animation-delay: 0.55s;
+}
+.ambientProvider:nth-child(3) {
+  animation-delay: 1.1s;
+}
+.ambientProvider:nth-child(4) {
+  animation-delay: 1.65s;
+}
+.ambientProvider:nth-child(5) {
+  animation-delay: 2.2s;
+}
+.ambientProvider:nth-child(6) {
+  animation-delay: 2.75s;
 }
 
 .ambientProvider:hover {
   opacity: 0.95;
+  animation-play-state: paused;
 }
 
 .ambientProviderIcon {
@@ -2945,7 +2975,6 @@
   background-color: var(--bg-button);
   color: var(--text-secondary);
   flex-shrink: 0;
-  order: 0;
 }
 
 .ambientProviderDot {
@@ -2954,7 +2983,6 @@
   border-radius: 50%;
   background-color: #c2683f;
   flex-shrink: 0;
-  order: 1;
 }
 
 .ambientProviderDotMuted {
@@ -2965,7 +2993,6 @@
   display: inline-flex;
   flex-direction: column;
   gap: 1px;
-  order: 2;
 }
 
 .ambientProviderLabel {
@@ -2985,67 +3012,6 @@
   font-style: italic;
 }
 
-/* Positions — intentionally scattered so the greeting + input stay centred.
-   Right-side badges flip their inner order so the icon sits outboard. */
-.ambientProvider_topLeft {
-  top: 22%;
-  left: 6%;
-}
-
-.ambientProvider_topCenter {
-  top: 11%;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.ambientProvider_topRight {
-  top: 22%;
-  right: 6%;
-}
-
-.ambientProvider_topRight .ambientProviderIcon {
-  order: 2;
-}
-
-.ambientProvider_topRight .ambientProviderText {
-  order: 0;
-  align-items: flex-end;
-}
-
-.ambientProvider_bottomLeft {
-  bottom: 22%;
-  left: 6%;
-}
-
-.ambientProvider_bottomCenter {
-  bottom: 11%;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.ambientProvider_bottomCenter .ambientProviderIcon {
-  order: 2;
-}
-
-.ambientProvider_bottomCenter .ambientProviderText {
-  order: 0;
-  align-items: flex-end;
-}
-
-.ambientProvider_bottomRight {
-  bottom: 22%;
-  right: 6%;
-}
-
-.ambientProvider_bottomRight .ambientProviderIcon {
-  order: 2;
-}
-
-.ambientProvider_bottomRight .ambientProviderText {
-  order: 0;
-  align-items: flex-end;
-}
-
 @keyframes ambientProvidersIn {
   from {
     opacity: 0;
@@ -3055,21 +3021,26 @@
   }
 }
 
-/* Narrow desktops / tablets: drop the two centre badges so the greeting
-   and input never compete with them. */
-@media (max-width: 1100px) {
-  .ambientProvider_topCenter,
-  .ambientProvider_bottomCenter {
-    display: none;
+/* Slow, subtle breathing — small delta so the strip stays ambient. */
+@keyframes ambientProviderPulse {
+  0%,
+  100% {
+    opacity: 0.45;
+  }
+  50% {
+    opacity: 0.65;
   }
 }
 
-/* Mobile: keep the four corner badges visible as compact icon-only chips so
-   the ambient presence of every provider still reads on small screens. */
-@media (max-width: 820px) {
+/* Narrow viewports: collapse to icon-only chips so all six providers still
+   read in a single wrapping row without the labels crowding. */
+@media (max-width: 640px) {
+  .ambientProviders {
+    gap: 12px 16px;
+  }
+
   .ambientProvider {
     gap: 6px;
-    opacity: 0.7;
   }
 
   .ambientProviderIcon {
@@ -3085,43 +3056,15 @@
   .ambientProviderText {
     display: none;
   }
-
-  .ambientProvider_topLeft {
-    top: 12%;
-    left: 4%;
-  }
-
-  .ambientProvider_topRight {
-    top: 12%;
-    right: 4%;
-  }
-
-  .ambientProvider_bottomLeft {
-    bottom: 14%;
-    left: 4%;
-  }
-
-  .ambientProvider_bottomRight {
-    bottom: 14%;
-    right: 4%;
-  }
 }
 
-/* Very small phones: tighten further so the icons never cross the input. */
-@media (max-width: 480px) {
-  .ambientProviderIcon {
-    width: 26px;
-    height: 26px;
-  }
-
-  .ambientProvider_topLeft,
-  .ambientProvider_topRight {
-    top: 8%;
-  }
-
-  .ambientProvider_bottomLeft,
-  .ambientProvider_bottomRight {
-    bottom: 10%;
+/* Short viewports: re-flow the strip into normal document flow beneath the
+   welcome stack so it never overlaps the action buttons. */
+@media (max-height: 720px) {
+  .ambientProviders {
+    position: static;
+    margin-top: 28px;
+    padding: 0;
   }
 }
 
@@ -3129,5 +3072,10 @@
   .ambientProviders {
     animation: none;
     opacity: 1;
+  }
+
+  .ambientProvider {
+    animation: none;
+    opacity: 0.55;
   }
 }


### PR DESCRIPTION
Consolidates the six scattered absolutely-positioned provider badges into a single horizontal centred row anchored above the bottom of the main area. The welcome stack (greeting → input → action buttons) keeps its perfect vertical centring; the strip lives in peripheral vision as an ambient capability indicator.

- Anchored to .main (not the viewport) so iOS keyboard and safe-area insets reflow naturally; uses --safe-area-bottom for parity with the containerBottom padding.
- Slow staggered opacity pulse (0.45 ↔ 0.65 over 5.5s, six 0.55s steps) reads as a calm shimmer instead of a wave; pause on hover.
- Wrapper is pointer-events: none so the strip never intercepts clicks intended for the input.
- Drops six per-position rules, two redundant width breakpoints, and the per-position flex-order overrides; replaces them with one base rule, one ≤640px icon-only fallback, and one ≤720px short-viewport reflow.
- prefers-reduced-motion disables both the entrance fade and the pulse.