### PR TITLE
Offset landing provider strip by the sidebar width

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -2953,7 +2953,11 @@
    column grows or how its flex layout centres its contents. */
 .ambientProviders {
   position: fixed;
-  left: 0;
+  /* Sidebar publishes its current rendered width as --sidebar-width on
+     the root. Offsetting `left` by it keeps the centred strip aligned
+     with the main column instead of disappearing under the open
+     sidebar. Falls back to 0 if the variable isn't set yet. */
+  left: var(--sidebar-width, 0);
   right: 0;
   bottom: calc(28px + var(--safe-area-bottom));
   z-index: 0;
@@ -2966,6 +2970,7 @@
   pointer-events: none;
   opacity: 0;
   animation: ambientProvidersIn 0.7s cubic-bezier(0.2, 0, 0, 1) 0.2s forwards;
+  transition: left 0.3s cubic-bezier(0.2, 0, 0, 1);
 }
 
 .ambientProvider {

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -257,6 +257,17 @@ export default function Sidebar() {
     return () => window.removeEventListener('resize', checkMobile);
   }, []);
 
+  // Publish the sidebar's current rendered width as a CSS variable on
+  // the root so position: fixed siblings (e.g. the landing page's
+  // ambient provider strip) can offset their `left` by it and stop
+  // sliding under the open sidebar. Mobile renders the sidebar as a
+  // full-screen overlay, so it doesn't take any horizontal space —
+  // we publish 0 there.
+  useEffect(() => {
+    const width = isMobile ? '0px' : collapsed ? '48px' : '260px';
+    document.documentElement.style.setProperty('--sidebar-width', width);
+  }, [collapsed, isMobile]);
+
   // Global Cmd/Ctrl+K shortcut for search
   useEffect(() => {
     const handleKeyDown = (e) => {


### PR DESCRIPTION
## Summary
Fix the landing-page provider strip getting buried under the sidebar when it's expanded.

The strip uses `position: fixed; left: 0`, which spans the full viewport. With the sidebar mounted as a fixed-width sibling at the left of the layout, the first few provider chips were always hidden behind the panel whenever the user opened the sidebar.

- **Sidebar** publishes its current rendered width as `--sidebar-width` on `document.documentElement` (260px expanded, 48px collapsed, 0px on mobile where it's an overlay).
- **`.ambientProviders`** sets `left: var(--sidebar-width, 0)` with a 0.3s ease transition that matches the sidebar's own collapse animation so the strip slides smoothly instead of snapping.

## Test plan
- [ ] Desktop, sidebar expanded → strip starts at the right edge of the sidebar, all six providers visible
- [ ] Collapse the sidebar → strip animates left and re-centres in the wider area
- [ ] Resize to mobile width → sidebar becomes overlay, strip fills the full width
- [ ] No regression at narrow viewport heights — strip still pinned to footer

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_