### PR TITLE
Reject under-13 Google sign-ins cleanly

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -131,11 +131,26 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
     setActiveTab(initialTab);
   }, [isOpen, initialTab]);
 
-  // Surface any age-rejection message handed in via navigate().
+  // Surface any age-rejection message — either handed in via
+  // navigate() (App.jsx age gate) or stashed in sessionStorage by
+  // useAuthListener before a hard redirect (Google under-13 path).
   useEffect(() => {
     if (!isOpen) return;
     const rejection = location.state?.ageRejection;
-    if (rejection) setLocalError(rejection);
+    if (rejection) {
+      setLocalError(rejection);
+      return;
+    }
+    if (typeof window === 'undefined') return;
+    try {
+      const stashed = sessionStorage.getItem('araviel-age-rejection');
+      if (stashed) {
+        setLocalError(stashed);
+        sessionStorage.removeItem('araviel-age-rejection');
+      }
+    } catch {
+      // sessionStorage unavailable → nothing to surface.
+    }
   }, [isOpen, location.state]);
 
   useEffect(() => {

--- a/src/hooks/useAuthListener.js
+++ b/src/hooks/useAuthListener.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { supabase } from '../lib/supabase';
-import { initializeAuth, setAuth, clearAuth, updateBirthDate } from '../store/slices/authSlice';
+import { initializeAuth, setAuth, clearAuth, signOut, updateBirthDate } from '../store/slices/authSlice';
 import { resetChatState, setCreditBalance } from '../store/slices/chatSlice';
 import { resetProjectsState } from '../store/slices/projectsSlice';
 import {
@@ -15,6 +15,7 @@ import { fetchSubscription } from '../services/subscription';
 import { fetchGoogleBirthday } from '../services/googleBirthday';
 import { clearImageCache } from '../services/imageGeneration';
 import { setLoggerUser } from '../lib/logger';
+import { isAgeAllowed, MIN_AGE } from '../utils/age';
 
 // ---------------------------------------------------------------------------
 // Helpers: map Supabase objects to our app shapes
@@ -101,9 +102,36 @@ export default function useAuthListener() {
             if (provider === 'google' && providerToken && !user.birthDate) {
               fetchGoogleBirthday(providerToken)
                 .then((birthDate) => {
-                  if (birthDate) {
-                    dispatch(updateBirthDate({ birthDate }));
+                  if (!birthDate) return; // Falls through to manual entry.
+                  // Validate against MIN_AGE here so an under-13 Google
+                  // user is signed out immediately, before App.jsx's
+                  // gate has to react to the metadata write. The DB
+                  // sync trigger would also reject the update, but
+                  // checking client-side gives a clearer UX path.
+                  if (!isAgeAllowed(birthDate)) {
+                    // Stash the rejection so AuthModal can surface it
+                    // after the hard redirect — we don't have router
+                    // access here. sessionStorage clears at the end of
+                    // the browsing session, and AuthModal removes the
+                    // key once read so refreshing /login doesn't echo
+                    // the message indefinitely.
+                    if (typeof window !== 'undefined') {
+                      try {
+                        sessionStorage.setItem(
+                          'araviel-age-rejection',
+                          `You must be at least ${MIN_AGE} years old to use Araviel.`
+                        );
+                      } catch {
+                        // Quota / private mode → skip the message.
+                      }
+                    }
+                    dispatch(signOut());
+                    if (typeof window !== 'undefined') {
+                      window.location.assign('/login');
+                    }
+                    return;
                   }
+                  dispatch(updateBirthDate({ birthDate }));
                 })
                 .catch(() => {});
             }


### PR DESCRIPTION
## Summary
Tighten the Google sign-in path so under-13 users are rejected cleanly, complementing the DB-side age gate in `araviel-api#133`.

Previously the auth listener saved every Google-fetched DOB and relied on `App.jsx`'s gate to catch under-13 on the next render. With the new `sync_user_birth_date` trigger that metadata write now raises `22023` for <13, leaving the user in a half-state.

This change:
- Validates the Google-supplied DOB against `MIN_AGE` in `useAuthListener` **before** the metadata write.
- For <13: stashes a rejection message in `sessionStorage`, dispatches `signOut`, hard-redirects to `/login`. We can't use `navigate()` here (no router context), so the hard redirect + sessionStorage handoff is the cleanest path.
- `AuthModal` already reads `location.state.ageRejection` for the soft-redirect path; extend it to also pick up the `sessionStorage` key and clear it after display.

## Test plan
- [ ] Apply `araviel-api#133` first
- [ ] Sign in with a Google account whose DOB on Google is <13 → land on `/login` with the rejection message visible, anonymous session restored
- [ ] Sign in with a Google account ≥13 → DOB saved silently, lands on `/`
- [ ] Sign in with a Google account with no/partial DOB → routed to `/signup/verify-age` (manual entry)

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_