### PR TITLE
Stop closing /login and /signup on overlay click

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -272,21 +272,17 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
       role="dialog"
       aria-modal="true"
       aria-label={heading}
-      onClick={handleClose}
     >
       <button
         type="button"
         className={styles.backBtn}
-        onClick={(e) => {
-          e.stopPropagation();
-          handleBackBtn();
-        }}
+        onClick={handleBackBtn}
       >
         <ArrowLeftIcon />
         <span>{backLabel}</span>
       </button>
 
-      <div className={styles.panel} onClick={(e) => e.stopPropagation()}>
+      <div className={styles.panel}>
         <div className={styles.logoMark} aria-hidden="true">
           A
         </div>


### PR DESCRIPTION
## Summary
Disable click-outside-to-close on `/login` and `/signup`. The overlay click handler made sense when AuthModal was a transient modal, but now that it's only mounted by `AuthRoute` (i.e. it's a full route), an accidental background click that whisks the user back to `/` is a footgun — half-typed credentials get wiped, and the URL changes silently.

- Removed the `onClick={handleClose}` handler from the `.overlay` and the matching `stopPropagation` guard on the inner `.panel`.
- The explicit **Back** button and the **Escape** key both still dismiss the surface, so there's no accessibility regression.

## Test plan
- [ ] On `/login`: click anywhere on the dark background → form stays open
- [ ] Type credentials, click background → input is preserved
- [ ] Press the Back button → returns to `/`
- [ ] Press Escape → returns to `/`
- [ ] Same on `/signup`

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_