### PR TITLE
Constrain attach dropdown height and lift z-index above top nav

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -1534,9 +1534,14 @@
   padding: 6px;
   gap: 2px;
   animation: attachDropdownSlide 0.15s ease;
-  z-index: 100;
+  /* Stay above the top nav (z-index: 10) and other chrome in every stacking context */
+  z-index: 1000;
   min-width: 220px;
-  overflow: hidden;
+  /* Never grow into the top nav / off-screen — leave a buffer for nav + composer + safe area */
+  max-height: min(440px, calc(var(--app-height, 100vh) - 160px));
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
 }
 
 @keyframes attachDropdownSlide {


### PR DESCRIPTION
The attach dropdown opens upward from the composer (bottom: 100%) and had no height ceiling. Submenus like Mood (8+ options) grew tall enough to extend into the top nav region, where they were visually clipped by the opaque nav bar.

Cap max-height to 'min(440px, calc(var(--app-height) - 160px))' so the dropdown always fits in the viewport above the composer with internal scrolling, and bump z-index to 1000 as a defensive guard against ancestor stacking contexts.