### PR TITLE
Google sign-up: pull DOB from Google + 13+ age gate

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,14 @@
 import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Outlet, useNavigate } from 'react-router-dom';
+import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { selectEffectiveTheme } from './store/slices/themeSlice';
-import { selectAuthLoading, selectAuthUser } from './store/slices/authSlice';
+import {
+  selectAuthLoading,
+  selectAuthUser,
+  selectIsAuthenticated,
+  signOut,
+} from './store/slices/authSlice';
+import { isAgeAllowed, calculateAge, MIN_AGE } from './utils/age';
 import { fetchSubscriptionThunk, setImageCredits } from './store/slices/subscriptionSlice';
 import { setCreditBalance } from './store/slices/chatSlice';
 import { subscribeToCreditPackChanges, fetchCreditBalance } from './services/credits';
@@ -18,6 +24,7 @@ import './App.css';
 export default function App() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
 
   // Initialize auth listener — subscribes to Supabase auth state changes
   useAuthListener();
@@ -29,7 +36,48 @@ export default function App() {
   const effectiveTheme = useSelector(selectEffectiveTheme);
   const authLoading = useSelector(selectAuthLoading);
   const user = useSelector(selectAuthUser);
+  const isAuthenticated = useSelector(selectIsAuthenticated);
   const unsubPackRef = useRef(null);
+
+  // Age gate: enforce the 13+ requirement on every authenticated session.
+  //   - missing birth_date → route to /signup/verify-age for manual entry
+  //   - birth_date present but under MIN_AGE → sign the user out and send
+  //     them back to /login with a rejection reason
+  // Skipped while inside the signup funnel (so the user can complete it)
+  // and while the auth slice is still resolving the initial session.
+  useEffect(() => {
+    if (authLoading) return;
+    if (!isAuthenticated || !user) return;
+    if (location.pathname.startsWith('/signup')) return;
+
+    if (!user.birthDate) {
+      navigate('/signup/verify-age', {
+        replace: true,
+        state: { from: location.pathname + location.search },
+      });
+      return;
+    }
+    if (!isAgeAllowed(user.birthDate)) {
+      const age = calculateAge(user.birthDate);
+      dispatch(signOut());
+      navigate('/login', {
+        replace: true,
+        state: {
+          ageRejection: `You must be at least ${MIN_AGE} years old to use Araviel${
+            age != null ? ` (you entered ${age}).` : '.'
+          }`,
+        },
+      });
+    }
+  }, [
+    authLoading,
+    isAuthenticated,
+    user,
+    location.pathname,
+    location.search,
+    navigate,
+    dispatch,
+  ]);
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', effectiveTheme);

--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -131,6 +131,13 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
     setActiveTab(initialTab);
   }, [isOpen, initialTab]);
 
+  // Surface any age-rejection message handed in via navigate().
+  useEffect(() => {
+    if (!isOpen) return;
+    const rejection = location.state?.ageRejection;
+    if (rejection) setLocalError(rejection);
+  }, [isOpen, location.state]);
+
   useEffect(() => {
     if (!isOpen) return undefined;
     const onKey = (event) => {

--- a/src/components/Auth/VerifyAgeView.jsx
+++ b/src/components/Auth/VerifyAgeView.jsx
@@ -3,8 +3,10 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   signUpWithEmail,
+  updateBirthDate,
   selectAuthLoading,
   selectAuthError,
+  selectIsAuthenticated,
   setAuthError,
 } from '../../store/slices/authSlice';
 import authStyles from './AuthModal.module.css';
@@ -131,16 +133,25 @@ export default function VerifyAgeView() {
   const dispatch = useDispatch();
   const isLoading = useSelector(selectAuthLoading);
   const authError = useSelector(selectAuthError);
+  const isAuthenticated = useSelector(selectIsAuthenticated);
 
   const pendingSignup = location.state?.pendingSignup;
+  // Two operating modes:
+  //   - "signup":  user came from /signup with credentials in transit;
+  //                we'll call signUpWithEmail with the chosen DOB.
+  //   - "update":  user is already authenticated (e.g. signed in via
+  //                Google but has no birth_date in user_metadata); we'll
+  //                call updateBirthDate to attach the chosen DOB.
+  const mode = pendingSignup ? 'signup' : isAuthenticated ? 'update' : null;
 
-  // No credentials in transit means the user landed here directly (refresh,
-  // shared link, history). Bounce them back to /signup to start over.
+  // No credentials and no session means the user landed here directly
+  // (refresh, shared link, history). Bounce them back to /signup so the
+  // flow stays linear.
   useEffect(() => {
-    if (!pendingSignup) {
+    if (!mode) {
       navigate('/signup', { replace: true });
     }
-  }, [pendingSignup, navigate]);
+  }, [mode, navigate]);
 
   const today = useMemo(() => new Date(), []);
   const [year, setYear] = useState(today.getFullYear() - 18);
@@ -165,6 +176,10 @@ export default function VerifyAgeView() {
   }, [monthIndex, year, day]);
 
   const handleBack = () => {
+    if (mode === 'update') {
+      navigate('/', { replace: true });
+      return;
+    }
     navigate('/signup', { state: { from: location.state?.from } });
   };
 
@@ -180,6 +195,17 @@ export default function VerifyAgeView() {
     }
 
     const birthDate = `${year}-${String(monthIndex + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+
+    if (mode === 'update') {
+      // Already-authenticated user (typically Google OAuth where the
+      // People API didn't return a complete DOB). Just persist the
+      // chosen date and drop them into the app.
+      const result = await dispatch(updateBirthDate({ birthDate }));
+      if (result.meta.requestStatus === 'fulfilled') {
+        navigate(location.state?.from || '/', { replace: true });
+      }
+      return;
+    }
 
     const result = await dispatch(
       signUpWithEmail({
@@ -220,7 +246,7 @@ export default function VerifyAgeView() {
     }
   };
 
-  if (!pendingSignup) return null;
+  if (!mode) return null;
 
   const errorMessage = error || authError;
 

--- a/src/hooks/useAuthListener.js
+++ b/src/hooks/useAuthListener.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { supabase } from '../lib/supabase';
-import { initializeAuth, setAuth, clearAuth } from '../store/slices/authSlice';
+import { initializeAuth, setAuth, clearAuth, updateBirthDate } from '../store/slices/authSlice';
 import { resetChatState, setCreditBalance } from '../store/slices/chatSlice';
 import { resetProjectsState } from '../store/slices/projectsSlice';
 import {
@@ -12,6 +12,7 @@ import {
 import { resetGuestPromptCount } from '../utils/guestSession';
 import { fetchCreditBalance } from '../services/credits';
 import { fetchSubscription } from '../services/subscription';
+import { fetchGoogleBirthday } from '../services/googleBirthday';
 import { clearImageCache } from '../services/imageGeneration';
 import { setLoggerUser } from '../lib/logger';
 
@@ -28,6 +29,7 @@ function mapUser(supabaseUser) {
     avatarUrl: supabaseUser.user_metadata?.avatar_url || null,
     fullName:
       supabaseUser.user_metadata?.full_name || supabaseUser.user_metadata?.display_name || null,
+    birthDate: supabaseUser.user_metadata?.birth_date || null,
   };
 }
 
@@ -85,6 +87,27 @@ export default function useAuthListener() {
           // On real (non-anonymous) sign-in, sync tier/credits from backend
           if (event === 'SIGNED_IN' && user && !user.isAnonymous) {
             resetGuestPromptCount();
+
+            // Google sign-in only: try to lift the user's date of birth from
+            // Google's People API so we can skip the manual age step when
+            // the data is already there. The provider_token is only exposed
+            // on this initial SIGNED_IN event after the OAuth redirect — it
+            // isn't refreshed — so we have to capture it here. If the fetch
+            // returns null (no DOB on the Google account, partial date, or
+            // request failed), App.jsx's age gate will route the user to
+            // /signup/verify-age for manual entry.
+            const provider = session?.user?.app_metadata?.provider;
+            const providerToken = session?.provider_token;
+            if (provider === 'google' && providerToken && !user.birthDate) {
+              fetchGoogleBirthday(providerToken)
+                .then((birthDate) => {
+                  if (birthDate) {
+                    dispatch(updateBirthDate({ birthDate }));
+                  }
+                })
+                .catch(() => {});
+            }
+
             fetchCreditBalance()
               .then((data) => {
                 if (data.balance) {

--- a/src/services/googleBirthday.js
+++ b/src/services/googleBirthday.js
@@ -1,0 +1,49 @@
+/**
+ * Fetch the signed-in user's birthday from the Google People API.
+ *
+ * Requires the `https://www.googleapis.com/auth/user.birthday.read`
+ * scope to have been requested during OAuth consent. The token used
+ * here is `session.provider_token` — Supabase only exposes that on
+ * the very first SIGNED_IN event after the Google OAuth redirect, so
+ * the caller must capture it then.
+ *
+ * Returns an ISO `yyyy-mm-dd` string only when Google has the full
+ * date (year + month + day). When the year is missing — Google lets
+ * users enter just month/day — we return null so the caller can fall
+ * back to the manual /signup/verify-age step instead of trying to
+ * compute an age from a partial date.
+ *
+ * @param {string} providerAccessToken Google OAuth access token.
+ * @returns {Promise<string|null>}
+ */
+export async function fetchGoogleBirthday(providerAccessToken) {
+  if (!providerAccessToken) return null;
+  try {
+    const response = await fetch(
+      'https://people.googleapis.com/v1/people/me?personFields=birthdays',
+      {
+        headers: { Authorization: `Bearer ${providerAccessToken}` },
+      }
+    );
+    if (!response.ok) return null;
+    const json = await response.json();
+    const birthdays = Array.isArray(json.birthdays) ? json.birthdays : [];
+    if (birthdays.length === 0) return null;
+
+    // Prefer the entry that comes from the user's own profile over any
+    // birthdays they might have stored in their address book contacts.
+    const entry =
+      birthdays.find((b) => b?.metadata?.source?.type === 'PROFILE') ||
+      birthdays.find((b) => b?.metadata?.primary) ||
+      birthdays[0];
+
+    const date = entry?.date;
+    if (!date) return null;
+    const { year, month, day } = date;
+    if (!year || !month || !day) return null;
+
+    return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  } catch {
+    return null;
+  }
+}

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -74,14 +74,24 @@ export const initializeAuth = createAsyncThunk(
   }
 );
 
-/** Redirect the user to Google OAuth. */
+/** Redirect the user to Google OAuth.
+ *
+ *  We ask for `user.birthday.read` in addition to the standard
+ *  identity scopes so the People API can return the user's date of
+ *  birth on the first sign-in. If they haven't set it on their Google
+ *  account, or only have a partial date, the auth listener falls back
+ *  to the manual /signup/verify-age step. */
 export const signInWithGoogle = createAsyncThunk(
   'auth/signInWithGoogle',
   async (_, { rejectWithValue }) => {
     try {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
-        options: { redirectTo: window.location.origin },
+        options: {
+          redirectTo: window.location.origin,
+          scopes:
+            'openid email profile https://www.googleapis.com/auth/user.birthday.read',
+        },
       });
       if (error) return rejectWithValue(error.message);
       // The browser will redirect — no meaningful return value.
@@ -171,6 +181,25 @@ export const resendSignupEmail = createAsyncThunk(
       });
       if (error) return rejectWithValue(error.message);
       return null;
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+/** Persist a user's date of birth (ISO yyyy-mm-dd) to user_metadata.
+ *  Used by VerifyAgeView's "update mode" for already-authenticated
+ *  users (e.g. Google sign-ins) and by the auth listener when it
+ *  successfully fetches a complete DOB from Google's People API. */
+export const updateBirthDate = createAsyncThunk(
+  'auth/updateBirthDate',
+  async ({ birthDate }, { rejectWithValue }) => {
+    try {
+      const { data, error } = await supabase.auth.updateUser({
+        data: { birth_date: birthDate },
+      });
+      if (error) return rejectWithValue(error.message);
+      return { user: mapUser(data.user) };
     } catch (err) {
       return rejectWithValue(err.message);
     }
@@ -319,6 +348,14 @@ const authSlice = createSlice({
       .addCase(signUpWithEmail.rejected, (state, action) => {
         state.isLoading = false;
         state.error = action.payload || 'Sign-up failed';
+      });
+
+    // updateBirthDate
+    builder
+      .addCase(updateBirthDate.fulfilled, (state, action) => {
+        if (state.user && action.payload?.user) {
+          state.user = action.payload.user;
+        }
       });
 
     // signOut

--- a/src/utils/age.js
+++ b/src/utils/age.js
@@ -1,0 +1,25 @@
+/** Minimum age (in years) required to use the app. */
+export const MIN_AGE = 13;
+
+/**
+ * Compute the user's age in whole years from an ISO yyyy-mm-dd birth
+ * date. Returns null if the input is unparseable.
+ */
+export function calculateAge(birthDate) {
+  if (!birthDate) return null;
+  const dob = new Date(birthDate);
+  if (Number.isNaN(dob.getTime())) return null;
+  const today = new Date();
+  let age = today.getFullYear() - dob.getFullYear();
+  const monthDelta = today.getMonth() - dob.getMonth();
+  if (monthDelta < 0 || (monthDelta === 0 && today.getDate() < dob.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+/** True iff the supplied birth date represents someone at least MIN_AGE old. */
+export function isAgeAllowed(birthDate) {
+  const age = calculateAge(birthDate);
+  return age != null && age >= MIN_AGE;
+}


### PR DESCRIPTION
## Summary
Complete the Google sign-up flow: pull DOB from Google when available, fall back to manual entry when it isn't, and apply a 13+ gate on every authenticated session.

- `signInWithGoogle` requests `user.birthday.read` alongside the standard identity scopes.
- `services/googleBirthday`: new helper that calls Google People API with the OAuth `provider_token` and returns ISO `yyyy-mm-dd` only when **year + month + day** are all set (Google lets users save just month/day, which we treat as missing).
- `useAuthListener`: on the first Google `SIGNED_IN`, fetches the People API and dispatches `updateBirthDate` if a complete date came back. `provider_token` is only exposed on that initial event, so we capture it there.
- `App.jsx`: age-gate effect that runs on every authenticated session outside the `/signup` funnel:
  - missing `birth_date` → `navigate('/signup/verify-age', { state: { from } })`
  - present but `< 13` → sign the user out and bounce to `/login` with an `ageRejection` message
- `AuthModal`: surfaces `location.state.ageRejection` as an inline error.
- `VerifyAgeView`: gains an "update" mode for already-authenticated users (Google sign-ins where People API returned partial / no DOB). In that mode Continue calls `updateBirthDate` instead of `signUpWithEmail`.
- `utils/age`: shared `MIN_AGE`, `calculateAge`, `isAgeAllowed`.

### Required Google Cloud config
For the People API path to work, the project's Google Cloud OAuth client (which Supabase points at) needs:
1. **People API** enabled
2. The `https://www.googleapis.com/auth/user.birthday.read` scope added to the OAuth consent screen

If neither is configured, sign-in still works — the People API call quietly returns nothing and users land on `/signup/verify-age` for manual entry.

## Test plan
- [ ] Google sign-up with full DOB on Google account → lands on `/`, `user_metadata.birth_date` populated
- [ ] Google sign-up with partial / no DOB → lands on `/signup/verify-age` (update mode); Continue saves DOB and routes to `/`
- [ ] Existing user (any provider) with no `birth_date` → routed to `/signup/verify-age` on next sign-in
- [ ] User with `birth_date < 13` years old → signed out, lands on `/login` with rejection message visible
- [ ] Email signup flow unchanged (`pendingSignup` still works)
- [ ] `npm run build` passes

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_