### PR TITLE
Route signup to /signup/check-email + handle email rate limit

### DIFF
--- a/src/components/Auth/CheckEmailView.jsx
+++ b/src/components/Auth/CheckEmailView.jsx
@@ -1,0 +1,167 @@
+import { useEffect, useState, useRef, useCallback } from 'react';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  resendSignupEmail,
+  selectAuthLoading,
+  selectAuthError,
+  setAuthError,
+} from '../../store/slices/authSlice';
+import authStyles from './AuthModal.module.css';
+import styles from './CheckEmailView.module.css';
+
+const RESEND_COOLDOWN_SECONDS = 30;
+
+const ArrowLeftIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="19" y1="12" x2="5" y2="12" />
+    <polyline points="12 19 5 12 12 5" />
+  </svg>
+);
+
+const MailIcon = () => (
+  <svg
+    width="32"
+    height="32"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="3" y="5" width="18" height="14" rx="2" />
+    <polyline points="3 7 12 13 21 7" />
+  </svg>
+);
+
+/**
+ * CheckEmailView — Mounted at /signup/check-email after a successful
+ * signUp call that returned no session (i.e. Supabase has email
+ * confirmation enabled). Tells the user to click the link in their
+ * inbox and provides a rate-limited resend so they can recover from
+ * a delayed or lost email without burning through Supabase's
+ * project-wide email quota.
+ */
+export default function CheckEmailView() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const dispatch = useDispatch();
+  const isLoading = useSelector(selectAuthLoading);
+  const authError = useSelector(selectAuthError);
+
+  const email = location.state?.email;
+
+  // No email in transit means the user landed here directly. Send them
+  // back to the start of signup so the flow stays linear.
+  useEffect(() => {
+    if (!email) {
+      navigate('/signup', { replace: true });
+    }
+  }, [email, navigate]);
+
+  const [cooldown, setCooldown] = useState(RESEND_COOLDOWN_SECONDS);
+  const [resentMessage, setResentMessage] = useState('');
+  const [localError, setLocalError] = useState('');
+  const tickRef = useRef(null);
+
+  // Run the cooldown countdown. Restarted whenever the user resends.
+  useEffect(() => {
+    if (cooldown <= 0) return undefined;
+    tickRef.current = window.setInterval(() => {
+      setCooldown((c) => (c <= 1 ? 0 : c - 1));
+    }, 1000);
+    return () => window.clearInterval(tickRef.current);
+  }, [cooldown]);
+
+  const handleResend = useCallback(async () => {
+    if (!email || cooldown > 0 || isLoading) return;
+    setLocalError('');
+    setResentMessage('');
+    dispatch(setAuthError(null));
+
+    const result = await dispatch(resendSignupEmail({ email }));
+
+    if (result.meta.requestStatus === 'fulfilled') {
+      setResentMessage('Confirmation email sent. Check your inbox again.');
+      setCooldown(RESEND_COOLDOWN_SECONDS);
+      return;
+    }
+
+    const raw = (result.payload || '').toString().toLowerCase();
+    if (raw.includes('rate limit') || raw.includes('over_email_send_rate_limit')) {
+      setLocalError(
+        "We've hit the email rate limit. Please wait a few minutes before trying again."
+      );
+      // Bump the cooldown so the button stays disabled a little longer.
+      setCooldown(60);
+    }
+  }, [email, cooldown, isLoading, dispatch]);
+
+  if (!email) return null;
+
+  const errorMessage = localError || authError;
+  const canResend = cooldown <= 0 && !isLoading;
+
+  return (
+    <div className={styles.container}>
+      <button
+        type="button"
+        className={authStyles.backBtn}
+        onClick={() => navigate('/login', { replace: true })}
+      >
+        <ArrowLeftIcon />
+        <span>Back to sign in</span>
+      </button>
+
+      <div className={styles.panel}>
+        <div className={styles.iconWrap} aria-hidden="true">
+          <MailIcon />
+        </div>
+        <h1 className={styles.heading}>Check your email</h1>
+        <p className={styles.subtitle}>
+          We sent a confirmation link to <span className={styles.email}>{email}</span>. Click the
+          link to finish setting up your account.
+        </p>
+
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={authStyles.submitBtn}
+            onClick={handleResend}
+            disabled={!canResend}
+          >
+            {isLoading ? (
+              <span className={authStyles.spinner} aria-hidden="true" />
+            ) : canResend ? (
+              'Resend confirmation email'
+            ) : (
+              `Resend in ${cooldown}s`
+            )}
+          </button>
+
+          {errorMessage && <div className={authStyles.error}>{errorMessage}</div>}
+          {resentMessage && <div className={authStyles.success}>{resentMessage}</div>}
+        </div>
+
+        <p className={styles.footer}>
+          Already confirmed?{' '}
+          <Link to="/login" className={styles.footerLink}>
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Auth/CheckEmailView.module.css
+++ b/src/components/Auth/CheckEmailView.module.css
@@ -1,0 +1,94 @@
+/* CheckEmailView — full-page confirmation surface shown after a
+   successful email signup that requires the user to click a link
+   in their inbox. Visual language mirrors VerifyAgeView and
+   AuthModal so the three onboarding screens read as one flow. */
+
+.container {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px calc(32px + var(--safe-area-bottom));
+  background-color: var(--bg-primary);
+}
+
+.panel {
+  width: 100%;
+  max-width: 380px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  text-align: center;
+  animation: panelIn 0.3s cubic-bezier(0.2, 0, 0, 1);
+}
+
+@keyframes panelIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.iconWrap {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background-color: var(--bg-icon-button);
+  color: var(--text-icon-button);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 18px;
+}
+
+.heading {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.subtitle {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  margin: 0 0 24px;
+}
+
+.email {
+  color: var(--text-primary);
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.footer {
+  margin: 18px 0 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.footerLink {
+  color: var(--text-primary);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.footerLink:hover {
+  opacity: 0.85;
+}

--- a/src/components/Auth/VerifyAgeView.jsx
+++ b/src/components/Auth/VerifyAgeView.jsx
@@ -147,7 +147,6 @@ export default function VerifyAgeView() {
   const [monthIndex, setMonthIndex] = useState(today.getMonth());
   const [day, setDay] = useState(today.getDate());
   const [error, setError] = useState('');
-  const [successMessage, setSuccessMessage] = useState('');
 
   const yearOptions = useMemo(
     () => Array.from({ length: 100 }, (_, i) => today.getFullYear() - i),
@@ -172,7 +171,6 @@ export default function VerifyAgeView() {
   const handleSubmit = async (event) => {
     event.preventDefault();
     setError('');
-    setSuccessMessage('');
     dispatch(setAuthError(null));
 
     const age = calculateAge(year, monthIndex, day);
@@ -193,7 +191,32 @@ export default function VerifyAgeView() {
     );
 
     if (result.meta.requestStatus === 'fulfilled') {
-      setSuccessMessage('Account created. Check your email to confirm.');
+      // Supabase returned a session → email confirmation is disabled in
+      // this project, the user is already authenticated. Drop them
+      // straight into the app.
+      if (result.payload?.session) {
+        navigate(location.state?.from || '/', { replace: true });
+        return;
+      }
+      // No session → email confirmation is on. Hand off to a dedicated
+      // "check your email" screen so the user can't accidentally retry
+      // and burn through Supabase's email rate limit.
+      navigate('/signup/check-email', {
+        replace: true,
+        state: { email: pendingSignup.email },
+      });
+      return;
+    }
+
+    // Friendly retry message for the project-wide email rate limit. The
+    // signUp call did NOT create a user when this fires, so it's safe to
+    // try again with the same email later.
+    const raw = (result.payload || '').toString().toLowerCase();
+    if (raw.includes('rate limit') || raw.includes('over_email_send_rate_limit')) {
+      setError(
+        "We couldn't send the confirmation email right now — try again in a few minutes. " +
+          "Your details haven't been submitted yet."
+      );
     }
   };
 
@@ -239,13 +262,8 @@ export default function VerifyAgeView() {
           </div>
 
           {errorMessage && <div className={authStyles.error}>{errorMessage}</div>}
-          {successMessage && <div className={authStyles.success}>{successMessage}</div>}
 
-          <button
-            className={authStyles.submitBtn}
-            type="submit"
-            disabled={isLoading || Boolean(successMessage)}
-          >
+          <button className={authStyles.submitBtn} type="submit" disabled={isLoading}>
             {isLoading ? <span className={authStyles.spinner} aria-hidden="true" /> : 'Continue'}
           </button>
         </form>

--- a/src/components/Auth/index.js
+++ b/src/components/Auth/index.js
@@ -1,3 +1,4 @@
 export { default as AuthModal } from './AuthModal';
 export { default as AuthRoute } from './AuthRoute';
 export { default as VerifyAgeView } from './VerifyAgeView';
+export { default as CheckEmailView } from './CheckEmailView';

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -14,7 +14,7 @@ import SharedConversationView from './components/SharedConversationView';
 import RouteErrorBoundary from './components/ErrorBoundary/RouteErrorBoundary';
 import NotFound from './components/ErrorBoundary/NotFound';
 import RouteShell from './components/RouteShell/RouteShell';
-import { AuthRoute, VerifyAgeView } from './components/Auth';
+import { AuthRoute, VerifyAgeView, CheckEmailView } from './components/Auth';
 import { WEB_APPLICATION_JSON_LD, ORGANIZATION_JSON_LD } from './lib/seo';
 
 const router = createBrowserRouter([
@@ -103,6 +103,22 @@ const router = createBrowserRouter([
             }}
           >
             <VerifyAgeView />
+          </RouteShell>
+        ),
+      },
+      {
+        path: 'signup/check-email',
+        element: (
+          <RouteShell
+            feature="signup-check-email"
+            seo={{
+              title: 'Check your email',
+              description:
+                'We sent a confirmation link to your email — click it to finish setting up your Araviel account.',
+              noindex: true,
+            }}
+          >
+            <CheckEmailView />
           </RouteShell>
         ),
       },

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -137,13 +137,40 @@ export const signUpWithEmail = createAsyncThunk(
       const { data, error } = await supabase.auth.signUp({
         email,
         password,
-        options: { data: metadata },
+        options: {
+          data: metadata,
+          // Send the user back to the app root after they click the
+          // confirmation link in the verification email.
+          emailRedirectTo: typeof window !== 'undefined' ? window.location.origin : undefined,
+        },
       });
       if (error) return rejectWithValue(error.message);
       return {
         user: mapUser(data.user),
         session: mapSession(data.session),
       };
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+/** Resend the signup confirmation email for an unconfirmed account. Used by
+ *  the /signup/check-email screen so users can retry without re-entering
+ *  their credentials. */
+export const resendSignupEmail = createAsyncThunk(
+  'auth/resendSignupEmail',
+  async ({ email }, { rejectWithValue }) => {
+    try {
+      const { error } = await supabase.auth.resend({
+        type: 'signup',
+        email,
+        options: {
+          emailRedirectTo: typeof window !== 'undefined' ? window.location.origin : undefined,
+        },
+      });
+      if (error) return rejectWithValue(error.message);
+      return null;
     } catch (err) {
       return rejectWithValue(err.message);
     }
@@ -277,11 +304,17 @@ const authSlice = createSlice({
         state.error = null;
       })
       .addCase(signUpWithEmail.fulfilled, (state, action) => {
-        state.user = action.payload.user;
-        state.session = action.payload.session;
+        // Only flip the user into the authenticated state if Supabase
+        // actually returned a session. When email confirmation is required
+        // signUp returns a user record but no session — the user must
+        // verify the email before they have an authenticated session.
+        if (action.payload.session) {
+          state.user = action.payload.user;
+          state.session = action.payload.session;
+          resetGuestPromptCount();
+        }
         state.isLoading = false;
         state.error = null;
-        resetGuestPromptCount();
       })
       .addCase(signUpWithEmail.rejected, (state, action) => {
         state.isLoading = false;


### PR DESCRIPTION
## Summary
- After a successful `signUp`, navigate based on whether Supabase returned a session: straight to `/` if it did (project has email confirmation off), or to a new `/signup/check-email` screen if it didn't
- New `CheckEmailView` confirmation page with a 30s-cooldown resend button so users can recover from a missing email without re-doing signup
- Detect Supabase's "email rate limit exceeded" error on both `signUp` and `resend`, and show a clearer message ("try again in a few minutes — your details haven't been submitted yet")
- Gate the `signUpWithEmail` fulfilled reducer on session presence so we don't mark a user as authenticated when they actually still need to click their confirmation link
- Pass `emailRedirectTo: window.location.origin` on signup and resend so the user lands on the app root after clicking the confirmation link
- Add a `resendSignupEmail` thunk for the resend flow

## Test plan
- [ ] Email-confirmation OFF in Supabase: signup → verify-age → lands on `/` authenticated
- [ ] Email-confirmation ON: signup → verify-age → `/signup/check-email` with the right email; resend button is disabled with countdown for 30s
- [ ] Hit the email rate limit: VerifyAgeView shows the friendly retry message, no DB row created; CheckEmailView resend button shows the rate-limit message and bumps cooldown to 60s
- [ ] Direct visit to `/signup/check-email` without state → redirects to `/signup`
- [ ] Click the confirmation link in the email → returns to app authenticated
- [ ] `npm run build` passes

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_