### PR TITLE
fix(input): circular research chip + click reopens attach dropdown

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -3547,8 +3547,11 @@ export default function MainContent() {
                   <ResearchModeChip
                     disabled={isProcessing}
                     onReopen={() => {
+                      // The research panel is rendered inside the attach
+                      // dropdown, so we have to open both to deep-link into
+                      // it from outside the normal "+ → Research" path.
+                      setShowAttachDropdown(true);
                       setShowResearchModes(true);
-                      setShowAttachDropdown(false);
                       setActiveDropdown(null);
                     }}
                   />

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -2472,7 +2472,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
+  border-radius: 50%;
   background-color: var(--bg-active);
   color: var(--text-primary);
   border: 1px solid transparent;
@@ -2504,7 +2504,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 6px;
+  border-radius: 50%;
   background: transparent;
   color: var(--text-muted);
   border: none;
@@ -2565,6 +2565,20 @@
   to {
     opacity: 1;
     transform: translateX(0);
+  }
+}
+
+/* Respect users who prefer reduced motion — skip the slide-in entrance and
+   drop transform-based reveal on the cancel button. Color and opacity
+   transitions stay subtle enough to keep without compromising the spirit
+   of the preference. */
+@media (prefers-reduced-motion: reduce) {
+  .researchChip {
+    animation: none;
+  }
+  .researchChipCancel {
+    transform: none;
+    transition: opacity 0.15s ease, color 0.15s ease, background-color 0.15s ease;
   }
 }
 


### PR DESCRIPTION
Two follow-ups on the research-mode chip:

- The chip's onReopen previously set only setShowResearchModes(true), so clicking it appeared to do nothing. The research panel is rendered inside `{showAttachDropdown && (...)}` — the parent has to be open for the panel to mount. Open both on chip click to deep-link into the research panel from outside the normal "+ → Research" path.
- Switched the chip and the cancel X to fully circular shapes (border-radius: 50%) so they sit visually as siblings of the existing webSearchToggle globe rather than as a different primitive in the same icon row. Matches the design-system pattern already used by every other icon-only button in the input bar.
- Added a prefers-reduced-motion rule that skips the slide-in entrance and drops the transform-based reveal on the cancel button. Color and opacity transitions remain because they're subtle and don't conflict with the spirit of the preference.

No new state, no new dependencies; only the click handler wiring and the visual treatment changed.