### PR TITLE
feat(input): persistent research-mode chip in the input bar

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -142,6 +142,7 @@ import { saveSettings } from '../../services/settings';
 import { readBooleanSetting } from '../../lib/localSettings';
 import ModalityBar from '../ModalityBar/ModalityBar';
 import BuyPacksModal from '../BuyPacksModal/BuyPacksModal';
+import ResearchModeChip from './ResearchModeChip';
 import { selectEffectiveTheme } from '../../store/slices/themeSlice';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import {
@@ -3543,6 +3544,14 @@ export default function MainContent() {
                   >
                     <GlobeIcon />
                   </button>
+                  <ResearchModeChip
+                    disabled={isProcessing}
+                    onReopen={() => {
+                      setShowResearchModes(true);
+                      setShowAttachDropdown(false);
+                      setActiveDropdown(null);
+                    }}
+                  />
                 </div>
                 <div className={styles.rightActions}>
                   <ModelSelector />

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -2453,6 +2453,121 @@
   }
 }
 
+/* Research mode chip — appears when a reasoning toggle is active so it can't
+   be forgotten. Click the icon to reopen the dropdown (e.g. switch modes);
+   hover or focus to reveal the X for one-click cancel. Mirrors Claude's
+   pattern but composed of two buttons so the cancel target is clearly
+   separable from the chip. */
+.researchChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  animation: researchChipIn 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.researchChipButton {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background-color: var(--bg-active);
+  color: var(--text-primary);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease;
+  flex-shrink: 0;
+}
+
+.researchChipButton svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.researchChipButton:hover:not(:disabled),
+.researchChipButton:focus-visible {
+  border-color: var(--border-color);
+  outline: none;
+}
+
+.researchChipButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.researchChipCancel {
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  cursor: pointer;
+  opacity: 0;
+  transform: translateX(-4px);
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease, color 0.15s ease,
+    background-color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.researchChipCancel svg {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
+
+/* Reveal X on hover/focus of the chip group, or focus on the X itself. */
+.researchChip:hover .researchChipCancel,
+.researchChip:focus-within .researchChipCancel {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.researchChipCancel:hover:not(:disabled) {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.researchChipCancel:focus-visible {
+  outline: 1px solid var(--border-color);
+  outline-offset: 1px;
+}
+
+.researchChipCancel:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Touch devices — no hover state, so keep the X always visible at reduced
+   prominence. Tap-target stays at 22px which is comfortable next to the
+   32px chip on phones. */
+@media (hover: none) {
+  .researchChipCancel {
+    opacity: 0.7;
+    transform: translateX(0);
+    pointer-events: auto;
+  }
+}
+
+@keyframes researchChipIn {
+  from {
+    opacity: 0;
+    transform: translateX(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 .modeSelector {
   display: flex;
   align-items: center;

--- a/src/components/MainContent/ResearchModeChip.jsx
+++ b/src/components/MainContent/ResearchModeChip.jsx
@@ -1,0 +1,101 @@
+import { useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  setExtendedThinking,
+  setDeepResearch,
+  setGoogleThinking,
+  selectExtendedThinking,
+  selectDeepResearch,
+  selectGoogleThinking,
+} from '../../store/slices/chatSlice';
+import { BrainIcon, BeakerIcon, CpuIcon, CloseIcon } from '../Icons';
+import styles from './MainContent.module.css';
+
+const MODES = [
+  {
+    key: 'extendedThinking',
+    label: 'Extended Thinking',
+    selector: selectExtendedThinking,
+    action: setExtendedThinking,
+    Icon: BrainIcon,
+  },
+  {
+    key: 'deepResearch',
+    label: 'Deep Research',
+    selector: selectDeepResearch,
+    action: setDeepResearch,
+    Icon: BeakerIcon,
+  },
+  {
+    key: 'googleThinking',
+    label: 'Thinking Mode',
+    selector: selectGoogleThinking,
+    action: setGoogleThinking,
+    Icon: CpuIcon,
+  },
+];
+
+/**
+ * Persistent indicator that appears in the input bar when a research mode is
+ * active. Click the chip to reopen the research dropdown (e.g. to switch
+ * modes); click the X to cancel the active mode entirely. Hidden when no mode
+ * is active so the input bar stays minimal in the default state.
+ */
+function ResearchModeChip({ onReopen, disabled = false }) {
+  const dispatch = useDispatch();
+
+  // Read all three flags at the top level — calling useSelector inside .map
+  // would violate the rules of hooks. The slice enforces mutual exclusivity,
+  // so at most one of these is ever true.
+  const extendedThinking = useSelector(selectExtendedThinking);
+  const deepResearch = useSelector(selectDeepResearch);
+  const googleThinking = useSelector(selectGoogleThinking);
+
+  const activeMode = useMemo(() => {
+    const flags = { extendedThinking, deepResearch, googleThinking };
+    return MODES.find((m) => flags[m.key]) ?? null;
+  }, [extendedThinking, deepResearch, googleThinking]);
+
+  if (!activeMode) return null;
+
+  const { label, Icon, action } = activeMode;
+
+  const handleCancel = (event) => {
+    // Stop the click from also reopening the dropdown via the chip handler.
+    event.stopPropagation();
+    if (disabled) return;
+    dispatch(action(false));
+  };
+
+  const handleReopen = () => {
+    if (disabled) return;
+    onReopen?.();
+  };
+
+  return (
+    <div className={styles.researchChip}>
+      <button
+        type="button"
+        className={styles.researchChipButton}
+        onClick={handleReopen}
+        disabled={disabled}
+        title={label}
+        aria-label={`${label} active. Click to change research mode.`}
+      >
+        <Icon />
+      </button>
+      <button
+        type="button"
+        className={styles.researchChipCancel}
+        onClick={handleCancel}
+        disabled={disabled}
+        title={`Turn off ${label}`}
+        aria-label={`Turn off ${label}`}
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+}
+
+export default ResearchModeChip;


### PR DESCRIPTION
When a user activates one of the research dropdown's three reasoning modes (Extended Thinking / Deep Research / Thinking Mode) the toggle is sticky across messages — easy to forget, easy to incur a long, expensive call on a follow-up trivial prompt. The dropdown is also several clicks away to turn off again.

This adds a small chip next to the web search icon that is hidden when no mode is active and appears as soon as one is selected. The chip renders the active mode's icon for at-a-glance recognition; hover or keyboard focus reveals an X for one-click cancel. Click the chip itself to reopen the research dropdown — useful for switching modes without first cancelling. On touch devices the X is always visible at reduced opacity since hover doesn't apply.

The chip is composed of two sibling buttons rather than nested elements so the cancel target is unambiguously separable from the chip target, both for pointer interaction and for keyboard navigation. State comes straight from the existing chatSlice selectors — no new Redux surface, no new request fields, no backend changes.

Visual treatment uses --bg-active on a rounded square (no pill shape) so it sits comfortably alongside the existing globe button without competing with it for attention. Animation is a single 180ms fade-and-slide-in, matching the timing of the rest of the input-bar interactions.