### PR TITLE
Drop tier badge from collapsed sidebar footer

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -905,17 +905,6 @@ export default function Sidebar() {
         )}
 
         <div className={styles.footer}>
-          {!showFullContent && isAuthenticated && (
-            <span
-              className={`${styles.tierBadge} ${
-                userTier && userTier !== 'free' ? styles.tierBadgePaid : ''
-              }`}
-              title={`${userTier.charAt(0).toUpperCase() + userTier.slice(1)} plan`}
-              aria-label={`${userTier} plan`}
-            >
-              {userTier.slice(0, 3)}
-            </span>
-          )}
           <div className={styles.userCard} ref={userMenuRef}>
             <button
               className={`${styles.userSection} ${userMenuOpen ? styles.userSectionOpen : ''}`}

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -840,29 +840,6 @@
   gap: 10px;
 }
 
-/* Tier badge (collapsed rail only) */
-.tierBadge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 9.5px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  padding: 4px 6px;
-  border-radius: 6px;
-  color: var(--text-muted);
-  background: transparent;
-  border: 1px solid var(--border-color);
-  text-transform: uppercase;
-  line-height: 1;
-}
-
-.tierBadgePaid {
-  color: var(--text-primary);
-  background-color: var(--bg-active);
-  border-color: var(--border-input);
-}
-
 /* User card — visually distinct container wrapping the userSection button */
 .userCard {
   position: relative;


### PR DESCRIPTION
## Summary
- Remove the truncated tier badge from the collapsed sidebar footer (it was rendering as `FRE` because there isn't room for the full label on the 48px rail)
- Tier still shown in the expanded user-info panel and the user-menu dropdown, so no information is lost

## Test plan
- [ ] Collapsed sidebar: no badge between the rail and the avatar
- [ ] Expanded sidebar: plan name still visible under the user name
- [ ] Open the user dropdown collapsed: plan name still visible

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_