### PR TITLE
Lift composer container above top nav so dropdown z-index escapes its…

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -1393,7 +1393,10 @@
   flex-direction: column;
   align-items: center;
   position: relative;
-  z-index: 1;
+  /* Sit above the top nav (z-index: 10) so popovers anchored to the
+     composer (e.g. attach dropdown / mood submenu) render above it.
+     Modals and overlays still win — they live at z-index ≥ 1000. */
+  z-index: 20;
 }
 
 /* When in chat mode, input sticks to bottom */


### PR DESCRIPTION
… stacking context

The previous attempt set z-index: 1000 on .attachDropdown, but .container
declared z-index: 1, which created a local stacking context that trapped
the dropdown beneath .topNav (z-index: 10) at the parent level.

Raise .container's z-index to 20 so its descendants (the attach dropdown and any future composer popovers) can render above the top nav. Modals and full-screen overlays still win — they live at z-index >= 1000.