### PR TITLE
Auth: confirm-password field + 90% panel scale

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -98,6 +98,7 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
   const [activeTab, setActiveTab] = useState(initialTab);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showForgotPassword, setShowForgotPassword] = useState(false);
@@ -112,6 +113,7 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
   const clearState = useCallback(() => {
     setEmail('');
     setPassword('');
+    setConfirmPassword('');
     setDisplayName('');
     setShowPassword(false);
     setLocalError('');
@@ -194,6 +196,11 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
 
     if (activeTab === 'signup' && password.length < 6) {
       setLocalError('Password must be at least 6 characters.');
+      return;
+    }
+
+    if (activeTab === 'signup' && password !== confirmPassword) {
+      setLocalError("Passwords don't match — re-enter to confirm.");
       return;
     }
 
@@ -400,6 +407,26 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
                   </button>
                 </div>
               )}
+            </div>
+          )}
+
+          {!showForgotPassword && isSignUp && (
+            <div className={styles.fieldGroup}>
+              <label className={styles.label} htmlFor="auth-confirm-password">
+                Confirm password
+              </label>
+              <div className={styles.passwordWrapper}>
+                <input
+                  id="auth-confirm-password"
+                  className={styles.input}
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="Re-enter your password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  autoComplete="new-password"
+                  required
+                />
+              </div>
             </div>
           )}
 

--- a/src/components/Auth/AuthModal.module.css
+++ b/src/components/Auth/AuthModal.module.css
@@ -70,17 +70,22 @@
   flex-direction: column;
   align-items: stretch;
   text-align: center;
+  /* Scale the inner content to ~90% so the auth surface reads at a
+     comfortable density on tall, empty screens — same effect as
+     zooming the browser to 90%. The overlay handles centering. */
+  transform: scale(0.9);
+  transform-origin: center;
   animation: panelIn 0.3s cubic-bezier(0.2, 0, 0, 1);
 }
 
 @keyframes panelIn {
   from {
     opacity: 0;
-    transform: translateY(10px);
+    transform: translateY(10px) scale(0.9);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(0.9);
   }
 }
 

--- a/src/components/Auth/CheckEmailView.module.css
+++ b/src/components/Auth/CheckEmailView.module.css
@@ -21,17 +21,21 @@
   flex-direction: column;
   align-items: stretch;
   text-align: center;
+  /* Match AuthModal's 90% scale so the onboarding screens read as a
+     single visually-consistent flow. */
+  transform: scale(0.9);
+  transform-origin: center;
   animation: panelIn 0.3s cubic-bezier(0.2, 0, 0, 1);
 }
 
 @keyframes panelIn {
   from {
     opacity: 0;
-    transform: translateY(10px);
+    transform: translateY(10px) scale(0.9);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(0.9);
   }
 }
 

--- a/src/components/Auth/VerifyAgeView.module.css
+++ b/src/components/Auth/VerifyAgeView.module.css
@@ -21,17 +21,21 @@
   flex-direction: column;
   align-items: stretch;
   text-align: left;
+  /* Match AuthModal's 90% scale so the onboarding screens read as a
+     single visually-consistent flow. */
+  transform: scale(0.9);
+  transform-origin: center;
   animation: panelIn 0.3s cubic-bezier(0.2, 0, 0, 1);
 }
 
 @keyframes panelIn {
   from {
     opacity: 0;
-    transform: translateY(10px);
+    transform: translateY(10px) scale(0.9);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(0.9);
   }
 }
 


### PR DESCRIPTION
## Summary
- Email signup now requires a **Confirm password** field; mismatched values block the submit with "Passwords don't match — re-enter to confirm."
- Sign-in form is unchanged.
- Visually scale `AuthModal`, `VerifyAgeView`, and `CheckEmailView` panels to 90% via `transform: scale(0.9)` so the onboarding surfaces read at a more comfortable density on tall, empty screens (mimics the user's "browser zoomed to 90%" reference).
- Composed the existing `panelIn` entry animation with the static scale so the entry doesn't snap back to scale(1).

## Test plan
- [ ] `/signup` shows Name, Email, Password, Confirm password fields in that order
- [ ] Mismatching password and confirm → red error, submit blocked
- [ ] Matching values → proceeds to `/signup/verify-age` as before
- [ ] `/login` is unchanged (no confirm field)
- [ ] All three auth surfaces look ~10% smaller; entry animation slides in cleanly without size jump

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_