### PR TITLE
feat(age-verification): add post-signup onboarding gate

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import useAnswerFont from './hooks/useAnswerFont';
 import useUsageLimitWarnings from './hooks/useUsageLimitWarnings';
 import Sidebar from './components/Sidebar';
 import UpgradeModal from './components/UpgradeModal/UpgradeModal';
+import AgeGate from './components/AgeGate/AgeGate';
 import styles from './components/Auth/AuthModal.module.css';
 import './App.css';
 
@@ -130,7 +131,9 @@ export default function App() {
   return (
     <div className="app">
       <Sidebar />
-      <Outlet />
+      <AgeGate>
+        <Outlet />
+      </AgeGate>
       <UpgradeModal />
       <SpeedInsights />
     </div>

--- a/src/components/AgeGate/AgeGate.jsx
+++ b/src/components/AgeGate/AgeGate.jsx
@@ -1,0 +1,56 @@
+import { useSelector } from 'react-redux';
+import { Navigate, useLocation } from 'react-router-dom';
+import { selectAuthLoading, selectIsAuthenticated } from '../../store/slices/authSlice';
+import {
+  selectOnboardingEnabled,
+  selectOnboardingLoading,
+  selectOnboardingStatus,
+} from '../../store/slices/onboardingSlice';
+
+const ONBOARDING_PREFIX = '/onboarding/';
+
+/**
+ * Route gate that redirects authenticated users to the age-verification flow
+ * until they pass it. Mounted once around the authenticated `<Outlet />`.
+ *
+ * The gate is intentionally conservative:
+ *  - It is a no-op for guests (anonymous / unauthenticated). The underlying
+ *    feature gating already lives in `GuestGate`; we don't want to redirect
+ *    a guest who is browsing public surfaces.
+ *  - It is a no-op when the server flag is off, so deploys without the
+ *    feature enabled behave exactly as before.
+ *  - It renders nothing while the initial /me fetch is in flight to avoid
+ *    a flash of the app or the onboarding screen on first load.
+ *  - It never redirects when the user is already on an `/onboarding/*`
+ *    page; the onboarding views own their own navigation from there.
+ */
+export default function AgeGate({ children }) {
+  const location = useLocation();
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const authLoading = useSelector(selectAuthLoading);
+  const enabled = useSelector(selectOnboardingEnabled);
+  const status = useSelector(selectOnboardingStatus);
+  const isLoading = useSelector(selectOnboardingLoading);
+
+  if (location.pathname.startsWith(ONBOARDING_PREFIX)) {
+    return children;
+  }
+
+  if (authLoading || !isAuthenticated) {
+    return children;
+  }
+
+  if (status === 'unknown' || isLoading) {
+    return null;
+  }
+
+  if (!enabled || status === 'verified') {
+    return children;
+  }
+
+  if (status === 'blocked') {
+    return <Navigate to="/onboarding/blocked" replace />;
+  }
+
+  return <Navigate to="/onboarding/age" replace />;
+}

--- a/src/components/Onboarding/AgeEntryView.jsx
+++ b/src/components/Onboarding/AgeEntryView.jsx
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import {
+  clearOnboardingError,
+  selectOnboardingEnabled,
+  selectOnboardingError,
+  selectOnboardingLoading,
+  selectOnboardingMinimumAge,
+  selectOnboardingStatus,
+  submitDateOfBirth,
+} from '../../store/slices/onboardingSlice';
+import { selectIsAuthenticated } from '../../store/slices/authSlice';
+import styles from './Onboarding.module.css';
+
+const MAX_AGE_YEARS = 120;
+
+function clampNumeric(value, max) {
+  const digits = value.replace(/\D/g, '');
+  if (!digits) return '';
+  const n = parseInt(digits, 10);
+  if (Number.isNaN(n)) return '';
+  if (max !== undefined && n > max) return digits.slice(0, -1);
+  return digits;
+}
+
+function isValidPastDate(month, day, year) {
+  const m = parseInt(month, 10);
+  const d = parseInt(day, 10);
+  const y = parseInt(year, 10);
+  if (!Number.isFinite(m) || !Number.isFinite(d) || !Number.isFinite(y)) return false;
+  if (m < 1 || m > 12) return false;
+  if (d < 1 || d > 31) return false;
+  const today = new Date();
+  if (y < today.getFullYear() - MAX_AGE_YEARS) return false;
+  if (y > today.getFullYear()) return false;
+  const date = new Date(Date.UTC(y, m - 1, d));
+  if (date.getUTCFullYear() !== y || date.getUTCMonth() !== m - 1 || date.getUTCDate() !== d) {
+    return false;
+  }
+  // Disallow future dates.
+  const todayUtc = new Date(
+    Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate())
+  );
+  return date.getTime() <= todayUtc.getTime();
+}
+
+function pad2(value) {
+  return value.length === 1 ? `0${value}` : value;
+}
+
+/**
+ * Single-screen DOB entry. Three numeric inputs (Month/Day/Year) with
+ * auto-advancing focus, submit disabled until the date parses to a real
+ * past calendar date. On submit:
+ *   - status 'verified' → navigate home
+ *   - status 'blocked'  → navigate to /onboarding/blocked
+ *   - 409 (already set) → fall back to fetched status; the gate redirects
+ */
+export default function AgeEntryView() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const isLoading = useSelector(selectOnboardingLoading);
+  const error = useSelector(selectOnboardingError);
+  const status = useSelector(selectOnboardingStatus);
+  const enabled = useSelector(selectOnboardingEnabled);
+  const minimumAge = useSelector(selectOnboardingMinimumAge);
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+
+  const [month, setMonth] = useState('');
+  const [day, setDay] = useState('');
+  const [year, setYear] = useState('');
+
+  const monthRef = useRef(null);
+  const dayRef = useRef(null);
+  const yearRef = useRef(null);
+
+  // If the user lands here with a status that should bypass the screen,
+  // bounce them out. Keeps deep-linking idempotent.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    if (!enabled || status === 'verified') {
+      navigate('/', { replace: true });
+    } else if (status === 'blocked') {
+      navigate('/onboarding/blocked', { replace: true });
+    }
+  }, [enabled, status, isAuthenticated, navigate]);
+
+  useEffect(() => {
+    monthRef.current?.focus();
+  }, []);
+
+  const isFormValid = useMemo(() => isValidPastDate(month, day, year), [month, day, year]);
+
+  const handleMonthChange = useCallback(
+    (event) => {
+      const next = clampNumeric(event.target.value, 12);
+      setMonth(next);
+      if (error) dispatch(clearOnboardingError());
+      if (next.length === 2) dayRef.current?.focus();
+    },
+    [dispatch, error]
+  );
+
+  const handleDayChange = useCallback(
+    (event) => {
+      const next = clampNumeric(event.target.value, 31);
+      setDay(next);
+      if (error) dispatch(clearOnboardingError());
+      if (next.length === 2) yearRef.current?.focus();
+    },
+    [dispatch, error]
+  );
+
+  const handleYearChange = useCallback(
+    (event) => {
+      const next = clampNumeric(event.target.value).slice(0, 4);
+      setYear(next);
+      if (error) dispatch(clearOnboardingError());
+    },
+    [dispatch, error]
+  );
+
+  const handleKeyDown = useCallback((event, fieldRef, value) => {
+    if (event.key === 'Backspace' && value.length === 0 && fieldRef?.current) {
+      fieldRef.current.focus();
+    }
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+      if (!isFormValid || isLoading) return;
+      const dateOfBirth = `${year}-${pad2(month)}-${pad2(day)}`;
+      const result = await dispatch(submitDateOfBirth({ dateOfBirth }));
+      if (result.meta.requestStatus !== 'fulfilled') return;
+      const next = result.payload?.status;
+      if (next === 'verified') {
+        navigate('/', { replace: true });
+      } else if (next === 'blocked') {
+        navigate('/onboarding/blocked', { replace: true });
+      }
+    },
+    [dispatch, navigate, isFormValid, isLoading, month, day, year]
+  );
+
+  return (
+    <div className={styles.root} role="dialog" aria-modal="true" aria-labelledby="ageHeading">
+      <div className={styles.panel}>
+        <div className={styles.logoMark} aria-hidden="true">
+          A
+        </div>
+        <h1 id="ageHeading" className={styles.heading}>
+          How old are you?
+        </h1>
+        <p className={styles.subtitle}>
+          Araveil is for people {minimumAge} and older. Enter your date of birth to continue.
+        </p>
+
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          <div className={styles.dobRow} role="group" aria-labelledby="dobLabel">
+            <span id="dobLabel" className={styles.dobLegend}>
+              Date of birth
+            </span>
+            <div className={styles.dobFields}>
+              <input
+                ref={monthRef}
+                className={`${styles.dobInput} ${styles.dobInputShort}`}
+                value={month}
+                onChange={handleMonthChange}
+                onKeyDown={(e) => handleKeyDown(e, null, month)}
+                inputMode="numeric"
+                autoComplete="bday-month"
+                placeholder="MM"
+                aria-label="Month"
+                maxLength={2}
+              />
+              <span className={styles.dobSep} aria-hidden="true">
+                /
+              </span>
+              <input
+                ref={dayRef}
+                className={`${styles.dobInput} ${styles.dobInputShort}`}
+                value={day}
+                onChange={handleDayChange}
+                onKeyDown={(e) => handleKeyDown(e, monthRef, day)}
+                inputMode="numeric"
+                autoComplete="bday-day"
+                placeholder="DD"
+                aria-label="Day"
+                maxLength={2}
+              />
+              <span className={styles.dobSep} aria-hidden="true">
+                /
+              </span>
+              <input
+                ref={yearRef}
+                className={`${styles.dobInput} ${styles.dobInputLong}`}
+                value={year}
+                onChange={handleYearChange}
+                onKeyDown={(e) => handleKeyDown(e, dayRef, year)}
+                inputMode="numeric"
+                autoComplete="bday-year"
+                placeholder="YYYY"
+                aria-label="Year"
+                maxLength={4}
+              />
+            </div>
+          </div>
+
+          {error ? <div className={styles.error}>{error}</div> : null}
+
+          <button type="submit" className={styles.submitBtn} disabled={!isFormValid || isLoading}>
+            {isLoading ? <span className={styles.spinner} aria-hidden="true" /> : 'Continue'}
+          </button>
+          <p className={styles.legalNote}>
+            By continuing, you confirm this is accurate. We use your date of birth to verify your
+            age and personalize your experience.
+          </p>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Onboarding/BlockedView.jsx
+++ b/src/components/Onboarding/BlockedView.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { signOut } from '../../store/slices/authSlice';
+import {
+  selectOnboardingEnabled,
+  selectOnboardingMinimumAge,
+  selectOnboardingStatus,
+} from '../../store/slices/onboardingSlice';
+import styles from './Onboarding.module.css';
+
+/**
+ * Calm, non-punitive screen shown to users whose stored DOB makes them
+ * younger than the configured minimum. Signs the Supabase session out on
+ * mount so the user is fully signed out — no retry, no edit-date affordance.
+ *
+ * Because verification is derived live from the stored DOB, a user who
+ * lands here today but returns once they've aged past the threshold will
+ * progress straight into the app on their next sign-in. No DB cleanup or
+ * "unblock" path is needed.
+ */
+export default function BlockedView() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const status = useSelector(selectOnboardingStatus);
+  const enabled = useSelector(selectOnboardingEnabled);
+  const minimumAge = useSelector(selectOnboardingMinimumAge);
+  const signOutFiredRef = useRef(false);
+
+  // Sign the user out on first mount. Guard against double-firing in
+  // React 18 strict mode by latching with a ref.
+  useEffect(() => {
+    if (signOutFiredRef.current) return;
+    signOutFiredRef.current = true;
+    dispatch(signOut());
+  }, [dispatch]);
+
+  // If the gate sends someone here who shouldn't be (e.g. status flipped
+  // to verified after a clock skew), bounce them home.
+  useEffect(() => {
+    if (!enabled || status === 'verified') {
+      navigate('/', { replace: true });
+    }
+  }, [enabled, status, navigate]);
+
+  return (
+    <div className={styles.root} role="dialog" aria-modal="true" aria-labelledby="blockedHeading">
+      <div className={styles.panel}>
+        <div className={styles.logoMark} aria-hidden="true">
+          A
+        </div>
+        <h1 id="blockedHeading" className={styles.heading}>
+          Araveil isn’t available to you yet.
+        </h1>
+        <p className={styles.subtitle}>
+          Araveil is for people {minimumAge} and older. We’ll be here when the time comes.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Onboarding/Onboarding.module.css
+++ b/src/components/Onboarding/Onboarding.module.css
@@ -1,0 +1,228 @@
+/* Onboarding screens — single-purpose full-page surfaces shown after
+   sign-up for age verification. Visual language matches AuthModal so the
+   transition from sign-in feels seamless. */
+
+.root {
+  position: fixed;
+  inset: 0;
+  z-index: 2500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px calc(32px + var(--safe-area-bottom));
+  background-color: var(--bg-primary);
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.panel {
+  width: 100%;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  text-align: center;
+  animation: panelIn 0.3s cubic-bezier(0.2, 0, 0, 1);
+}
+
+@keyframes panelIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.logoMark {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background-color: var(--bg-icon-button);
+  color: var(--text-icon-button);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0 auto 18px;
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.subtitle {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  margin: 0 0 24px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  text-align: left;
+}
+
+.dobRow {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dobLegend {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.dobFields {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dobInput {
+  padding: 12px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border-input);
+  background-color: var(--bg-input);
+  color: var(--text-primary);
+  font-size: 16px;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  box-sizing: border-box;
+  appearance: textfield;
+}
+
+.dobInput::-webkit-outer-spin-button,
+.dobInput::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.dobInput::placeholder {
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.dobInput:focus {
+  border-color: var(--text-secondary);
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.04);
+}
+
+:global([data-theme='dark']) .dobInput:focus {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.06);
+}
+
+.dobInputShort {
+  flex: 1 1 64px;
+}
+
+.dobInputLong {
+  flex: 1.4 1 96px;
+}
+
+.dobSep {
+  color: var(--text-muted);
+  font-size: 18px;
+  font-weight: 300;
+  user-select: none;
+}
+
+.error {
+  font-size: 13px;
+  color: #b22f2f;
+  background-color: rgba(178, 47, 47, 0.08);
+  padding: 10px 12px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+:global([data-theme='dark']) .error {
+  color: #f4a4a4;
+  background-color: rgba(244, 164, 164, 0.08);
+}
+
+.submitBtn {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: none;
+  background-color: var(--bg-icon-button);
+  color: var(--text-icon-button);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s ease, transform 0.1s ease;
+  margin-top: 4px;
+}
+
+.submitBtn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.submitBtn:active:not(:disabled) {
+  transform: scale(0.99);
+}
+
+.submitBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid transparent;
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.legalNote {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  text-align: center;
+  margin: 8px 0 0;
+}
+
+@media (max-width: 480px) {
+  .root {
+    padding: 24px 20px calc(24px + var(--safe-area-bottom));
+  }
+  .heading {
+    font-size: 22px;
+  }
+  .dobInput {
+    padding: 11px 8px;
+    font-size: 15px;
+  }
+}

--- a/src/hooks/useAuthListener.js
+++ b/src/hooks/useAuthListener.js
@@ -14,6 +14,11 @@ import { fetchCreditBalance } from '../services/credits';
 import { fetchSubscription } from '../services/subscription';
 import { clearImageCache } from '../services/imageGeneration';
 import { setLoggerUser } from '../lib/logger';
+import {
+  fetchVerificationStatus,
+  resetOnboardingState,
+  verifyWithGoogle,
+} from '../store/slices/onboardingSlice';
 
 // ---------------------------------------------------------------------------
 // Helpers: map Supabase objects to our app shapes
@@ -107,6 +112,25 @@ export default function useAuthListener() {
                 dispatch(setSubscriptionData(data));
               })
               .catch(() => {});
+
+            // Age verification gate. Always fetch status; on Google OAuth the
+            // session also carries a short-lived `provider_token` (only on
+            // the very first callback) which we forward to the API for
+            // silent verification via the People API. If Google's response
+            // lacks a usable birthday, we fall through to the manual screen.
+            const isGoogleSignIn =
+              session?.user?.app_metadata?.provider === 'google' &&
+              Boolean(session?.provider_token);
+            const statusPromise = dispatch(fetchVerificationStatus()).unwrap();
+            if (isGoogleSignIn) {
+              statusPromise
+                .then((verification) => {
+                  if (verification?.enabled && verification?.status === 'pending') {
+                    dispatch(verifyWithGoogle({ providerToken: session.provider_token }));
+                  }
+                })
+                .catch(() => {});
+            }
           }
           break;
         }
@@ -124,6 +148,7 @@ export default function useAuthListener() {
           dispatch(resetChatState());
           dispatch(resetProjectsState());
           dispatch(resetSubscriptionState());
+          dispatch(resetOnboardingState());
 
           // 4. Re-create anonymous session so guest flow works
           dispatch(initializeAuth());

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -14,6 +14,8 @@ import SharedConversationView from './components/SharedConversationView';
 import RouteErrorBoundary from './components/ErrorBoundary/RouteErrorBoundary';
 import NotFound from './components/ErrorBoundary/NotFound';
 import RouteShell from './components/RouteShell/RouteShell';
+import AgeEntryView from './components/Onboarding/AgeEntryView';
+import BlockedView from './components/Onboarding/BlockedView';
 import { WEB_APPLICATION_JSON_LD, ORGANIZATION_JSON_LD } from './lib/seo';
 
 const router = createBrowserRouter([
@@ -169,6 +171,27 @@ const router = createBrowserRouter([
         element: (
           <RouteShell feature="subscription" seo={{ title: 'Subscription', noindex: true }}>
             <SubscriptionView />
+          </RouteShell>
+        ),
+      },
+      // Post-signup age verification flow. Sits inside <App /> so it
+      // inherits the global theme/auth bootstrap, but the views render
+      // their own full-screen surface and the AgeGate around <Outlet />
+      // intentionally leaves /onboarding/* untouched so they can render
+      // without redirect loops.
+      {
+        path: 'onboarding/age',
+        element: (
+          <RouteShell feature="onboarding-age" seo={{ title: 'Welcome', noindex: true }}>
+            <AgeEntryView />
+          </RouteShell>
+        ),
+      },
+      {
+        path: 'onboarding/blocked',
+        element: (
+          <RouteShell feature="onboarding-blocked" seo={{ title: 'Not available', noindex: true }}>
+            <BlockedView />
           </RouteShell>
         ),
       },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,6 +6,7 @@ import chatReducer from './slices/chatSlice';
 import analyticsReducer from './slices/analyticsSlice';
 import projectsReducer from './slices/projectsSlice';
 import subscriptionReducer from './slices/subscriptionSlice';
+import onboardingReducer from './slices/onboardingSlice';
 
 export const store = configureStore({
   reducer: {
@@ -16,5 +17,6 @@ export const store = configureStore({
     analytics: analyticsReducer,
     projects: projectsReducer,
     subscription: subscriptionReducer,
+    onboarding: onboardingReducer,
   },
 });

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -73,14 +73,24 @@ export const initializeAuth = createAsyncThunk(
   }
 );
 
-/** Redirect the user to Google OAuth. */
+/** Redirect the user to Google OAuth.
+ *
+ * Requests the optional `user.birthday.read` scope so the API can attempt
+ * silent age verification via the People API on the very first callback.
+ * If the user (or the OAuth client config) declines the scope, the People
+ * API simply returns no birthday and we fall back to manual entry —
+ * nothing breaks.
+ */
 export const signInWithGoogle = createAsyncThunk(
   'auth/signInWithGoogle',
   async (_, { rejectWithValue }) => {
     try {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
-        options: { redirectTo: window.location.origin },
+        options: {
+          redirectTo: window.location.origin,
+          scopes: 'https://www.googleapis.com/auth/user.birthday.read',
+        },
       });
       if (error) return rejectWithValue(error.message);
       // The browser will redirect — no meaningful return value.

--- a/src/store/slices/onboardingSlice.js
+++ b/src/store/slices/onboardingSlice.js
@@ -1,0 +1,175 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { apiFetch } from '../../lib/apiClient';
+
+// ---------------------------------------------------------------------------
+// Onboarding slice — tracks the post-signup age verification gate.
+//
+// State shape mirrors the server's `ageVerification` block from /api/me so the
+// gate component can read it directly. Status is recomputed server-side on
+// every fetch (it depends on stored DOB + the current date + the configured
+// minimum), so the slice never tries to derive it locally.
+// ---------------------------------------------------------------------------
+
+const STATUS_UNKNOWN = 'unknown';
+
+const initialState = {
+  // Server-driven status: 'pending' | 'blocked' | 'verified' | 'unknown'.
+  // 'unknown' is the local-only state we use until the first /me response
+  // returns; the gate renders nothing during this window so there is no
+  // flash of either the onboarding screen or the app.
+  status: STATUS_UNKNOWN,
+  // Mirrors AGE_VERIFICATION_ENABLED on the server — when false the gate is
+  // a no-op and the client should never redirect.
+  enabled: false,
+  // Configurable threshold from the server (default 13). Used in the
+  // blocked-screen copy so it stays in sync with whatever the operator set.
+  minimumAge: 13,
+  // ISO date string the server has on file for this user, or null.
+  dateOfBirth: null,
+  // Generic loading flag used by both the gate (initial fetch) and the
+  // submit form. The form has its own button-level disabled state so this
+  // doesn't cause cross-talk.
+  isLoading: false,
+  // Last submission error, surfaced in the entry form.
+  error: null,
+};
+
+/**
+ * Fetch the current user's verification status from the server. Called once
+ * on every SIGNED_IN event from the auth listener.
+ */
+export const fetchVerificationStatus = createAsyncThunk(
+  'onboarding/fetchVerificationStatus',
+  async (_, { rejectWithValue }) => {
+    try {
+      const me = await apiFetch('/api/me', { errorContext: 'onboarding.fetchStatus' });
+      return me.ageVerification;
+    } catch (err) {
+      return rejectWithValue(err?.userMessage || err?.message || 'Failed to fetch status');
+    }
+  }
+);
+
+/**
+ * Submit a manually-entered date of birth.
+ * Returns the updated verification block on success.
+ */
+export const submitDateOfBirth = createAsyncThunk(
+  'onboarding/submitDateOfBirth',
+  async ({ dateOfBirth }, { rejectWithValue }) => {
+    try {
+      const response = await apiFetch('/api/onboarding/age', {
+        method: 'POST',
+        json: { dateOfBirth },
+        errorContext: 'onboarding.submitDOB',
+      });
+      return response.ageVerification;
+    } catch (err) {
+      return rejectWithValue(err?.userMessage || err?.message || 'Failed to verify age');
+    }
+  }
+);
+
+/**
+ * Best-effort silent verification using the Google `provider_token` Supabase
+ * exposes only on the very first OAuth callback. The server fetches the
+ * birthday from the Google People API; if it isn't available the response
+ * carries `requiresManualEntry: true` and we fall through to the manual
+ * screen via the gate.
+ */
+export const verifyWithGoogle = createAsyncThunk(
+  'onboarding/verifyWithGoogle',
+  async ({ providerToken }, { rejectWithValue }) => {
+    try {
+      const response = await apiFetch('/api/onboarding/age/google', {
+        method: 'POST',
+        json: { providerToken },
+        errorContext: 'onboarding.verifyGoogle',
+      });
+      return response.ageVerification;
+    } catch (err) {
+      return rejectWithValue(err?.userMessage || err?.message || 'Google verification failed');
+    }
+  }
+);
+
+const onboardingSlice = createSlice({
+  name: 'onboarding',
+  initialState,
+  reducers: {
+    /** Reset to initial state on sign-out so the next user starts clean. */
+    resetOnboardingState() {
+      return { ...initialState };
+    },
+    /** Clear the last submission error (e.g. when the user edits the form). */
+    clearOnboardingError(state) {
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    const applyVerification = (state, action) => {
+      if (!action.payload) return;
+      state.status = action.payload.status ?? STATUS_UNKNOWN;
+      state.enabled = Boolean(action.payload.enabled);
+      if (typeof action.payload.minimumAge === 'number') {
+        state.minimumAge = action.payload.minimumAge;
+      }
+      state.dateOfBirth = action.payload.dateOfBirth ?? null;
+      state.error = null;
+    };
+
+    builder
+      .addCase(fetchVerificationStatus.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(fetchVerificationStatus.fulfilled, (state, action) => {
+        applyVerification(state, action);
+        state.isLoading = false;
+      })
+      .addCase(fetchVerificationStatus.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.payload || 'Failed to fetch status';
+      });
+
+    builder
+      .addCase(submitDateOfBirth.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(submitDateOfBirth.fulfilled, (state, action) => {
+        applyVerification(state, action);
+        state.isLoading = false;
+      })
+      .addCase(submitDateOfBirth.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.payload || 'Failed to verify age';
+      });
+
+    builder
+      .addCase(verifyWithGoogle.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(verifyWithGoogle.fulfilled, (state, action) => {
+        applyVerification(state, action);
+        state.isLoading = false;
+      })
+      .addCase(verifyWithGoogle.rejected, (state, action) => {
+        // Google flow failures fall back to manual entry — surface no error.
+        state.isLoading = false;
+        state.error = null;
+        state.status = 'pending';
+      });
+  },
+});
+
+export const { resetOnboardingState, clearOnboardingError } = onboardingSlice.actions;
+
+export const selectOnboardingStatus = (state) => state.onboarding.status;
+export const selectOnboardingEnabled = (state) => state.onboarding.enabled;
+export const selectOnboardingMinimumAge = (state) => state.onboarding.minimumAge;
+export const selectOnboardingLoading = (state) => state.onboarding.isLoading;
+export const selectOnboardingError = (state) => state.onboarding.error;
+
+export default onboardingSlice.reducer;


### PR DESCRIPTION
Adds the client side of age verification: a route gate, two onboarding screens, and the wiring that picks up the server's status from /api/me.

- onboardingSlice: status, enabled, minimumAge, dateOfBirth tracked centrally; thunks for fetching status, manual DOB submission, and Google silent verification.
- useAuthListener: dispatches fetchVerificationStatus on every SIGNED_IN event; on Google OAuth where Supabase provides a one-shot provider_token, forwards it to the API for silent verification.
- signInWithGoogle: requests user.birthday.read so the People API can resolve a birthday on the first callback. Falls back to manual entry on any non-success.
- AgeGate: thin wrapper around <Outlet />. No-op for guests, when the flag is off, while the initial /me is in flight, or while on /onboarding/* itself. Otherwise redirects pending → /onboarding/age, blocked → /onboarding/blocked.
- AgeEntryView: single-screen MM/DD/YYYY form with auto-advance, real calendar-date validation, submit disabled until valid.
- BlockedView: calm, non-punitive screen; signs the user out on mount. Because verification is derived live, a user blocked at 12 progresses naturally on their next sign-in once they've aged past the threshold.
- Visual language matches AuthModal so the flow feels native; full light/dark token compliance.