### PR TITLE
fix(auth): handle email-confirmation signup and Google OAuth flicker

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,18 @@
 .app {
   display: flex;
+  flex-direction: column;
   height: var(--app-height);
   width: 100%;
   max-width: 100vw;
   overflow: hidden;
+}
+
+/* Inner row that holds the sidebar + main outlet. Lifted out of .app
+   so the global PendingEmailBanner can sit above the row when present
+   without breaking the existing horizontal layout. */
+.appContent {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import useAnswerFont from './hooks/useAnswerFont';
 import useUsageLimitWarnings from './hooks/useUsageLimitWarnings';
 import Sidebar from './components/Sidebar';
 import UpgradeModal from './components/UpgradeModal/UpgradeModal';
+import PendingEmailBanner from './components/PendingEmailBanner/PendingEmailBanner';
 import styles from './components/Auth/AuthModal.module.css';
 import './App.css';
 
@@ -129,8 +130,11 @@ export default function App() {
 
   return (
     <div className="app">
-      <Sidebar />
-      <Outlet />
+      <PendingEmailBanner />
+      <div className="appContent">
+        <Sidebar />
+        <Outlet />
+      </div>
       <UpgradeModal />
       <SpeedInsights />
     </div>

--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -1,16 +1,22 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   signInWithGoogle,
   signInWithEmail,
   signUpWithEmail,
   resetPassword,
+  resendConfirmationEmail,
   selectAuthLoading,
   selectAuthError,
+  selectIsOAuthRedirecting,
+  selectPendingEmailVerification,
   setAuthError,
+  clearPendingEmailVerification,
 } from '../../store/slices/authSlice';
 import { getRememberMePreference, setRememberMePreference } from '../../lib/authStorage';
 import styles from './AuthModal.module.css';
+
+const RESEND_COOLDOWN_SECONDS = 30;
 
 const GoogleIcon = () => (
   <svg className={styles.googleIcon} viewBox="0 0 24 24" aria-hidden="true">
@@ -92,6 +98,8 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
   const dispatch = useDispatch();
   const isLoading = useSelector(selectAuthLoading);
   const authError = useSelector(selectAuthError);
+  const isOAuthRedirecting = useSelector(selectIsOAuthRedirecting);
+  const pendingEmailVerification = useSelector(selectPendingEmailVerification);
 
   const [activeTab, setActiveTab] = useState(initialTab);
   const [email, setEmail] = useState('');
@@ -102,10 +110,23 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
   const [localError, setLocalError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [rememberMe, setRememberMe] = useState(() => getRememberMePreference());
+  // Cooldown timer for the "Resend confirmation email" button so a single
+  // user can't spam the endpoint past Supabase's own rate limit.
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const resendTimerRef = useRef(null);
 
   useEffect(() => {
     setRememberMePreference(rememberMe);
   }, [rememberMe]);
+
+  useEffect(() => {
+    if (resendCooldown <= 0) return undefined;
+    resendTimerRef.current = setTimeout(
+      () => setResendCooldown((value) => Math.max(0, value - 1)),
+      1000
+    );
+    return () => clearTimeout(resendTimerRef.current);
+  }, [resendCooldown]);
 
   const clearState = useCallback(() => {
     setEmail('');
@@ -195,8 +216,45 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
       })
     );
     if (result.meta.requestStatus === 'fulfilled') {
-      setSuccessMessage('Account created. Check your email to confirm.');
+      // The slice has either committed a real session (project disabled
+      // email confirmation) or stashed a pendingEmailVerification entry.
+      // In the second case the modal automatically switches to its
+      // "Check your inbox" view via the `mode` derivation below; we only
+      // need to clear local form state here.
+      setPassword('');
+      setDisplayName('');
+      setSuccessMessage('');
+      // Seed the resend cooldown so the just-sent email is the only one
+      // for at least RESEND_COOLDOWN_SECONDS.
+      if (!result.payload?.session) {
+        setResendCooldown(RESEND_COOLDOWN_SECONDS);
+      }
     }
+  };
+
+  const handleResendConfirmation = async () => {
+    if (!pendingEmailVerification?.email || resendCooldown > 0) return;
+    setLocalError('');
+    setSuccessMessage('');
+    dispatch(setAuthError(null));
+    setResendCooldown(RESEND_COOLDOWN_SECONDS);
+    const result = await dispatch(
+      resendConfirmationEmail({ email: pendingEmailVerification.email })
+    );
+    if (result.meta.requestStatus === 'fulfilled') {
+      setSuccessMessage('Confirmation email sent. Check your inbox.');
+    }
+  };
+
+  const handleUseDifferentEmail = () => {
+    dispatch(clearPendingEmailVerification());
+    dispatch(setAuthError(null));
+    setLocalError('');
+    setSuccessMessage('');
+    setEmail('');
+    setPassword('');
+    setActiveTab('signup');
+    setResendCooldown(0);
   };
 
   const handleForgotPassword = () => {
@@ -216,10 +274,19 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
 
   const errorMessage = localError || authError;
   const isSignUp = activeTab === 'signup';
+  // `verifyEmail` takes precedence over signin/signup tabs while a
+  // pending verification exists — the user just submitted signup and is
+  // waiting on the confirmation link in their inbox. The Redux flag is
+  // cleared on real sign-in (via the listener) or on "use different
+  // email", so the modal returns to its normal flow automatically.
+  const isVerifyEmail = Boolean(pendingEmailVerification);
 
   let heading;
   let subtitle;
-  if (showForgotPassword) {
+  if (isVerifyEmail) {
+    heading = 'Check your inbox';
+    subtitle = `We sent a confirmation link to ${pendingEmailVerification.email}. Click the link to activate your account.`;
+  } else if (showForgotPassword) {
     heading = 'Reset your password';
     subtitle = "Enter your email and we'll send you a reset link.";
   } else if (isSignUp) {
@@ -265,16 +332,37 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
         <h1 className={styles.heading}>{heading}</h1>
         <p className={styles.subtitle}>{subtitle}</p>
 
-        {!showForgotPassword && (
+        {isVerifyEmail && (
+          <div className={styles.verifyActions}>
+            <button
+              type="button"
+              className={styles.submitBtn}
+              onClick={handleResendConfirmation}
+              disabled={resendCooldown > 0}
+            >
+              {resendCooldown > 0 ? `Resend in ${resendCooldown}s` : 'Resend confirmation email'}
+            </button>
+            {successMessage && <div className={styles.success}>{successMessage}</div>}
+            {errorMessage && <div className={styles.error}>{errorMessage}</div>}
+            <p className={styles.footer}>
+              Wrong email?{' '}
+              <button type="button" className={styles.footerLink} onClick={handleUseDifferentEmail}>
+                Use a different email
+              </button>
+            </p>
+          </div>
+        )}
+
+        {!isVerifyEmail && !showForgotPassword && (
           <>
             <button
               type="button"
               className={styles.googleBtn}
               onClick={handleGoogleSignIn}
-              disabled={isLoading}
+              disabled={isLoading || isOAuthRedirecting}
             >
               <GoogleIcon />
-              <span>Continue with Google</span>
+              <span>{isOAuthRedirecting ? 'Redirecting to Google…' : 'Continue with Google'}</span>
             </button>
 
             <div className={styles.divider}>
@@ -285,112 +373,114 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
           </>
         )}
 
-        <form className={styles.form} onSubmit={handleEmailSubmit} noValidate>
-          {!showForgotPassword && isSignUp && (
+        {!isVerifyEmail && (
+          <form className={styles.form} onSubmit={handleEmailSubmit} noValidate>
+            {!showForgotPassword && isSignUp && (
+              <div className={styles.fieldGroup}>
+                <label className={styles.label} htmlFor="auth-name">
+                  Name
+                </label>
+                <input
+                  id="auth-name"
+                  className={styles.input}
+                  type="text"
+                  placeholder="Your name (optional)"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  autoComplete="name"
+                />
+              </div>
+            )}
+
             <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="auth-name">
-                Name
+              <label className={styles.label} htmlFor="auth-email">
+                Email
               </label>
               <input
-                id="auth-name"
+                id="auth-email"
                 className={styles.input}
-                type="text"
-                placeholder="Your name (optional)"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                autoComplete="name"
+                type="email"
+                placeholder="you@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+                required
               />
             </div>
-          )}
 
-          <div className={styles.fieldGroup}>
-            <label className={styles.label} htmlFor="auth-email">
-              Email
-            </label>
-            <input
-              id="auth-email"
-              className={styles.input}
-              type="email"
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              autoComplete="email"
-              required
-            />
-          </div>
-
-          {!showForgotPassword && (
-            <div className={styles.fieldGroup}>
-              <label className={styles.label} htmlFor="auth-password">
-                Password
-              </label>
-              <div className={styles.passwordWrapper}>
-                <input
-                  id="auth-password"
-                  className={styles.input}
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder={isSignUp ? 'Min. 6 characters' : 'Your password'}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  autoComplete={isSignUp ? 'new-password' : 'current-password'}
-                  required
-                />
-                <button
-                  type="button"
-                  className={styles.passwordToggle}
-                  onClick={() => setShowPassword((v) => !v)}
-                  aria-label={showPassword ? 'Hide password' : 'Show password'}
-                >
-                  <EyeIcon open={showPassword} />
-                </button>
-              </div>
-              {!isSignUp && (
-                <div className={styles.credentialsRow}>
-                  <label className={styles.rememberMe}>
-                    <input
-                      type="checkbox"
-                      className={styles.rememberMeInput}
-                      checked={rememberMe}
-                      onChange={(e) => setRememberMe(e.target.checked)}
-                    />
-                    <span className={styles.rememberMeBox} aria-hidden="true">
-                      <svg
-                        className={styles.rememberMeCheck}
-                        viewBox="0 0 16 16"
-                        width="10"
-                        height="10"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <polyline points="3 8.5 6.5 12 13 4.5" />
-                      </svg>
-                    </span>
-                    <span className={styles.rememberMeLabel}>Remember me</span>
-                  </label>
+            {!showForgotPassword && (
+              <div className={styles.fieldGroup}>
+                <label className={styles.label} htmlFor="auth-password">
+                  Password
+                </label>
+                <div className={styles.passwordWrapper}>
+                  <input
+                    id="auth-password"
+                    className={styles.input}
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder={isSignUp ? 'Min. 6 characters' : 'Your password'}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    autoComplete={isSignUp ? 'new-password' : 'current-password'}
+                    required
+                  />
                   <button
                     type="button"
-                    className={styles.forgotLinkBtn}
-                    onClick={handleForgotPassword}
+                    className={styles.passwordToggle}
+                    onClick={() => setShowPassword((v) => !v)}
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
                   >
-                    Forgot password?
+                    <EyeIcon open={showPassword} />
                   </button>
                 </div>
-              )}
-            </div>
-          )}
+                {!isSignUp && (
+                  <div className={styles.credentialsRow}>
+                    <label className={styles.rememberMe}>
+                      <input
+                        type="checkbox"
+                        className={styles.rememberMeInput}
+                        checked={rememberMe}
+                        onChange={(e) => setRememberMe(e.target.checked)}
+                      />
+                      <span className={styles.rememberMeBox} aria-hidden="true">
+                        <svg
+                          className={styles.rememberMeCheck}
+                          viewBox="0 0 16 16"
+                          width="10"
+                          height="10"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <polyline points="3 8.5 6.5 12 13 4.5" />
+                        </svg>
+                      </span>
+                      <span className={styles.rememberMeLabel}>Remember me</span>
+                    </label>
+                    <button
+                      type="button"
+                      className={styles.forgotLinkBtn}
+                      onClick={handleForgotPassword}
+                    >
+                      Forgot password?
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
 
-          {errorMessage && <div className={styles.error}>{errorMessage}</div>}
-          {successMessage && <div className={styles.success}>{successMessage}</div>}
+            {errorMessage && <div className={styles.error}>{errorMessage}</div>}
+            {successMessage && <div className={styles.success}>{successMessage}</div>}
 
-          <button className={styles.submitBtn} type="submit" disabled={isLoading}>
-            {isLoading ? <span className={styles.spinner} aria-hidden="true" /> : submitLabel}
-          </button>
-        </form>
+            <button className={styles.submitBtn} type="submit" disabled={isLoading}>
+              {isLoading ? <span className={styles.spinner} aria-hidden="true" /> : submitLabel}
+            </button>
+          </form>
+        )}
 
-        {!showForgotPassword && (
+        {!isVerifyEmail && !showForgotPassword && (
           <p className={styles.footer}>
             {isSignUp ? (
               <>

--- a/src/components/Auth/AuthModal.module.css
+++ b/src/components/Auth/AuthModal.module.css
@@ -415,6 +415,25 @@
   text-underline-offset: 2px;
 }
 
+/* Verify-email view — sits in place of the form when a signup is
+   awaiting confirmation. Layout mirrors the form's vertical rhythm so
+   the panel feels stable across mode switches. */
+.verifyActions {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  text-align: left;
+  margin-top: 4px;
+}
+
+.verifyActions .submitBtn {
+  margin-top: 0;
+}
+
+.verifyActions .footer {
+  margin: 4px 0 0;
+}
+
 /* Footer mode toggle */
 .footer {
   margin: 18px 0 0;

--- a/src/components/PendingEmailBanner/PendingEmailBanner.jsx
+++ b/src/components/PendingEmailBanner/PendingEmailBanner.jsx
@@ -1,0 +1,102 @@
+import { useCallback, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  clearPendingEmailVerification,
+  resendConfirmationEmail,
+  selectIsAuthenticated,
+  selectPendingEmailVerification,
+} from '../../store/slices/authSlice';
+import styles from './PendingEmailBanner.module.css';
+
+const RESEND_COOLDOWN_SECONDS = 30;
+
+/**
+ * Thin top banner shown while a user has signed up but has not yet
+ * clicked the confirmation link in their email.
+ *
+ * Mounted globally inside <App />. Only renders when:
+ *  - `pendingEmailVerification` is set in Redux (signup just happened
+ *    and Supabase did NOT issue a session — the standard flow), and
+ *  - the user is not yet authenticated (a real sign-in clears the flag
+ *    via the auth listener anyway, but we double-check here to avoid
+ *    flicker).
+ *
+ * Dismissing the banner clears `pendingEmailVerification` permanently
+ * for this session — the user is telling us they don't want the prompt
+ * anymore. They can still confirm via the email link itself, which is
+ * what actually authenticates them.
+ */
+export default function PendingEmailBanner() {
+  const dispatch = useDispatch();
+  const pending = useSelector(selectPendingEmailVerification);
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const [resendCooldown, setResendCooldown] = useState(0);
+  const [feedback, setFeedback] = useState('');
+
+  const handleResend = useCallback(async () => {
+    if (!pending?.email || resendCooldown > 0) return;
+    setFeedback('');
+    setResendCooldown(RESEND_COOLDOWN_SECONDS);
+    const tickInterval = setInterval(() => {
+      setResendCooldown((value) => {
+        if (value <= 1) {
+          clearInterval(tickInterval);
+          return 0;
+        }
+        return value - 1;
+      });
+    }, 1000);
+    const result = await dispatch(resendConfirmationEmail({ email: pending.email }));
+    if (result.meta.requestStatus === 'fulfilled') {
+      setFeedback('Sent. Check your inbox.');
+    } else {
+      setFeedback("Couldn't resend. Please try again.");
+    }
+  }, [dispatch, pending?.email, resendCooldown]);
+
+  const handleDismiss = useCallback(() => {
+    dispatch(clearPendingEmailVerification());
+  }, [dispatch]);
+
+  if (!pending?.email || isAuthenticated) return null;
+
+  return (
+    <div className={styles.banner} role="status" aria-live="polite">
+      <span className={styles.message}>
+        Verify <strong className={styles.email}>{pending.email}</strong> to activate your account.
+      </span>
+      <span className={styles.actions}>
+        {feedback && <span className={styles.feedback}>{feedback}</span>}
+        <button
+          type="button"
+          className={styles.actionBtn}
+          onClick={handleResend}
+          disabled={resendCooldown > 0}
+        >
+          {resendCooldown > 0 ? `Resend in ${resendCooldown}s` : 'Resend email'}
+        </button>
+        <button
+          type="button"
+          className={styles.dismissBtn}
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </span>
+    </div>
+  );
+}

--- a/src/components/PendingEmailBanner/PendingEmailBanner.module.css
+++ b/src/components/PendingEmailBanner/PendingEmailBanner.module.css
@@ -1,0 +1,92 @@
+/* Pending-email banner — sits at the top of the app shell while a
+   user has signed up but has not yet clicked their confirmation link.
+   Visual language: same warm-sand / charcoal tokens as the rest of the
+   app, no chrome you wouldn't see elsewhere. */
+
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  background-color: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  font-size: 13px;
+  color: var(--text-primary);
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+}
+
+.message {
+  flex: 1 1 auto;
+  min-width: 0;
+  line-height: 1.4;
+}
+
+.email {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.feedback {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.actionBtn {
+  background-color: var(--bg-button);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.actionBtn:hover:not(:disabled) {
+  background-color: var(--bg-button-hover);
+  border-color: var(--border-input);
+}
+
+.actionBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dismissBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 6px;
+  transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.dismissBtn:hover {
+  color: var(--text-secondary);
+  background-color: var(--bg-hover);
+}
+
+@media (max-width: 600px) {
+  .banner {
+    padding: 10px 14px;
+    gap: 10px;
+  }
+  .message {
+    flex-basis: 100%;
+  }
+}

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -123,7 +123,16 @@ export const signInWithEmail = createAsyncThunk(
   }
 );
 
-/** Create a new account with email, password, and optional display name. */
+/** Create a new account with email, password, and optional display name.
+ *
+ * When email confirmation is enabled in Supabase (the project default for
+ * Araviel), a successful `signUp` returns a `user` object but a `null`
+ * session — the user record exists but no session is issued until they
+ * click the link in the confirmation email. The slice surfaces this as a
+ * `pendingEmailVerification` state instead of writing a half-formed user
+ * into Redux: the modal switches to its "check your email" view, and the
+ * underlying anonymous session keeps the rest of the app usable.
+ */
 export const signUpWithEmail = createAsyncThunk(
   'auth/signUpWithEmail',
   async ({ email, password, displayName }, { rejectWithValue }) => {
@@ -131,13 +140,38 @@ export const signUpWithEmail = createAsyncThunk(
       const { data, error } = await supabase.auth.signUp({
         email,
         password,
-        options: { data: { display_name: displayName } },
+        options: {
+          data: { display_name: displayName },
+          emailRedirectTo: window.location.origin,
+        },
       });
       if (error) return rejectWithValue(error.message);
       return {
         user: mapUser(data.user),
         session: mapSession(data.session),
+        emailSubmitted: email,
       };
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+/** Re-send the signup confirmation email for a user who hasn't confirmed yet.
+ * Supabase enforces its own rate limit; the UI applies a short cooldown on
+ * top so the button isn't a spam vector.
+ */
+export const resendConfirmationEmail = createAsyncThunk(
+  'auth/resendConfirmationEmail',
+  async ({ email }, { rejectWithValue }) => {
+    try {
+      const { error } = await supabase.auth.resend({
+        type: 'signup',
+        email,
+        options: { emailRedirectTo: window.location.origin },
+      });
+      if (error) return rejectWithValue(error.message);
+      return { email };
     } catch (err) {
       return rejectWithValue(err.message);
     }
@@ -178,6 +212,17 @@ const initialState = {
   session: null,
   isLoading: true,
   error: null,
+  // When a user signs up with email but Supabase requires email
+  // confirmation, no session is issued. We hold the email here so the
+  // AuthModal can render its "check your email" view and the global
+  // banner can prompt them until they confirm. Cleared on sign-in
+  // (confirmation flow lands them with a real session) and on sign-out.
+  pendingEmailVerification: null,
+  // True only while a Google OAuth redirect is in flight. Kept separate
+  // from `isLoading` so the modal can keep its CTA in the "Redirecting…"
+  // state until the browser actually navigates away — avoids the
+  // momentary flash of the modal closing before Google's screen appears.
+  isOAuthRedirecting: false,
 };
 
 const authSlice = createSlice({
@@ -190,6 +235,13 @@ const authSlice = createSlice({
       state.session = action.payload.session;
       state.error = null;
       state.isLoading = false;
+      // A real (non-anonymous) sign-in always satisfies any pending
+      // verification — the only way to land here without an existing
+      // session is via the Supabase confirmation link.
+      if (action.payload.user && !action.payload.user.isAnonymous) {
+        state.pendingEmailVerification = null;
+      }
+      state.isOAuthRedirecting = false;
     },
     /** Clear all auth state (e.g. on sign-out). */
     clearAuth(state) {
@@ -197,6 +249,13 @@ const authSlice = createSlice({
       state.session = null;
       state.error = null;
       state.isLoading = false;
+      state.pendingEmailVerification = null;
+      state.isOAuthRedirecting = false;
+    },
+    /** Manually clear the pending email verification (e.g. user dismisses
+     *  the banner or chooses "use a different email"). */
+    clearPendingEmailVerification(state) {
+      state.pendingEmailVerification = null;
     },
     /** Explicitly toggle the loading flag. */
     setAuthLoading(state, action) {
@@ -231,18 +290,24 @@ const authSlice = createSlice({
         state.error = action.payload || 'Failed to initialize auth';
       });
 
-    // signInWithGoogle
+    // signInWithGoogle — `fulfilled` resolves the moment Supabase has
+    // queued the redirect; the browser navigation itself happens a tick
+    // later. We deliberately leave `isOAuthRedirecting` true so the
+    // modal can keep showing "Redirecting…" until the page changes,
+    // avoiding the previous flash of the modal closing before Google's
+    // consent screen appeared.
     builder
       .addCase(signInWithGoogle.pending, (state) => {
         state.isLoading = true;
+        state.isOAuthRedirecting = true;
         state.error = null;
       })
       .addCase(signInWithGoogle.fulfilled, (state) => {
-        // Browser redirects — state will be updated by the auth listener
         state.isLoading = false;
       })
       .addCase(signInWithGoogle.rejected, (state, action) => {
         state.isLoading = false;
+        state.isOAuthRedirecting = false;
         state.error = action.payload || 'Google sign-in failed';
       });
 
@@ -271,16 +336,35 @@ const authSlice = createSlice({
         state.error = null;
       })
       .addCase(signUpWithEmail.fulfilled, (state, action) => {
-        state.user = action.payload.user;
-        state.session = action.payload.session;
         state.isLoading = false;
         state.error = null;
-        resetGuestPromptCount();
+        // If Supabase issued a session immediately (email confirmation
+        // disabled at the project level), commit the real auth state.
+        // Otherwise hold the email as a pending verification — the user
+        // is NOT authenticated yet. Writing a session-less user to
+        // `state.user` was the source of the "drops you into the app"
+        // bug.
+        if (action.payload.session) {
+          state.user = action.payload.user;
+          state.session = action.payload.session;
+          resetGuestPromptCount();
+        } else {
+          state.pendingEmailVerification = {
+            email: action.payload.emailSubmitted,
+          };
+        }
       })
       .addCase(signUpWithEmail.rejected, (state, action) => {
         state.isLoading = false;
         state.error = action.payload || 'Sign-up failed';
       });
+
+    // resendConfirmationEmail — surfaces errors via the slice but doesn't
+    // mutate session state. We don't toggle `isLoading` here so it
+    // doesn't fight with the modal's button-level cooldown spinner.
+    builder.addCase(resendConfirmationEmail.rejected, (state, action) => {
+      state.error = action.payload || 'Failed to resend confirmation email';
+    });
 
     // signOut
     builder
@@ -319,8 +403,14 @@ const authSlice = createSlice({
 // Exports
 // ---------------------------------------------------------------------------
 
-export const { setAuth, clearAuth, setAuthLoading, setAuthError, setUserAvatarUrl } =
-  authSlice.actions;
+export const {
+  setAuth,
+  clearAuth,
+  setAuthLoading,
+  setAuthError,
+  setUserAvatarUrl,
+  clearPendingEmailVerification,
+} = authSlice.actions;
 
 // Selectors
 export const selectAuthUser = (state) => state.auth.user;
@@ -330,5 +420,7 @@ export const selectAuthError = (state) => state.auth.error;
 export const selectIsAuthenticated = (state) =>
   Boolean(state.auth.user) && !state.auth.user.isAnonymous;
 export const selectIsAnonymous = (state) => Boolean(state.auth.user) && state.auth.user.isAnonymous;
+export const selectPendingEmailVerification = (state) => state.auth.pendingEmailVerification;
+export const selectIsOAuthRedirecting = (state) => state.auth.isOAuthRedirecting;
 
 export default authSlice.reducer;

--- a/src/store/slices/authSlice.test.js
+++ b/src/store/slices/authSlice.test.js
@@ -19,6 +19,8 @@ describe('authSlice', () => {
     session: null,
     isLoading: true,
     error: null,
+    pendingEmailVerification: null,
+    isOAuthRedirecting: false,
   };
 
   describe('initial state', () => {
@@ -154,12 +156,39 @@ describe('authSlice', () => {
       expect(state.error).toBe('Wrong password');
     });
 
-    it('handles signUpWithEmail.fulfilled', () => {
+    it('handles signUpWithEmail.fulfilled with no session (email confirmation pending)', () => {
       const state = authReducer(initialState, {
         type: 'auth/signUpWithEmail/fulfilled',
-        payload: { user: { id: 'new' }, session: null },
+        payload: {
+          user: { id: 'new' },
+          session: null,
+          emailSubmitted: 'new@example.com',
+        },
       });
+      // No session means no real auth yet — the user must NOT be
+      // written to state. Instead, the email is held as a pending
+      // verification so the modal/banner can prompt them.
+      expect(state.user).toBeNull();
+      expect(state.session).toBeNull();
+      expect(state.pendingEmailVerification).toEqual({ email: 'new@example.com' });
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('handles signUpWithEmail.fulfilled with an immediate session', () => {
+      const state = authReducer(initialState, {
+        type: 'auth/signUpWithEmail/fulfilled',
+        payload: {
+          user: { id: 'new' },
+          session: { access_token: 'tok' },
+          emailSubmitted: 'new@example.com',
+        },
+      });
+      // When email confirmation is disabled at the project level the
+      // signup IS a real auth — commit user/session and skip the
+      // pending-verification path.
       expect(state.user.id).toBe('new');
+      expect(state.session.access_token).toBe('tok');
+      expect(state.pendingEmailVerification).toBeNull();
       expect(state.isLoading).toBe(false);
     });
 


### PR DESCRIPTION
Three connected fixes to the post-signup auth flow:

- signUpWithEmail no longer writes a session-less user into Redux. Supabase returns user+null-session when email confirmation is enabled, but the slice was committing that user, which made selectors flip and dropped the user into the app without a real session. Now: if no session is issued, stash the email as `pendingEmailVerification` and leave auth state untouched. The underlying anonymous session keeps the app usable in the meantime.

- AuthModal gains a 'verify-email' view rendered automatically while pendingEmailVerification is set. It shows the email, a rate-limited resend button, and a 'use a different email' escape hatch. Resending uses Supabase's auth.resend with type=signup.

- Google OAuth no longer flickers. signInWithOAuth resolves a tick before the browser actually navigates, which previously caused the modal to think loading had finished and close mid-redirect. We now hold an `isOAuthRedirecting` flag on the slice, leave it true after fulfilled (until navigation), and show 'Redirecting to Google…' on the button so it stays in a clear loading state until the page changes.

Also adds a small global PendingEmailBanner mounted in the app shell: when the user dismisses the modal but hasn't confirmed yet, a top strip prompts them to verify, with the same resend behavior. A real sign-in (via the email link) clears the pending state through setAuth's reducer; sign-out clears it via clearAuth.

Tests updated to reflect the new contract; 31/31 authSlice tests pass.