### PR TITLE
fix(auth): gate authentication on email_confirmed_at, not is_anonymous

### DIFF
--- a/src/hooks/useAuthListener.js
+++ b/src/hooks/useAuthListener.js
@@ -14,31 +14,7 @@ import { fetchCreditBalance } from '../services/credits';
 import { fetchSubscription } from '../services/subscription';
 import { clearImageCache } from '../services/imageGeneration';
 import { setLoggerUser } from '../lib/logger';
-
-// ---------------------------------------------------------------------------
-// Helpers: map Supabase objects to our app shapes
-// ---------------------------------------------------------------------------
-
-function mapUser(supabaseUser) {
-  if (!supabaseUser) return null;
-  return {
-    id: supabaseUser.id,
-    email: supabaseUser.email || null,
-    isAnonymous: supabaseUser.is_anonymous || false,
-    avatarUrl: supabaseUser.user_metadata?.avatar_url || null,
-    fullName:
-      supabaseUser.user_metadata?.full_name || supabaseUser.user_metadata?.display_name || null,
-  };
-}
-
-function mapSession(session) {
-  if (!session) return null;
-  return {
-    access_token: session.access_token,
-    refresh_token: session.refresh_token,
-    expires_at: session.expires_at,
-  };
-}
+import { mapUser, mapSession, isFullyAuthenticated } from '../lib/authMappers';
 
 // ---------------------------------------------------------------------------
 // localStorage keys to clear on sign-out (user-specific data)
@@ -82,8 +58,13 @@ export default function useAuthListener() {
               session: mapSession(session),
             })
           );
-          // On real (non-anonymous) sign-in, sync tier/credits from backend
-          if (event === 'SIGNED_IN' && user && !user.isAnonymous) {
+          // Sync tier/credits from backend only for fully authenticated
+          // users — i.e. non-anonymous AND email-confirmed. An
+          // email-pending user is technically non-anonymous (Supabase
+          // converts them on signUp) but their account doesn't have any
+          // server-side credits or subscription yet, and our API treats
+          // them as a guest, so calling these endpoints would just churn.
+          if (event === 'SIGNED_IN' && isFullyAuthenticated(user)) {
             resetGuestPromptCount();
             fetchCreditBalance()
               .then((data) => {

--- a/src/lib/authMappers.js
+++ b/src/lib/authMappers.js
@@ -1,0 +1,81 @@
+/**
+ * Shape adapters between raw Supabase Auth objects and the slim user/session
+ * shape we put into Redux.
+ *
+ * Centralised here because both the auth slice (`store/slices/authSlice.js`)
+ * and the auth listener hook (`hooks/useAuthListener.js`) need the same
+ * mapping — letting them drift produces extremely subtle bugs around the
+ * email-confirmation gate, which keys on `email_confirmed_at`.
+ *
+ * @typedef {Object} AppUser
+ * @property {string}      id
+ * @property {string|null} email
+ * @property {boolean}     isAnonymous
+ * @property {string|null} emailConfirmedAt   ISO timestamp Supabase set when
+ *                                            the user clicked their confirmation
+ *                                            link. Null until then. This is the
+ *                                            single source of truth for "really
+ *                                            authenticated" — `is_anonymous`
+ *                                            alone is not enough because a
+ *                                            converted anonymous-to-email user
+ *                                            has `is_anonymous=false` while
+ *                                            their email is still pending.
+ * @property {string|null} avatarUrl
+ * @property {string|null} fullName
+ *
+ * @typedef {Object} AppSession
+ * @property {string} access_token
+ * @property {string} refresh_token
+ * @property {number} expires_at
+ */
+
+/**
+ * Map a raw Supabase user object into the app's `AppUser` shape.
+ * Returns null when given a falsy input.
+ */
+export function mapUser(supabaseUser) {
+  if (!supabaseUser) return null;
+  return {
+    id: supabaseUser.id,
+    email: supabaseUser.email || null,
+    isAnonymous: supabaseUser.is_anonymous || false,
+    emailConfirmedAt: supabaseUser.email_confirmed_at || null,
+    avatarUrl: supabaseUser.user_metadata?.avatar_url || null,
+    fullName:
+      supabaseUser.user_metadata?.full_name || supabaseUser.user_metadata?.display_name || null,
+  };
+}
+
+/**
+ * Map a raw Supabase session into the minimal `AppSession` shape we keep in
+ * Redux. We deliberately do NOT mirror the entire Supabase session — the JS
+ * client owns refresh/expiry; we only need the fields downstream services
+ * read.
+ */
+export function mapSession(session) {
+  if (!session) return null;
+  return {
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+    expires_at: session.expires_at,
+  };
+}
+
+/**
+ * `true` iff the user is fully authenticated — non-anonymous AND has a
+ * confirmed email. This is the predicate the rest of the app should use.
+ */
+export function isFullyAuthenticated(user) {
+  return Boolean(user) && !user.isAnonymous && Boolean(user.emailConfirmedAt);
+}
+
+/**
+ * `true` iff the user has signed up with an email but has not yet clicked
+ * the confirmation link. We use the user object's own state (rather than a
+ * separate flag in Redux) so the predicate stays correct across reloads —
+ * Supabase rehydrates the user from localStorage, and `email_confirmed_at`
+ * is the persistent signal we rely on.
+ */
+export function hasPendingEmailVerification(user) {
+  return Boolean(user) && Boolean(user.email) && !user.emailConfirmedAt;
+}

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -3,33 +3,7 @@ import { supabase } from '../../lib/supabase';
 import { setRememberMePreference } from '../../lib/authStorage';
 import { resetGuestPromptCount } from '../../utils/guestSession';
 import { logger } from '../../lib/logger';
-
-// ---------------------------------------------------------------------------
-// Helper: map a Supabase user object to our app's user shape
-// ---------------------------------------------------------------------------
-function mapUser(supabaseUser) {
-  if (!supabaseUser) return null;
-  return {
-    id: supabaseUser.id,
-    email: supabaseUser.email || null,
-    isAnonymous: supabaseUser.is_anonymous || false,
-    avatarUrl: supabaseUser.user_metadata?.avatar_url || null,
-    fullName:
-      supabaseUser.user_metadata?.full_name || supabaseUser.user_metadata?.display_name || null,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Helper: map a Supabase session to a minimal session shape
-// ---------------------------------------------------------------------------
-function mapSession(session) {
-  if (!session) return null;
-  return {
-    access_token: session.access_token,
-    refresh_token: session.refresh_token,
-    expires_at: session.expires_at,
-  };
-}
+import { mapUser, mapSession, hasPendingEmailVerification } from '../../lib/authMappers';
 
 // ---------------------------------------------------------------------------
 // Async thunks
@@ -229,19 +203,27 @@ const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    /** Set user and session (typically called from the auth listener). */
+    /** Set user and session (typically called from the auth listener).
+     *
+     * The pending-verification flag is derived purely from the user object
+     * here: a Supabase user with an email but no `email_confirmed_at` is
+     * email-pending — we surface that via `pendingEmailVerification` no
+     * matter how it arrived (signUp success, USER_UPDATED after Supabase
+     * converted an anon user, an `INITIAL_SESSION` rehydration on reload,
+     * etc.). Once the email is confirmed the same path clears the flag.
+     */
     setAuth(state, action) {
       state.user = action.payload.user;
       state.session = action.payload.session;
       state.error = null;
       state.isLoading = false;
-      // A real (non-anonymous) sign-in always satisfies any pending
-      // verification — the only way to land here without an existing
-      // session is via the Supabase confirmation link.
-      if (action.payload.user && !action.payload.user.isAnonymous) {
+      state.isOAuthRedirecting = false;
+      const nextUser = action.payload.user;
+      if (hasPendingEmailVerification(nextUser)) {
+        state.pendingEmailVerification = { email: nextUser.email };
+      } else if (nextUser && nextUser.emailConfirmedAt) {
         state.pendingEmailVerification = null;
       }
-      state.isOAuthRedirecting = false;
     },
     /** Clear all auth state (e.g. on sign-out). */
     clearAuth(state) {
@@ -284,6 +266,13 @@ const authSlice = createSlice({
         state.session = action.payload.session;
         state.isLoading = false;
         state.error = null;
+        // Restore the pending-verification prompt across reloads:
+        // Supabase persists the email-pending session in localStorage, so
+        // a returning user lands here with `email && !emailConfirmedAt`.
+        // The banner needs the flag to prompt them.
+        if (hasPendingEmailVerification(action.payload.user)) {
+          state.pendingEmailVerification = { email: action.payload.user.email };
+        }
       })
       .addCase(initializeAuth.rejected, (state, action) => {
         state.isLoading = false;
@@ -322,6 +311,12 @@ const authSlice = createSlice({
         state.session = action.payload.session;
         state.isLoading = false;
         state.error = null;
+        // Supabase blocks signInWithPassword for unconfirmed emails ("Email
+        // not confirmed"), so reaching `fulfilled` implies a confirmed user.
+        // Clear any lingering pending state defensively (e.g. user signed
+        // in to a different account than the one they previously had a
+        // pending verification for).
+        state.pendingEmailVerification = null;
         resetGuestPromptCount();
       })
       .addCase(signInWithEmail.rejected, (state, action) => {
@@ -330,6 +325,14 @@ const authSlice = createSlice({
       });
 
     // signUpWithEmail
+    //
+    // The session can be non-null here even when the user hasn't confirmed —
+    // when `signUp` runs against an active anonymous session, Supabase
+    // *converts* the anon user into an email-pending user, keeping the
+    // existing session valid. The only field that distinguishes "really
+    // authenticated" from "email pending" is `email_confirmed_at`, so the
+    // reducer keys on that exclusively. The earlier `if (session)` check
+    // was the source of the "drops you into the app" bug.
     builder
       .addCase(signUpWithEmail.pending, (state) => {
         state.isLoading = true;
@@ -338,17 +341,20 @@ const authSlice = createSlice({
       .addCase(signUpWithEmail.fulfilled, (state, action) => {
         state.isLoading = false;
         state.error = null;
-        // If Supabase issued a session immediately (email confirmation
-        // disabled at the project level), commit the real auth state.
-        // Otherwise hold the email as a pending verification — the user
-        // is NOT authenticated yet. Writing a session-less user to
-        // `state.user` was the source of the "drops you into the app"
-        // bug.
-        if (action.payload.session) {
-          state.user = action.payload.user;
+        const newUser = action.payload.user;
+        if (newUser?.emailConfirmedAt) {
+          state.user = newUser;
           state.session = action.payload.session;
+          state.pendingEmailVerification = null;
           resetGuestPromptCount();
         } else {
+          // Email-pending. Hold the email so the modal/banner can prompt
+          // the user; deliberately do NOT commit user/session here — that
+          // would flip selectIsAuthenticated to true and drop the user
+          // into the app. The auth listener will receive a USER_UPDATED
+          // shortly after this and write the canonical user via setAuth,
+          // which preserves pendingEmailVerification because the user is
+          // still email-pending.
           state.pendingEmailVerification = {
             email: action.payload.emailSubmitted,
           };
@@ -417,8 +423,22 @@ export const selectAuthUser = (state) => state.auth.user;
 export const selectAuthSession = (state) => state.auth.session;
 export const selectAuthLoading = (state) => state.auth.isLoading;
 export const selectAuthError = (state) => state.auth.error;
+
+/**
+ * `true` only for fully authenticated users — non-anonymous AND
+ * email-confirmed. An "email-pending" user (signed up but hasn't yet
+ * clicked the confirmation link) is intentionally NOT authenticated:
+ * they should still see the verify view in the modal and the prompt
+ * banner, and the rest of the app should continue treating them as a
+ * guest until they confirm. Using `email_confirmed_at` (rather than
+ * `is_anonymous`) is what makes this robust against Supabase's
+ * "convert anonymous user to email user on signUp" behavior, which
+ * flips `is_anonymous` to `false` while the email is still unconfirmed.
+ */
 export const selectIsAuthenticated = (state) =>
-  Boolean(state.auth.user) && !state.auth.user.isAnonymous;
+  Boolean(state.auth.user) &&
+  !state.auth.user.isAnonymous &&
+  Boolean(state.auth.user.emailConfirmedAt);
 export const selectIsAnonymous = (state) => Boolean(state.auth.user) && state.auth.user.isAnonymous;
 export const selectPendingEmailVerification = (state) => state.auth.pendingEmailVerification;
 export const selectIsOAuthRedirecting = (state) => state.auth.isOAuthRedirecting;

--- a/src/store/slices/authSlice.test.js
+++ b/src/store/slices/authSlice.test.js
@@ -34,14 +34,51 @@ describe('authSlice', () => {
   });
 
   describe('setAuth', () => {
-    it('sets user and session', () => {
-      const user = { id: 'u1', email: 'test@test.com', isAnonymous: false };
+    it('sets user and session for a confirmed user and clears pending', () => {
+      const user = {
+        id: 'u1',
+        email: 'test@test.com',
+        isAnonymous: false,
+        emailConfirmedAt: '2026-04-30T12:00:00Z',
+      };
+      const session = { access_token: 'token' };
+      const state = authReducer(
+        { ...initialState, pendingEmailVerification: { email: 'old@test.com' } },
+        setAuth({ user, session })
+      );
+      expect(state.user).toEqual(user);
+      expect(state.session).toEqual(session);
+      expect(state.pendingEmailVerification).toBeNull();
+      expect(state.error).toBeNull();
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('records pending verification for an email-pending user (anon-conversion case)', () => {
+      // Supabase converts an active anonymous session into an email-pending
+      // user on signUp: is_anonymous flips to false but email_confirmed_at
+      // stays null. setAuth must NOT treat this as an authenticated sign-in;
+      // it has to keep prompting the user to confirm.
+      const user = {
+        id: 'u1',
+        email: 'pending@test.com',
+        isAnonymous: false,
+        emailConfirmedAt: null,
+      };
       const session = { access_token: 'token' };
       const state = authReducer(initialState, setAuth({ user, session }));
       expect(state.user).toEqual(user);
       expect(state.session).toEqual(session);
-      expect(state.error).toBeNull();
-      expect(state.isLoading).toBe(false);
+      expect(state.pendingEmailVerification).toEqual({ email: 'pending@test.com' });
+    });
+
+    it('leaves pending verification alone for an anonymous user', () => {
+      const user = { id: 'anon', isAnonymous: true, emailConfirmedAt: null };
+      const session = { access_token: 'anon-tok' };
+      const state = authReducer(
+        { ...initialState, pendingEmailVerification: { email: 'pending@test.com' } },
+        setAuth({ user, session })
+      );
+      expect(state.pendingEmailVerification).toEqual({ email: 'pending@test.com' });
     });
   });
 
@@ -138,13 +175,25 @@ describe('authSlice', () => {
     });
 
     it('handles signInWithEmail.fulfilled', () => {
-      const user = { id: 'u1' };
+      // Supabase blocks signInWithPassword for unconfirmed users with
+      // "Email not confirmed", so reaching `fulfilled` always means a
+      // confirmed user. The reducer commits user/session and defensively
+      // clears any lingering pending verification (e.g. from a prior
+      // signup attempt with a different email).
+      const user = {
+        id: 'u1',
+        email: 'test@test.com',
+        isAnonymous: false,
+        emailConfirmedAt: '2026-04-30T12:00:00Z',
+      };
       const session = { access_token: 'tok' };
-      const state = authReducer(initialState, {
-        type: 'auth/signInWithEmail/fulfilled',
-        payload: { user, session },
-      });
+      const state = authReducer(
+        { ...initialState, pendingEmailVerification: { email: 'old@test.com' } },
+        { type: 'auth/signInWithEmail/fulfilled', payload: { user, session } }
+      );
       expect(state.user).toEqual(user);
+      expect(state.session).toEqual(session);
+      expect(state.pendingEmailVerification).toBeNull();
       expect(state.isLoading).toBe(false);
     });
 
@@ -156,36 +205,66 @@ describe('authSlice', () => {
       expect(state.error).toBe('Wrong password');
     });
 
-    it('handles signUpWithEmail.fulfilled with no session (email confirmation pending)', () => {
+    it('handles signUpWithEmail.fulfilled for a fresh email-pending signup (no session)', () => {
       const state = authReducer(initialState, {
         type: 'auth/signUpWithEmail/fulfilled',
         payload: {
-          user: { id: 'new' },
+          user: { id: 'new', email: 'new@example.com', emailConfirmedAt: null },
           session: null,
           emailSubmitted: 'new@example.com',
         },
       });
-      // No session means no real auth yet — the user must NOT be
-      // written to state. Instead, the email is held as a pending
-      // verification so the modal/banner can prompt them.
+      // No confirmed email — must NOT commit user/session, must surface
+      // pending verification so the modal flips to the "Check your inbox"
+      // view.
       expect(state.user).toBeNull();
       expect(state.session).toBeNull();
       expect(state.pendingEmailVerification).toEqual({ email: 'new@example.com' });
       expect(state.isLoading).toBe(false);
     });
 
-    it('handles signUpWithEmail.fulfilled with an immediate session', () => {
+    it('handles signUpWithEmail.fulfilled for the anon-conversion case', () => {
+      // The bug case. Supabase JS, on `signUp` against an active anonymous
+      // session, converts the user in place and returns the still-valid
+      // session. `is_anonymous` is now false but `email_confirmed_at` is
+      // still null. The reducer must NOT commit the user — it must hold
+      // pending and let the modal show the verify view.
       const state = authReducer(initialState, {
         type: 'auth/signUpWithEmail/fulfilled',
         payload: {
-          user: { id: 'new' },
+          user: {
+            id: 'new',
+            email: 'new@example.com',
+            isAnonymous: false,
+            emailConfirmedAt: null,
+          },
+          session: { access_token: 'still-anon-session-tok' },
+          emailSubmitted: 'new@example.com',
+        },
+      });
+      expect(state.user).toBeNull();
+      expect(state.session).toBeNull();
+      expect(state.pendingEmailVerification).toEqual({ email: 'new@example.com' });
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('handles signUpWithEmail.fulfilled when Supabase returns a confirmed user', () => {
+      // Some Supabase projects disable email confirmation entirely; in that
+      // case `email_confirmed_at` is filled in immediately. Then the signup
+      // IS a real authentication — commit user/session, skip pending.
+      const state = authReducer(initialState, {
+        type: 'auth/signUpWithEmail/fulfilled',
+        payload: {
+          user: {
+            id: 'new',
+            email: 'new@example.com',
+            isAnonymous: false,
+            emailConfirmedAt: '2026-04-30T12:00:00Z',
+          },
           session: { access_token: 'tok' },
           emailSubmitted: 'new@example.com',
         },
       });
-      // When email confirmation is disabled at the project level the
-      // signup IS a real auth — commit user/session and skip the
-      // pending-verification path.
       expect(state.user.id).toBe('new');
       expect(state.session.access_token).toBe('tok');
       expect(state.pendingEmailVerification).toBeNull();
@@ -239,7 +318,12 @@ describe('authSlice', () => {
   describe('selectors', () => {
     const authenticatedState = {
       auth: {
-        user: { id: 'u1', email: 'test@test.com', isAnonymous: false },
+        user: {
+          id: 'u1',
+          email: 'test@test.com',
+          isAnonymous: false,
+          emailConfirmedAt: '2026-04-30T12:00:00Z',
+        },
         session: { access_token: 'tok' },
         isLoading: false,
         error: null,
@@ -248,8 +332,22 @@ describe('authSlice', () => {
 
     const anonymousState = {
       auth: {
-        user: { id: 'anon-1', isAnonymous: true },
+        user: { id: 'anon-1', isAnonymous: true, emailConfirmedAt: null },
         session: { access_token: 'anon-tok' },
+        isLoading: false,
+        error: null,
+      },
+    };
+
+    const emailPendingState = {
+      auth: {
+        user: {
+          id: 'pending-1',
+          email: 'pending@test.com',
+          isAnonymous: false,
+          emailConfirmedAt: null,
+        },
+        session: { access_token: 'tok' },
         isLoading: false,
         error: null,
       },
@@ -275,12 +373,20 @@ describe('authSlice', () => {
       expect(selectAuthError(emptyState)).toBe('err');
     });
 
-    it('selectIsAuthenticated returns true for non-anonymous user', () => {
+    it('selectIsAuthenticated returns true for confirmed non-anonymous user', () => {
       expect(selectIsAuthenticated(authenticatedState)).toBe(true);
     });
 
     it('selectIsAuthenticated returns false for anonymous user', () => {
       expect(selectIsAuthenticated(anonymousState)).toBe(false);
+    });
+
+    it('selectIsAuthenticated returns false for email-pending user', () => {
+      // Critical: a user mid-conversion (is_anonymous=false but
+      // email_confirmed_at=null) must NOT be considered authenticated.
+      // Otherwise the gate logic flips and we drop them into the app
+      // before they confirm.
+      expect(selectIsAuthenticated(emailPendingState)).toBe(false);
     });
 
     it('selectIsAuthenticated returns false for null user', () => {


### PR DESCRIPTION
The previous fix didn't actually solve the bug because it keyed on the wrong signals. When supabase.auth.signUp() runs against an active anonymous session — which Araveil always has on app load — Supabase *converts* the anon user into an email-pending user: same user ID, same session, but is_anonymous flips to false and email_confirmed_at stays null. Two effects:

1. signUpWithEmail.fulfilled saw `data.session` non-null (the still- valid anon session) and committed user/session as if the email had been confirmed.
2. Supabase fired USER_UPDATED, the listener called setAuth, the reducer cleared pendingEmailVerification because !user.isAnonymous was true.

Both effects dropped the user into the app before they confirmed.

Switch the entire auth gate to email_confirmed_at as the single source of truth:

- New shared util src/lib/authMappers.js owns mapUser, mapSession, isFullyAuthenticated, hasPendingEmailVerification. Both authSlice and useAuthListener import from it (the duplicated mapper functions were the structural smell that let these signals drift).
- AppUser gains `emailConfirmedAt`.
- selectIsAuthenticated now requires !isAnonymous AND emailConfirmedAt.
- setAuth derives pendingEmailVerification from the user object: an email-pending user (email set, emailConfirmedAt null) keeps the flag set; a confirmed user clears it; an anonymous user leaves it alone.
- signUpWithEmail.fulfilled commits user/session only when emailConfirmedAt is set. The anon-conversion case (session truthy, emailConfirmedAt null) correctly routes into pending now.
- initializeAuth.fulfilled restores pendingEmailVerification on reload if the rehydrated user is email-pending — the banner stays correct across refreshes.
- signInWithEmail.fulfilled defensively clears pendingEmailVerification (Supabase already blocks signin on unconfirmed accounts).
- useAuthListener uses isFullyAuthenticated to gate the post-sign-in credit/subscription fetches so email-pending users don't churn the API with partial accounts.

Tests: 35/35 authSlice tests pass, including new cases for the anon- conversion flow, email-pending setAuth, and email-pending isAuthenticated.