### PR TITLE
Show password rule errors on /signup with friendly messages

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -10,6 +10,7 @@ import {
   setAuthError,
 } from '../../store/slices/authSlice';
 import { getRememberMePreference, setRememberMePreference } from '../../lib/authStorage';
+import { getPasswordRuleViolations, formatPasswordError } from '../../utils/password';
 import styles from './AuthModal.module.css';
 
 const GoogleIcon = () => (
@@ -133,11 +134,17 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
     setActiveTab(initialTab);
   }, [isOpen, initialTab]);
 
-  // Surface any age-rejection message — either handed in via
-  // navigate() (App.jsx age gate) or stashed in sessionStorage by
-  // useAuthListener before a hard redirect (Google under-13 path).
+  // Surface any inline message handed in via navigate() — either an
+  // age rejection from the App.jsx gate / useAuthListener (Google
+  // under-13 hard redirect) or a password rejection bounced back from
+  // VerifyAgeView when the server's policy is stricter than ours.
   useEffect(() => {
     if (!isOpen) return;
+    const passwordError = location.state?.passwordError;
+    if (passwordError) {
+      setLocalError(passwordError);
+      return;
+    }
     const rejection = location.state?.ageRejection;
     if (rejection) {
       setLocalError(rejection);
@@ -194,14 +201,16 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
       return;
     }
 
-    if (activeTab === 'signup' && password.length < 6) {
-      setLocalError('Password must be at least 6 characters.');
-      return;
-    }
-
-    if (activeTab === 'signup' && password !== confirmPassword) {
-      setLocalError("Passwords don't match — re-enter to confirm.");
-      return;
+    if (activeTab === 'signup') {
+      const violations = getPasswordRuleViolations(password);
+      if (violations.length > 0) {
+        setLocalError(formatPasswordError(violations));
+        return;
+      }
+      if (password !== confirmPassword) {
+        setLocalError("Passwords don't match — re-enter to confirm.");
+        return;
+      }
     }
 
     if (activeTab === 'signin') {
@@ -353,7 +362,7 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
                   id="auth-password"
                   className={styles.input}
                   type={showPassword ? 'text' : 'password'}
-                  placeholder={isSignUp ? 'Min. 6 characters' : 'Your password'}
+                  placeholder={isSignUp ? 'At least 8 chars, mix of cases & a number' : 'Your password'}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   autoComplete={isSignUp ? 'new-password' : 'current-password'}

--- a/src/components/Auth/VerifyAgeView.jsx
+++ b/src/components/Auth/VerifyAgeView.jsx
@@ -243,6 +243,25 @@ export default function VerifyAgeView() {
         "We couldn't send the confirmation email right now — try again in a few minutes. " +
           "Your details haven't been submitted yet."
       );
+      return;
+    }
+
+    // If Supabase's password policy is stricter than our client-side
+    // rules (or someone bypassed them), the server can still reject the
+    // signUp with a password error after the user has already filled
+    // in their DOB. Bounce them back to /signup with a friendly
+    // message instead of trapping them on this screen — the password
+    // is the thing they need to fix.
+    if (raw.includes('password')) {
+      navigate('/signup', {
+        replace: true,
+        state: {
+          ...location.state,
+          passwordError:
+            'Password must contain at least: 8 characters, 1 uppercase letter, ' +
+            '1 lowercase letter, 1 number.',
+        },
+      });
     }
   };
 

--- a/src/utils/password.js
+++ b/src/utils/password.js
@@ -1,0 +1,30 @@
+/**
+ * Password validation that mirrors Supabase Auth's "Lowercase, uppercase
+ * letters, and digits" policy plus a minimum length. Returns a list of
+ * the rules the input fails (empty array = valid). Callers join the list
+ * into a user-friendly message instead of relying on Supabase's verbose
+ * error string.
+ */
+
+export const PASSWORD_MIN_LENGTH = 8;
+
+export function getPasswordRuleViolations(password) {
+  const issues = [];
+  if (!password || password.length < PASSWORD_MIN_LENGTH) {
+    issues.push(`${PASSWORD_MIN_LENGTH} characters`);
+  }
+  if (!/[a-z]/.test(password || '')) issues.push('1 lowercase letter');
+  if (!/[A-Z]/.test(password || '')) issues.push('1 uppercase letter');
+  if (!/[0-9]/.test(password || '')) issues.push('1 number');
+  return issues;
+}
+
+/**
+ * Format a list of failing rules as a single line: e.g.
+ * "Password must contain at least: 8 characters, 1 uppercase letter,
+ * 1 number."
+ */
+export function formatPasswordError(violations) {
+  if (!violations || violations.length === 0) return '';
+  return `Password must contain at least: ${violations.join(', ')}.`;
+}


### PR DESCRIPTION
## Summary
Move password complexity feedback off `/signup/verify-age` and onto the `/signup` form where the user can actually fix it.

- **`utils/password`** — new helper exporting `getPasswordRuleViolations()` (returns failing rules) and `formatPasswordError()` (formats them as a single line). Policy: 8+ chars, 1 lowercase, 1 uppercase, 1 number — mirrors Supabase's default "Lowercase, uppercase letters, and digits" plus a tighter min length.
- **`AuthModal`** — signup submit checks the new helper before navigating. Failure shows e.g.
  > Password must contain at least: 8 characters, 1 uppercase letter, 1 lowercase letter, 1 number.
  
  Also updates the password placeholder from "Min. 6 characters" to "At least 8 chars, mix of cases & a number".
- **`VerifyAgeView` safety net** — if Supabase still rejects with a password error (server policy stricter than ours), bounce the user back to `/signup` with the friendly message in `location.state.passwordError` instead of trapping them on the age page where they can't edit the password.
- **`AuthModal`** — picks up `location.state.passwordError` on mount, on the same channel as the existing `ageRejection` message.

## Test plan
- [ ] On `/signup`, submit with `password = "abc"` → inline error lists the failing rules
- [ ] Submit with `password = "abcdefgh"` (no upper/digit) → error lists `1 uppercase letter, 1 number`
- [ ] Submit with `password = "Abcd1234"` (matches policy) and matching confirm → proceeds to `/signup/verify-age`
- [ ] Sign-in form unchanged
- [ ] If a password somehow slips through and Supabase rejects it on the verify-age step, the user lands back on `/signup` with the friendly message visible (not the raw `abcdefghij...` Supabase string)

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_