### PR TITLE
Add tier-aware Upgrade CTA to top nav

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -126,7 +126,7 @@ import {
   selectCurrentTier,
   setImageCredits,
 } from '../../store/slices/subscriptionSlice';
-import { getNextTier } from '../../config/subscription';
+import { getNextTier, getUpgradeCtaLabel } from '../../config/subscription';
 import { PROVIDERS, isImageGenerationModel } from '../../data/models';
 import { getProviderLogo } from '../getProviderLogo';
 import { compressImage, isAcceptedImageType } from '../../utils/imageCompression';
@@ -2830,14 +2830,32 @@ export default function MainContent() {
             </>
           )}
           {isAuthenticated ? (
-            <button
-              className={styles.newChatNavBtn}
-              onClick={handleNewChat}
-              title="New Chat"
-              aria-label="Start new chat"
-            >
-              <NewChatIcon />
-            </button>
+            <>
+              {(() => {
+                const upgradeLabel = getUpgradeCtaLabel(currentTier);
+                if (!upgradeLabel) return null;
+                return (
+                  <button
+                    type="button"
+                    className={styles.upgradeNavBtn}
+                    onClick={() => navigate('/plans')}
+                    title={`${upgradeLabel} your plan`}
+                    aria-label={`${upgradeLabel} your plan`}
+                  >
+                    <ZapIcon />
+                    <span className={styles.upgradeNavBtnLabel}>{upgradeLabel}</span>
+                  </button>
+                );
+              })()}
+              <button
+                className={styles.newChatNavBtn}
+                onClick={handleNewChat}
+                title="New Chat"
+                aria-label="Start new chat"
+              >
+                <NewChatIcon />
+              </button>
+            </>
           ) : (
             <>
               <button
@@ -3125,7 +3143,9 @@ export default function MainContent() {
           isStreaming={isStreaming}
           streamedText={streamedText}
           onRetry={handleRetry}
-          onSessionExpired={() => navigate('/login', { state: { from: location.pathname + location.search } })}
+          onSessionExpired={() =>
+            navigate('/login', { state: { from: location.pathname + location.search } })
+          }
           onAlternateModelRequest={handleAlternateModelRequest}
           onSubConvPanelToggle={setIsSubConvPanelOpen}
           onCodePanelToggle={setIsCodePanelOpen}

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -599,6 +599,50 @@
   height: 18px;
 }
 
+/* Upgrade CTA — sits to the left of the New Chat button when the user is on a
+   non-Pro plan. Shows "Upgrade" for free users, "Go Pro" for Lite users. */
+.upgradeNavBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background-color: var(--bg-icon-button);
+  color: var(--text-icon-button);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.12s ease, opacity 0.15s ease, box-shadow 0.2s ease;
+  box-shadow: var(--shadow);
+}
+
+.upgradeNavBtn:hover {
+  opacity: 0.92;
+  box-shadow: var(--shadow-lg);
+}
+
+.upgradeNavBtn:active {
+  transform: scale(0.97);
+}
+
+.upgradeNavBtn:focus-visible {
+  outline: 2px solid var(--text-muted);
+  outline-offset: 2px;
+}
+
+.upgradeNavBtn svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.upgradeNavBtnLabel {
+  line-height: 1;
+}
+
 /* Guest sign-up CTA — replaces .newChatNavBtn in the top-right when not authenticated */
 .signUpNavBtn {
   display: inline-flex;

--- a/src/config/subscription.js
+++ b/src/config/subscription.js
@@ -214,11 +214,7 @@ export const COMPARISON_FEATURES = [
 ];
 
 // Tier ordering for comparison (higher index = higher tier)
-export const TIER_ORDER = [
-  SubscriptionTier.Free,
-  SubscriptionTier.Lite,
-  SubscriptionTier.Pro,
-];
+export const TIER_ORDER = [SubscriptionTier.Free, SubscriptionTier.Lite, SubscriptionTier.Pro];
 
 export function isUpgrade(fromTier, toTier) {
   return TIER_ORDER.indexOf(toTier) > TIER_ORDER.indexOf(fromTier);
@@ -248,4 +244,19 @@ const NEXT_TIER_MAP = {
 
 export function getNextTier(tierId) {
   return NEXT_TIER_MAP[tierId] ?? null;
+}
+
+// CTA label for the top-nav upgrade button. Returns null when the user is
+// already on the highest tier and no upgrade is available.
+const UPGRADE_CTA_LABELS = {
+  [SubscriptionTier.Free]: 'Upgrade',
+  [SubscriptionTier.Lite]: 'Go Pro',
+  [SubscriptionTier.Pro]: null,
+};
+
+export function getUpgradeCtaLabel(tierId) {
+  // Treat unknown / missing tiers as Free so newly-logged-in users immediately
+  // see the Upgrade CTA before their subscription has been fetched.
+  if (!tierId) return UPGRADE_CTA_LABELS[SubscriptionTier.Free];
+  return UPGRADE_CTA_LABELS[tierId] ?? null;
 }

--- a/src/config/subscription.test.js
+++ b/src/config/subscription.test.js
@@ -14,6 +14,7 @@ import {
   isDowngrade,
   getProjectLimit,
   getNextTier,
+  getUpgradeCtaLabel,
 } from './subscription';
 
 describe('subscription config', () => {
@@ -228,6 +229,30 @@ describe('subscription config', () => {
 
     it('unknown tier returns null', () => {
       expect(getNextTier('nonexistent')).toBeNull();
+    });
+  });
+
+  describe('getUpgradeCtaLabel', () => {
+    it('shows "Upgrade" for free tier', () => {
+      expect(getUpgradeCtaLabel('free')).toBe('Upgrade');
+    });
+
+    it('shows "Go Pro" for lite tier', () => {
+      expect(getUpgradeCtaLabel('lite')).toBe('Go Pro');
+    });
+
+    it('returns null for pro tier (already top tier)', () => {
+      expect(getUpgradeCtaLabel('pro')).toBeNull();
+    });
+
+    it('defaults to "Upgrade" when tier is missing (newly-logged-in users)', () => {
+      expect(getUpgradeCtaLabel(undefined)).toBe('Upgrade');
+      expect(getUpgradeCtaLabel(null)).toBe('Upgrade');
+      expect(getUpgradeCtaLabel('')).toBe('Upgrade');
+    });
+
+    it('returns null for unknown tier ids', () => {
+      expect(getUpgradeCtaLabel('nonexistent')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Show "Upgrade" for Free users and "Go Pro" for Lite users next to the New Chat button; route to /plans on click. Hidden for Pro (no upgrade available) and guests (sign-in/sign-up CTAs already shown). Label logic lives in subscription config as getUpgradeCtaLabel and is unit-tested.