### PR TITLE
Onboarding flow: dedicated auth routes + age gate

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -1,10 +1,9 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   signInWithGoogle,
   signInWithEmail,
-  signUpWithEmail,
   resetPassword,
   selectAuthLoading,
   selectAuthError,
@@ -92,6 +91,7 @@ const EyeIcon = ({ open }) => (
 export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
   const dispatch = useDispatch();
   const location = useLocation();
+  const navigate = useNavigate();
   const isLoading = useSelector(selectAuthLoading);
   const authError = useSelector(selectAuthError);
 
@@ -183,16 +183,19 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
       return;
     }
 
-    const result = await dispatch(
-      signUpWithEmail({
-        email: email.trim(),
-        password,
-        displayName: displayName.trim() || undefined,
-      })
-    );
-    if (result.meta.requestStatus === 'fulfilled') {
-      setSuccessMessage('Account created. Check your email to confirm.');
-    }
+    // Defer the actual Supabase signup until after age verification so
+    // under-13 users never have an account created. Hand the credentials
+    // to /signup/verify-age via location.state — they live in memory only.
+    navigate('/signup/verify-age', {
+      state: {
+        pendingSignup: {
+          email: email.trim(),
+          password,
+          displayName: displayName.trim() || undefined,
+        },
+        from: location.state?.from,
+      },
+    });
   };
 
   const handleForgotPassword = () => {

--- a/src/components/Auth/VerifyAgeView.jsx
+++ b/src/components/Auth/VerifyAgeView.jsx
@@ -1,0 +1,255 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  signUpWithEmail,
+  selectAuthLoading,
+  selectAuthError,
+  setAuthError,
+} from '../../store/slices/authSlice';
+import authStyles from './AuthModal.module.css';
+import styles from './VerifyAgeView.module.css';
+
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+const MIN_AGE = 13;
+const ITEM_HEIGHT = 36;
+
+function daysInMonth(monthIndex, year) {
+  return new Date(year, monthIndex + 1, 0).getDate();
+}
+
+function calculateAge(year, monthIndex, day) {
+  const today = new Date();
+  let age = today.getFullYear() - year;
+  const monthDelta = today.getMonth() - monthIndex;
+  if (monthDelta < 0 || (monthDelta === 0 && today.getDate() < day)) age -= 1;
+  return age;
+}
+
+const ArrowLeftIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="19" y1="12" x2="5" y2="12" />
+    <polyline points="12 19 5 12 12 5" />
+  </svg>
+);
+
+/**
+ * Vertical scroll-snap wheel picker. Renders a column of items where the
+ * one in the middle band is the selection. Padding above and below allows
+ * the first and last items to centre.
+ */
+function WheelPicker({ items, value, onChange, label, getLabel = (i) => String(i) }) {
+  const containerRef = useRef(null);
+  const programmaticRef = useRef(false);
+  const scrollTimeoutRef = useRef(null);
+
+  const valueIndex = items.indexOf(value);
+
+  // Sync external value changes back into scroll position.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || valueIndex < 0) return;
+    const target = valueIndex * ITEM_HEIGHT;
+    if (Math.abs(el.scrollTop - target) > 1) {
+      programmaticRef.current = true;
+      el.scrollTop = target;
+      // Release the programmatic guard after the smooth scroll settles.
+      window.setTimeout(() => {
+        programmaticRef.current = false;
+      }, 200);
+    }
+  }, [valueIndex]);
+
+  const handleScroll = useCallback(
+    (event) => {
+      if (programmaticRef.current) return;
+      const { scrollTop } = event.target;
+      window.clearTimeout(scrollTimeoutRef.current);
+      scrollTimeoutRef.current = window.setTimeout(() => {
+        const idx = Math.round(scrollTop / ITEM_HEIGHT);
+        const clamped = Math.max(0, Math.min(items.length - 1, idx));
+        if (items[clamped] !== value) onChange(items[clamped]);
+      }, 80);
+    },
+    [items, value, onChange]
+  );
+
+  return (
+    <div className={styles.wheel} role="listbox" aria-label={label}>
+      <div className={styles.wheelHighlight} aria-hidden="true" />
+      <div ref={containerRef} className={styles.wheelScroll} onScroll={handleScroll}>
+        <div className={styles.wheelPad} aria-hidden="true" />
+        {items.map((item, i) => (
+          <div
+            key={item}
+            role="option"
+            aria-selected={i === valueIndex}
+            className={`${styles.wheelItem} ${i === valueIndex ? styles.wheelItemSelected : ''}`}
+          >
+            {getLabel(item)}
+          </div>
+        ))}
+        <div className={styles.wheelPad} aria-hidden="true" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * VerifyAgeView — Mounted at /signup/verify-age. Collects the user's
+ * date of birth and only completes signup when they are at least
+ * MIN_AGE years old. The Supabase signUp call is intentionally deferred
+ * to this step so under-age users never have an account created.
+ */
+export default function VerifyAgeView() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const dispatch = useDispatch();
+  const isLoading = useSelector(selectAuthLoading);
+  const authError = useSelector(selectAuthError);
+
+  const pendingSignup = location.state?.pendingSignup;
+
+  // No credentials in transit means the user landed here directly (refresh,
+  // shared link, history). Bounce them back to /signup to start over.
+  useEffect(() => {
+    if (!pendingSignup) {
+      navigate('/signup', { replace: true });
+    }
+  }, [pendingSignup, navigate]);
+
+  const today = useMemo(() => new Date(), []);
+  const [year, setYear] = useState(today.getFullYear() - 18);
+  const [monthIndex, setMonthIndex] = useState(today.getMonth());
+  const [day, setDay] = useState(today.getDate());
+  const [error, setError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  const yearOptions = useMemo(
+    () => Array.from({ length: 100 }, (_, i) => today.getFullYear() - i),
+    [today]
+  );
+  const monthOptions = useMemo(() => MONTHS.map((_, i) => i), []);
+  const dayOptions = useMemo(
+    () => Array.from({ length: daysInMonth(monthIndex, year) }, (_, i) => i + 1),
+    [monthIndex, year]
+  );
+
+  // Clamp day when the chosen month/year has fewer days (e.g. Feb 31 → 28/29).
+  useEffect(() => {
+    const max = daysInMonth(monthIndex, year);
+    if (day > max) setDay(max);
+  }, [monthIndex, year, day]);
+
+  const handleBack = () => {
+    navigate('/signup', { state: { from: location.state?.from } });
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    setSuccessMessage('');
+    dispatch(setAuthError(null));
+
+    const age = calculateAge(year, monthIndex, day);
+    if (age < MIN_AGE) {
+      setError(`Sorry, you must be at least ${MIN_AGE} years old to use Araviel.`);
+      return;
+    }
+
+    const birthDate = `${year}-${String(monthIndex + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+    const result = await dispatch(
+      signUpWithEmail({
+        email: pendingSignup.email,
+        password: pendingSignup.password,
+        displayName: pendingSignup.displayName,
+        birthDate,
+      })
+    );
+
+    if (result.meta.requestStatus === 'fulfilled') {
+      setSuccessMessage('Account created. Check your email to confirm.');
+    }
+  };
+
+  if (!pendingSignup) return null;
+
+  const errorMessage = error || authError;
+
+  return (
+    <div className={styles.container}>
+      <button type="button" className={authStyles.backBtn} onClick={handleBack}>
+        <ArrowLeftIcon />
+        <span>Back</span>
+      </button>
+
+      <div className={styles.panel}>
+        <h1 className={styles.heading}>Verify your age</h1>
+        <p className={styles.subtitle}>
+          This information will not be made public and will only be used as described in our{' '}
+          <a
+            href="/legal/privacy"
+            className={styles.privacyLink}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            privacy policy
+          </a>
+          .
+        </p>
+
+        <form className={styles.form} onSubmit={handleSubmit} noValidate>
+          <p className={styles.dobLabel}>Choose your date of birth</p>
+
+          <div className={styles.wheels}>
+            <WheelPicker
+              label="Month"
+              items={monthOptions}
+              value={monthIndex}
+              onChange={setMonthIndex}
+              getLabel={(i) => MONTHS[i]}
+            />
+            <WheelPicker label="Day" items={dayOptions} value={day} onChange={setDay} />
+            <WheelPicker label="Year" items={yearOptions} value={year} onChange={setYear} />
+          </div>
+
+          {errorMessage && <div className={authStyles.error}>{errorMessage}</div>}
+          {successMessage && <div className={authStyles.success}>{successMessage}</div>}
+
+          <button
+            className={authStyles.submitBtn}
+            type="submit"
+            disabled={isLoading || Boolean(successMessage)}
+          >
+            {isLoading ? <span className={authStyles.spinner} aria-hidden="true" /> : 'Continue'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Auth/VerifyAgeView.module.css
+++ b/src/components/Auth/VerifyAgeView.module.css
@@ -1,0 +1,141 @@
+/* VerifyAgeView — full-page age-verification step that the email signup
+   flow is routed through after the credentials form. Visual language
+   mirrors AuthModal so the two screens read as a single onboarding
+   surface. */
+
+.container {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px calc(32px + var(--safe-area-bottom));
+  background-color: var(--bg-primary);
+}
+
+.panel {
+  width: 100%;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  text-align: left;
+  animation: panelIn 0.3s cubic-bezier(0.2, 0, 0, 1);
+}
+
+@keyframes panelIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.subtitle {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  margin: 0 0 24px;
+}
+
+.privacyLink {
+  color: var(--text-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.privacyLink:hover {
+  opacity: 0.85;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dobLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 4px 0 0;
+}
+
+.wheels {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+/* Wheel picker — three columns side by side. The middle band of the
+   visible viewport is the selection; rows above and below fade so the
+   focus stays on the chosen value. */
+.wheel {
+  position: relative;
+  flex: 1;
+  height: 180px; /* 5 rows × 36px */
+  overflow: hidden;
+  border-radius: 12px;
+}
+
+.wheelScroll {
+  height: 100%;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  position: relative;
+  z-index: 1;
+}
+
+.wheelScroll::-webkit-scrollbar {
+  display: none;
+}
+
+.wheelPad {
+  height: 72px; /* 2 × 36px so the first/last items can centre */
+}
+
+.wheelItem {
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  scroll-snap-align: center;
+  font-size: 15px;
+  color: var(--text-muted);
+  opacity: 0.4;
+  transition: opacity 0.15s ease, color 0.15s ease, font-weight 0.15s ease;
+  user-select: none;
+}
+
+.wheelItemSelected {
+  color: var(--text-primary);
+  font-weight: 600;
+  opacity: 1;
+}
+
+.wheelHighlight {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(50% - 18px);
+  height: 36px;
+  border-radius: 10px;
+  background-color: var(--bg-button);
+  pointer-events: none;
+  z-index: 0;
+}

--- a/src/components/Auth/index.js
+++ b/src/components/Auth/index.js
@@ -1,2 +1,3 @@
 export { default as AuthModal } from './AuthModal';
 export { default as AuthRoute } from './AuthRoute';
+export { default as VerifyAgeView } from './VerifyAgeView';

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -2839,14 +2839,32 @@ export default function MainContent() {
               <NewChatIcon />
             </button>
           ) : (
-            <button
-              type="button"
-              className={styles.signUpNavBtn}
-              onClick={() => navigate('/signup', { state: { from: location.pathname + location.search } })}
-              aria-label="Sign up or sign in"
-            >
-              <span className={styles.signUpNavBtnLabel}>Sign up</span>
-            </button>
+            <>
+              <button
+                type="button"
+                className={styles.signInNavBtn}
+                onClick={() =>
+                  navigate('/login', {
+                    state: { from: location.pathname + location.search },
+                  })
+                }
+                aria-label="Sign in"
+              >
+                <span className={styles.signInNavBtnLabel}>Sign in</span>
+              </button>
+              <button
+                type="button"
+                className={styles.signUpNavBtn}
+                onClick={() =>
+                  navigate('/signup', {
+                    state: { from: location.pathname + location.search },
+                  })
+                }
+                aria-label="Sign up"
+              >
+                <span className={styles.signUpNavBtnLabel}>Sign up</span>
+              </button>
+            </>
           )}
           {currentChatId && (
             <div className={styles.chatMenuWrapper} ref={chatMenuRef}>

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -3058,15 +3058,9 @@
   }
 }
 
-/* Short viewports: re-flow the strip into normal document flow beneath the
-   welcome stack so it never overlaps the action buttons. */
-@media (max-height: 720px) {
-  .ambientProviders {
-    position: static;
-    margin-top: 28px;
-    padding: 0;
-  }
-}
+/* Short viewports: keep the provider strip pinned to the footer. The
+   absolute positioning (defined above) is intentional at every height
+   so the row never floats up under the chat input on shorter screens. */
 
 @media (prefers-reduced-motion: reduce) {
   .ambientProviders {

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -2904,12 +2904,15 @@
   font-weight: 500;
 }
 
-/* Ambient provider strip — a single horizontal centred row anchored near
-   the bottom of the main area. Decorative; communicates the range of
-   providers Araveil orchestrates without competing with the welcome stack.
-   The wrapper is non-interactive; only the badges opt back in for hover. */
+/* Ambient provider strip — a single horizontal centred row pinned to
+   the viewport footer. Decorative; communicates the range of providers
+   Araveil orchestrates without competing with the welcome stack. The
+   wrapper is non-interactive; only the badges opt back in for hover.
+   `position: fixed` (instead of absolute-to-.main) keeps the row at
+   the bottom of the visible viewport regardless of how tall the main
+   column grows or how its flex layout centres its contents. */
 .ambientProviders {
-  position: absolute;
+  position: fixed;
   left: 0;
   right: 0;
   bottom: calc(28px + var(--safe-area-bottom));

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -636,6 +636,46 @@
   line-height: 1;
 }
 
+/* Guest sign-in CTA — secondary, ghost style sitting to the left of
+   .signUpNavBtn so the pair reads "Sign in   Sign up" with the
+   primary action emphasised. */
+.signInNavBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 999px;
+  background-color: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, transform 0.12s ease,
+    border-color 0.15s ease;
+}
+
+.signInNavBtn:hover {
+  background-color: var(--bg-button-hover);
+  color: var(--text-primary);
+  border-color: var(--border-input);
+}
+
+.signInNavBtn:active {
+  transform: scale(0.97);
+}
+
+.signInNavBtn:focus-visible {
+  outline: 2px solid var(--text-muted);
+  outline-offset: 2px;
+}
+
+.signInNavBtnLabel {
+  line-height: 1;
+}
+
 /* Chat menu (3-dot) */
 .chatMenuWrapper {
   position: relative;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -14,7 +14,7 @@ import SharedConversationView from './components/SharedConversationView';
 import RouteErrorBoundary from './components/ErrorBoundary/RouteErrorBoundary';
 import NotFound from './components/ErrorBoundary/NotFound';
 import RouteShell from './components/RouteShell/RouteShell';
-import { AuthRoute } from './components/Auth';
+import { AuthRoute, VerifyAgeView } from './components/Auth';
 import { WEB_APPLICATION_JSON_LD, ORGANIZATION_JSON_LD } from './lib/seo';
 
 const router = createBrowserRouter([
@@ -87,6 +87,22 @@ const router = createBrowserRouter([
             }}
           >
             <AuthRoute initialTab="signup" />
+          </RouteShell>
+        ),
+      },
+      {
+        path: 'signup/verify-age',
+        element: (
+          <RouteShell
+            feature="signup-verify-age"
+            seo={{
+              title: 'Verify your age',
+              description:
+                'Confirm your date of birth to complete signing up for Araviel. You must be 13 or older.',
+              noindex: true,
+            }}
+          >
+            <VerifyAgeView />
           </RouteShell>
         ),
       },

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -16,6 +16,7 @@ function mapUser(supabaseUser) {
     avatarUrl: supabaseUser.user_metadata?.avatar_url || null,
     fullName:
       supabaseUser.user_metadata?.full_name || supabaseUser.user_metadata?.display_name || null,
+    birthDate: supabaseUser.user_metadata?.birth_date || null,
   };
 }
 
@@ -123,15 +124,20 @@ export const signInWithEmail = createAsyncThunk(
   }
 );
 
-/** Create a new account with email, password, and optional display name. */
+/** Create a new account with email, password, optional display name, and
+ *  date of birth (ISO yyyy-mm-dd). The DOB is stored in user_metadata so it
+ *  travels with the auth user record and is available client-side without a
+ *  separate profile fetch. */
 export const signUpWithEmail = createAsyncThunk(
   'auth/signUpWithEmail',
-  async ({ email, password, displayName }, { rejectWithValue }) => {
+  async ({ email, password, displayName, birthDate }, { rejectWithValue }) => {
     try {
+      const metadata = { display_name: displayName };
+      if (birthDate) metadata.birth_date = birthDate;
       const { data, error } = await supabase.auth.signUp({
         email,
         password,
-        options: { data: { display_name: displayName } },
+        options: { data: metadata },
       });
       if (error) return rejectWithValue(error.message);
       return {


### PR DESCRIPTION
## Summary
- Add dedicated `/login` and `/signup` routes (reusing the existing `AuthModal` UI)
- Rewire every in-app callsite (Sidebar, MainContent, ImageGalleryView, PricingView, GuestGate, AuthModal footer) to navigate to those routes instead of opening the modal in-place; each carries `location.state.from` so AuthRoute can return the user there
- Add a "Sign in" ghost button beside the existing top-right "Sign up" CTA
- Pin the landing provider strip to the viewport footer (`position: fixed`) so it stops floating up on shorter viewports
- Add a `/signup/verify-age` step gating email signup on age 13+; under-13 are blocked client-side before any Supabase user is created. DOB is stored on `user_metadata.birth_date`
- Align stale `subscription.test.js` assertions with the live 3-tier set

## Test plan
- [ ] `/login` and `/signup` render the auth surface; back / outside-click returns to `/`
- [ ] Top-right shows **Sign in** + **Sign up** for guests; routes preserve `state.from`
- [ ] Sidebar "Settings" (guest) and "Sign in / Sign up" go to `/login`
- [ ] Guest prompt-limit hit on home navigates to `/signup`; session expiry navigates to `/login`
- [ ] Provider strip stays pinned to footer at narrow heights
- [ ] Email signup form → routes to `/signup/verify-age`; selecting <13 shows error and does NOT create a Supabase user; selecting ≥13 completes signup with `user_metadata.birth_date` set
- [ ] `npm test` passes (subscription.test.js assertions corrected)
- [ ] `npm run build` passes

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_