### PR TITLE
Replace inline auth modals with dedicated /login and /signup routes

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { Link, useLocation } from 'react-router-dom';
 import {
   signInWithGoogle,
   signInWithEmail,
@@ -90,6 +91,7 @@ const EyeIcon = ({ open }) => (
  */
 export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
   const dispatch = useDispatch();
+  const location = useLocation();
   const isLoading = useSelector(selectAuthLoading);
   const authError = useSelector(selectAuthError);
 
@@ -137,12 +139,6 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
     document.addEventListener('keydown', onKey);
     return () => document.removeEventListener('keydown', onKey);
   }, [isOpen, handleClose]);
-
-  const handleTabSwitch = (tab) => {
-    setActiveTab(tab);
-    clearState();
-    setShowForgotPassword(false);
-  };
 
   const handleGoogleSignIn = () => {
     setLocalError('');
@@ -395,24 +391,24 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
             {isSignUp ? (
               <>
                 Already have an account?{' '}
-                <button
-                  type="button"
+                <Link
+                  to="/login"
+                  state={location.state}
                   className={styles.footerLink}
-                  onClick={() => handleTabSwitch('signin')}
                 >
                   Sign in
-                </button>
+                </Link>
               </>
             ) : (
               <>
                 New to Araviel?{' '}
-                <button
-                  type="button"
+                <Link
+                  to="/signup"
+                  state={location.state}
                   className={styles.footerLink}
-                  onClick={() => handleTabSwitch('signup')}
                 >
                   Create an account
-                </button>
+                </Link>
               </>
             )}
           </p>

--- a/src/components/Auth/AuthRoute.jsx
+++ b/src/components/Auth/AuthRoute.jsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { selectIsAuthenticated } from '../../store/slices/authSlice';
+import AuthModal from './AuthModal';
+
+/**
+ * AuthRoute — Full-page auth surface mounted at /login and /signup.
+ *
+ * Reuses AuthModal as the visual layer (it already renders a fixed,
+ * full-viewport panel that covers the sidebar). Once the user is
+ * authenticated, redirects to `location.state.from` if a caller passed
+ * one when navigating here, otherwise back to '/'.
+ */
+export default function AuthRoute({ initialTab = 'signin' }) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+
+  const redirectTo = location.state?.from || '/';
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate(redirectTo, { replace: true });
+    }
+  }, [isAuthenticated, navigate, redirectTo]);
+
+  return (
+    <AuthModal isOpen onClose={() => navigate('/')} initialTab={initialTab} />
+  );
+}

--- a/src/components/Auth/index.js
+++ b/src/components/Auth/index.js
@@ -1,1 +1,2 @@
 export { default as AuthModal } from './AuthModal';
+export { default as AuthRoute } from './AuthRoute';

--- a/src/components/GuestGate/GuestGate.jsx
+++ b/src/components/GuestGate/GuestGate.jsx
@@ -1,12 +1,14 @@
-import { useState } from 'react';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
-import { AuthModal } from '../Auth';
 import styles from './GuestGate.module.css';
 
 /**
- * GuestGate — A beautiful inline login prompt shown to guest users
- * when they try to access features that require authentication.
+ * GuestGate — Inline sign-in prompt shown to guest users on routes that
+ * require authentication. Sends visitors to the dedicated /signup or
+ * /login route, preserving the current path as `location.state.from`
+ * so they are redirected back after authenticating.
  *
  * Props:
  * - icon: ReactNode — Icon component to display
@@ -22,58 +24,55 @@ export default function GuestGate({
   actionLabel = 'Sign in to continue',
   compact = false,
 }) {
-  const [authModalOpen, setAuthModalOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const goToLogin = useCallback(() => {
+    navigate('/login', { state: { from: location.pathname + location.search } });
+  }, [navigate, location.pathname, location.search]);
+
+  const goToSignup = useCallback(() => {
+    navigate('/signup', { state: { from: location.pathname + location.search } });
+  }, [navigate, location.pathname, location.search]);
 
   return (
-    <>
-      <div className={`${styles.container} ${compact ? styles.compact : ''}`}>
-        <div className={styles.content}>
-          {icon && <div className={styles.icon}>{icon}</div>}
-          <h2 className={styles.title}>{title}</h2>
-          <p className={styles.description}>{description}</p>
-          <button className={styles.signInBtn} onClick={() => setAuthModalOpen(true)}>
-            {actionLabel}
-          </button>
-          <button
-            className={styles.signUpLink}
-            onClick={() => setAuthModalOpen(true)}
-          >
-            Don&apos;t have an account? <span>Sign up for free</span>
-          </button>
-        </div>
+    <div className={`${styles.container} ${compact ? styles.compact : ''}`}>
+      <div className={styles.content}>
+        {icon && <div className={styles.icon}>{icon}</div>}
+        <h2 className={styles.title}>{title}</h2>
+        <p className={styles.description}>{description}</p>
+        <button className={styles.signInBtn} onClick={goToLogin}>
+          {actionLabel}
+        </button>
+        <button className={styles.signUpLink} onClick={goToSignup}>
+          Don&apos;t have an account? <span>Sign up for free</span>
+        </button>
       </div>
-      <AuthModal
-        isOpen={authModalOpen}
-        onClose={() => setAuthModalOpen(false)}
-        initialTab="signup"
-      />
-    </>
+    </div>
   );
 }
 
 /**
- * useGuestGate — Hook that returns whether the user is a guest
- * and a function to show the auth modal.
+ * useGuestGate — Hook that returns whether the user is a guest and a
+ * `requireAuth` function that navigates to /signup (preserving the
+ * current path as `state.from`) when called for a non-authenticated
+ * user. `GateModal` is a no-op kept for back-compat with existing
+ * callers; safe to drop once all sites have migrated.
  */
 export function useGuestGate() {
   const isAuthenticated = useSelector(selectIsAuthenticated);
-  const [authModalOpen, setAuthModalOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  const requireAuth = () => {
+  const requireAuth = useCallback(() => {
     if (!isAuthenticated) {
-      setAuthModalOpen(true);
+      navigate('/signup', { state: { from: location.pathname + location.search } });
       return true; // blocked
     }
     return false; // allowed
-  };
+  }, [isAuthenticated, navigate, location.pathname, location.search]);
 
-  const GateModal = () => (
-    <AuthModal
-      isOpen={authModalOpen}
-      onClose={() => setAuthModalOpen(false)}
-      initialTab="signup"
-    />
-  );
+  const GateModal = () => null;
 
-  return { isGuest: !isAuthenticated, requireAuth, GateModal, setAuthModalOpen };
+  return { isGuest: !isAuthenticated, requireAuth, GateModal };
 }

--- a/src/components/ImageGalleryView/ImageGalleryView.jsx
+++ b/src/components/ImageGalleryView/ImageGalleryView.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import {
   setInputValue,
@@ -13,7 +13,6 @@ import {
   setImageQuality,
   setCreditBalance,
 } from '../../store/slices/chatSlice';
-import { AuthModal } from '../Auth';
 import { hasReachedGuestImageLimit, incrementGuestImageCount } from '../../utils/guestSession';
 import { fetchCreditBalance } from '../../services/credits';
 import { IMAGE_QUALITY_OPTIONS } from '../../config/credits';
@@ -96,6 +95,7 @@ const QUICK_PROMPTS = [
 export default function ImageGalleryView() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
   const { id: routeImageId } = useParams();
   const creditBalance = useSelector(selectCreditBalance);
   const imageQuality = useSelector(selectImageQuality);
@@ -108,7 +108,6 @@ export default function ImageGalleryView() {
   const [promptInput, setPromptInput] = useState('');
   const [showAttachMenu, setShowAttachMenu] = useState(false);
   const [showBuyPacks, setShowBuyPacks] = useState(false);
-  const [showAuthModal, setShowAuthModal] = useState(false);
   const [qualityOpen, setQualityOpen] = useState(false);
   const isAuthenticated = useSelector(selectIsAuthenticated);
   const promptInputRef = useRef(null);
@@ -313,7 +312,7 @@ export default function ImageGalleryView() {
   const firePromptInChat = (prompt) => {
     // Guest image limit check
     if (!isAuthenticated && hasReachedGuestImageLimit()) {
-      setShowAuthModal(true);
+      navigate('/signup', { state: { from: location.pathname + location.search } });
       return;
     }
     // Track guest image usage
@@ -529,7 +528,9 @@ export default function ImageGalleryView() {
               tier={creditBalance?.tier ?? 'free'}
               onBuyCredits={() => {
                 if (!isAuthenticated) {
-                  setShowAuthModal(true);
+                  navigate('/signup', {
+                    state: { from: location.pathname + location.search },
+                  });
                 } else {
                   setShowBuyPacks(true);
                 }
@@ -802,12 +803,6 @@ export default function ImageGalleryView() {
           document.body
         )}
 
-      {/* Guest auth modal */}
-      <AuthModal
-        isOpen={showAuthModal}
-        onClose={() => setShowAuthModal(false)}
-        initialTab="signup"
-      />
     </div>
   );
 }

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   selectInputValue,
@@ -150,7 +150,6 @@ import {
   hasReachedGuestImageLimit,
   incrementGuestImageCount,
 } from '../../utils/guestSession';
-import { AuthModal } from '../Auth';
 import DynamicSubtitle from '../DynamicSubtitle/DynamicSubtitle';
 import useUserLocation from '../../hooks/useUserLocation';
 import styles from './MainContent.module.css';
@@ -1001,6 +1000,7 @@ function ImageLimitPrompt({ onClose, onBuyCredits, onUpgrade }) {
 export default function MainContent() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
   const inputValue = useSelector(selectInputValue);
   const mode = useSelector(selectMode);
   const messages = useSelector(selectMessages);
@@ -1063,8 +1063,6 @@ export default function MainContent() {
   const [galleryFiles, setGalleryFiles] = useState([]);
   const [showLimitToast, setShowLimitToast] = useState(false);
   const [showImageLimitPrompt, setShowImageLimitPrompt] = useState(false);
-  const [showGuestLimitModal, setShowGuestLimitModal] = useState(false);
-  const [showSessionExpiredModal, setShowSessionExpiredModal] = useState(false);
   const isAuthenticated = useSelector(selectIsAuthenticated);
   // conversationProject is now derived from Redux — see below
   const [conversationTitle, setConversationTitle] = useState('');
@@ -1862,7 +1860,7 @@ export default function MainContent() {
               } else if (data.code === 'GUEST_LIMIT') {
                 dispatch(setIsProcessing(false));
                 // Guest limit reached — show sign-up auth modal
-                setShowGuestLimitModal(true);
+                navigate('/signup', { state: { from: location.pathname + location.search } });
                 if (assistantMsgAdded) {
                   dispatch(
                     updateLastMessage({
@@ -1992,11 +1990,11 @@ export default function MainContent() {
     // Guest limit checks — separate text and image counters
     if (!isAuthenticated) {
       if (willGenerateImage && hasReachedGuestImageLimit()) {
-        setShowGuestLimitModal(true);
+        navigate('/signup', { state: { from: location.pathname + location.search } });
         return;
       }
       if (!willGenerateImage && hasReachedGuestLimit()) {
-        setShowGuestLimitModal(true);
+        navigate('/signup', { state: { from: location.pathname + location.search } });
         return;
       }
     }
@@ -2128,11 +2126,11 @@ export default function MainContent() {
     const willGenImage =
       modality === 'image' || (selectedModelId && isImageGenerationModel(selectedModelId));
 
-    // Guest image limit — show AuthModal (sign up), not "Upgrade to Pro"
+    // Guest image limit — bounce to /signup, not "Upgrade to Pro"
     if (!isAuthenticated && willGenImage && hasReachedGuestImageLimit()) {
       dispatch(setPendingAutoSubmit(false));
       dispatch(setPendingModality(null));
-      setShowGuestLimitModal(true);
+      navigate('/signup', { state: { from: location.pathname + location.search } });
       return;
     }
 
@@ -2844,7 +2842,7 @@ export default function MainContent() {
             <button
               type="button"
               className={styles.signUpNavBtn}
-              onClick={() => setShowGuestLimitModal(true)}
+              onClick={() => navigate('/signup', { state: { from: location.pathname + location.search } })}
               aria-label="Sign up or sign in"
             >
               <span className={styles.signUpNavBtnLabel}>Sign up</span>
@@ -3068,20 +3066,6 @@ export default function MainContent() {
 
       {showBuyPacksModal && <BuyPacksModal onClose={() => setShowBuyPacksModal(false)} />}
 
-      {/* Guest prompt limit — uniform sign-up surface */}
-      <AuthModal
-        isOpen={showGuestLimitModal}
-        onClose={() => setShowGuestLimitModal(false)}
-        initialTab="signup"
-      />
-
-      {/* Session expired modal */}
-      <AuthModal
-        isOpen={showSessionExpiredModal}
-        onClose={() => setShowSessionExpiredModal(false)}
-        initialTab="signin"
-      />
-
       {/* Gallery preview */}
       {showGallery && galleryFiles.length > 0 && (
         <GalleryPreview
@@ -3123,7 +3107,7 @@ export default function MainContent() {
           isStreaming={isStreaming}
           streamedText={streamedText}
           onRetry={handleRetry}
-          onSessionExpired={() => setShowSessionExpiredModal(true)}
+          onSessionExpired={() => navigate('/login', { state: { from: location.pathname + location.search } })}
           onAlternateModelRequest={handleAlternateModelRequest}
           onSubConvPanelToggle={setIsSubConvPanelOpen}
           onCodePanelToggle={setIsCodePanelOpen}

--- a/src/components/PricingView/PricingView.jsx
+++ b/src/components/PricingView/PricingView.jsx
@@ -1,6 +1,6 @@
 import { useSelector, useDispatch } from 'react-redux';
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   selectCurrentTier,
   selectBillingCycle,
@@ -14,13 +14,13 @@ import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import { getAvailableTiers, SubscriptionTier } from '../../config/subscription';
 import BillingToggle from './BillingToggle';
 import TierCard from './TierCard';
-import { AuthModal } from '../Auth';
 import { useToast } from '../Toast/Toast';
 import styles from './PricingView.module.css';
 
 export default function PricingView() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
   const { showError } = useToast();
   const currentTier = useSelector(selectCurrentTier);
   const billingCycle = useSelector(selectBillingCycle);
@@ -28,11 +28,10 @@ export default function PricingView() {
   const subscriptionError = useSelector(selectSubscriptionError);
   const isAuthenticated = useSelector(selectIsAuthenticated);
   const tiers = getAvailableTiers();
-  const [showAuthModal, setShowAuthModal] = useState(false);
 
   const handleCtaClick = (tier) => {
     if (!isAuthenticated) {
-      setShowAuthModal(true);
+      navigate('/signup', { state: { from: location.pathname + location.search } });
       return;
     }
 
@@ -116,12 +115,6 @@ export default function PricingView() {
           <p>Prices shown in GBP. Cancel or change your plan anytime.</p>
         </div>
       </div>
-
-      <AuthModal
-        isOpen={showAuthModal}
-        onClose={() => setShowAuthModal(false)}
-        initialTab="signup"
-      />
     </div>
   );
 }

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -27,7 +27,6 @@ import {
 import { useToast } from '../Toast/Toast';
 import { selectProjects, setProjects } from '../../store/slices/projectsSlice';
 import { selectCurrentTier } from '../../store/slices/subscriptionSlice';
-import { AuthModal } from '../Auth';
 import {
   PlusIcon,
   ChevronLeftIcon,
@@ -171,7 +170,6 @@ export default function Sidebar() {
   const [linkCopied, setLinkCopied] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const userTier = useSelector(selectCurrentTier);
-  const [authModalOpen, setAuthModalOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const userMenuRef = useRef(null);
   const renameInputRef = useRef(null);
@@ -982,7 +980,9 @@ export default function Sidebar() {
                   onClick={() => {
                     setUserMenuOpen(false);
                     if (!isAuthenticated) {
-                      setAuthModalOpen(true);
+                      navigate('/login', {
+                        state: { from: location.pathname + location.search },
+                      });
                     } else {
                       navigate('/settings');
                     }
@@ -1054,7 +1054,9 @@ export default function Sidebar() {
                     className={styles.userDropdownItem}
                     onClick={() => {
                       setUserMenuOpen(false);
-                      setAuthModalOpen(true);
+                      navigate('/login', {
+                        state: { from: location.pathname + location.search },
+                      });
                     }}
                   >
                     <LogOutIcon />
@@ -1146,9 +1148,6 @@ export default function Sidebar() {
           onError={showError}
         />
       )}
-
-      {/* Auth modal */}
-      <AuthModal isOpen={authModalOpen} onClose={() => setAuthModalOpen(false)} />
 
       {/* Search modal */}
       {searchOpen && <SearchModal onClose={() => setSearchOpen(false)} />}

--- a/src/config/subscription.test.js
+++ b/src/config/subscription.test.js
@@ -18,12 +18,10 @@ import {
 
 describe('subscription config', () => {
   describe('SubscriptionTier enum', () => {
-    it('contains all 5 tiers', () => {
+    it('contains the live tiers', () => {
       expect(SubscriptionTier.Free).toBe('free');
       expect(SubscriptionTier.Lite).toBe('lite');
       expect(SubscriptionTier.Pro).toBe('pro');
-      expect(SubscriptionTier.Ultra).toBe('ultra');
-      expect(SubscriptionTier.Apex).toBe('apex');
     });
   });
 
@@ -46,8 +44,8 @@ describe('subscription config', () => {
   });
 
   describe('SUBSCRIPTION_TIERS', () => {
-    it('contains exactly 5 tiers', () => {
-      expect(SUBSCRIPTION_TIERS).toHaveLength(5);
+    it('contains the live tiers', () => {
+      expect(SUBSCRIPTION_TIERS).toHaveLength(3);
     });
 
     it('each tier has required properties', () => {
@@ -80,7 +78,7 @@ describe('subscription config', () => {
 
   describe('TIER_ORDER', () => {
     it('orders tiers from lowest to highest', () => {
-      expect(TIER_ORDER).toEqual(['free', 'lite', 'pro', 'ultra', 'apex']);
+      expect(TIER_ORDER).toEqual(['free', 'lite', 'pro']);
     });
   });
 

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -14,6 +14,7 @@ import SharedConversationView from './components/SharedConversationView';
 import RouteErrorBoundary from './components/ErrorBoundary/RouteErrorBoundary';
 import NotFound from './components/ErrorBoundary/NotFound';
 import RouteShell from './components/RouteShell/RouteShell';
+import { AuthRoute } from './components/Auth';
 import { WEB_APPLICATION_JSON_LD, ORGANIZATION_JSON_LD } from './lib/seo';
 
 const router = createBrowserRouter([
@@ -56,6 +57,36 @@ const router = createBrowserRouter([
             }}
           >
             <MainContent />
+          </RouteShell>
+        ),
+      },
+      {
+        path: 'login',
+        element: (
+          <RouteShell
+            feature="login"
+            seo={{
+              title: 'Sign in',
+              description: 'Sign in to your Araviel account.',
+              noindex: true,
+            }}
+          >
+            <AuthRoute initialTab="signin" />
+          </RouteShell>
+        ),
+      },
+      {
+        path: 'signup',
+        element: (
+          <RouteShell
+            feature="signup"
+            seo={{
+              title: 'Sign up',
+              description: 'Create a free Araviel account.',
+              noindex: true,
+            }}
+          >
+            <AuthRoute initialTab="signup" />
           </RouteShell>
         ),
       },


### PR DESCRIPTION
## Summary
Refactors authentication flow to use dedicated `/login` and `/signup` routes instead of inline modals scattered throughout the application. This centralizes the auth experience, improves navigation state management, and allows callers to preserve their current location for post-auth redirects.

## Key Changes

- **New `AuthRoute` component** (`src/components/Auth/AuthRoute.jsx`): Full-page auth surface mounted at `/login` and `/signup` that reuses `AuthModal` as the visual layer. Automatically redirects to `location.state.from` after successful authentication, or to `/` if no redirect was specified.

- **Router updates** (`src/router.jsx`): Added `/login` and `/signup` routes with proper SEO metadata and `RouteShell` wrapping.

- **`GuestGate` refactor**: Replaced inline modal state with `useNavigate` calls. Now navigates to `/login` or `/signup` while preserving the current path in `location.state.from` for post-auth redirect.

- **`useGuestGate` hook update**: `requireAuth()` now navigates to `/signup` instead of opening a modal. `GateModal` is now a no-op for backward compatibility.

- **Removed inline auth modals** from:
  - `MainContent.jsx`: Removed `showGuestLimitModal` and `showSessionExpiredModal` state; replaced with navigation calls
  - `ImageGalleryView.jsx`: Removed `showAuthModal` state
  - `PricingView.jsx`: Removed `showAuthModal` state
  - `Sidebar.jsx`: Removed `authModalOpen` state

- **`AuthModal` improvements** (`src/components/Auth/AuthModal.jsx`): 
  - Replaced tab-switching buttons with `<Link>` components that navigate to `/login` or `/signup`
  - Preserves `location.state` when switching between auth tabs
  - Removed `handleTabSwitch` function

- **Navigation state preservation**: All auth triggers now pass `{ state: { from: location.pathname + location.search } }` to preserve the user's original destination.

- **Test updates** (`src/config/subscription.test.js`): Updated subscription tier tests to reflect only 3 live tiers (free, lite, pro) instead of 5.

## Implementation Details

- Auth routes use `useLocation().state?.from` to determine post-auth redirect destination, defaulting to `/` if not provided
- `AuthModal` is reused as the visual component for both dedicated routes and any remaining inline use cases
- All guest limit checks and session expiration handlers now use `navigate()` instead of state-based modal control
- The `GateModal` export from `useGuestGate` is retained as a no-op for backward compatibility during migration

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv