### PR TITLE
fix(MessageList,Sidebar): robust markdown tables; thin themed sidebar…

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -74,6 +74,7 @@ import { generateAndDownload } from '../../services/fileGenerator';
 import { dedupeCitations } from '../../utils/dedupeCitations';
 import styles from './MessageList.module.css';
 import MarkdownTextarea from '../MarkdownTextarea/MarkdownTextarea';
+import { parseMarkdownTable } from './parseMarkdownTable';
 
 // Initialize mermaid with sensible defaults
 mermaid.initialize({
@@ -239,58 +240,29 @@ function renderMarkdown(text, isStreaming = false, citations = null) {
       continue;
     }
 
-    // Markdown table: detect header row with pipes
-    if (line.trim().startsWith('|') && line.trim().endsWith('|')) {
-      const tableRows = [];
-      let hasValidSeparator = false;
-      const startIdx = i;
-
-      // Collect all contiguous pipe-delimited lines
-      while (i < lines.length && lines[i].trim().startsWith('|') && lines[i].trim().endsWith('|')) {
-        tableRows.push(lines[i].trim());
-        i++;
-      }
-
-      // Validate: need at least 2 rows, and 2nd row should be separator (| --- | --- |)
-      if (tableRows.length >= 2) {
-        const separatorRow = tableRows[1];
-        hasValidSeparator = /^\|[\s:]*-{2,}[\s:]*\|/.test(separatorRow);
-      }
-
-      if (hasValidSeparator && tableRows.length >= 2) {
-        const parseCells = (row) =>
-          row
-            .slice(1, -1) // remove leading/trailing pipes
-            .split('|')
-            .map((cell) => cell.trim());
-
-        const headerCells = parseCells(tableRows[0]);
-        // Parse alignment from separator row
-        const alignCells = parseCells(tableRows[1]);
-        const alignments = alignCells.map((cell) => {
-          if (cell.startsWith(':') && cell.endsWith(':')) return 'center';
-          if (cell.endsWith(':')) return 'right';
-          return 'left';
-        });
-        const bodyRows = tableRows.slice(2).map(parseCells);
-
+    // Markdown table — tolerant of blank-line gaps, single-dash separators,
+    // and rows with or without outer pipes. See parseMarkdownTable above.
+    if (line.includes('|')) {
+      const table = parseMarkdownTable(lines, i);
+      if (table) {
+        const { headers, rows, alignments } = table;
         elements.push(
           <div className={styles.tableWrapper} key={key++}>
             <table className={styles.table}>
               <thead>
                 <tr>
-                  {headerCells.map((cell, ci) => (
-                    <th key={ci} style={{ textAlign: alignments[ci] || 'left' }}>
+                  {headers.map((cell, ci) => (
+                    <th key={ci} style={{ textAlign: alignments[ci] }}>
                       {renderInline(cell)}
                     </th>
                   ))}
                 </tr>
               </thead>
               <tbody>
-                {bodyRows.map((row, ri) => (
+                {rows.map((row, ri) => (
                   <tr key={ri}>
-                    {headerCells.map((_, ci) => (
-                      <td key={ci} style={{ textAlign: alignments[ci] || 'left' }}>
+                    {headers.map((_, ci) => (
+                      <td key={ci} style={{ textAlign: alignments[ci] }}>
                         {renderInline(row[ci] || '')}
                       </td>
                     ))}
@@ -300,11 +272,9 @@ function renderMarkdown(text, isStreaming = false, citations = null) {
             </table>
           </div>
         );
+        i = table.endIdx;
         continue;
       }
-
-      // Not a valid table — reset and let normal parsing handle it
-      i = startIdx;
     }
 
     // Horizontal rule
@@ -2779,27 +2749,13 @@ function parseMessageToSections(content) {
     }
 
     // Table
-    if (line.trim().startsWith('|') && line.trim().endsWith('|')) {
-      const tableRows = [];
-      while (i < lines.length && lines[i].trim().startsWith('|') && lines[i].trim().endsWith('|')) {
-        tableRows.push(lines[i].trim());
-        i++;
-      }
-      if (tableRows.length >= 2 && /^\|[\s:]*-{2,}/.test(tableRows[1])) {
-        const parseCells = (row) =>
-          row
-            .slice(1, -1)
-            .split('|')
-            .map((c) => c.trim());
-        sections.push({
-          type: 'table',
-          headers: parseCells(tableRows[0]),
-          rows: tableRows.slice(2).map(parseCells),
-        });
+    if (line.includes('|')) {
+      const table = parseMarkdownTable(lines, i);
+      if (table) {
+        sections.push({ type: 'table', headers: table.headers, rows: table.rows });
+        i = table.endIdx;
         continue;
       }
-      // Not a valid table, fall through
-      i -= tableRows.length;
     }
 
     // Horizontal rule
@@ -2869,22 +2825,12 @@ function extractTablesFromContent(content) {
   let i = 0;
 
   while (i < lines.length) {
-    if (lines[i].trim().startsWith('|') && lines[i].trim().endsWith('|')) {
-      const tableRows = [];
-      const startIdx = i;
-      while (i < lines.length && lines[i].trim().startsWith('|') && lines[i].trim().endsWith('|')) {
-        tableRows.push(lines[i].trim());
-        i++;
-      }
-      if (tableRows.length >= 2 && /^\|[\s:]*-{2,}/.test(tableRows[1])) {
-        const parseCells = (row) =>
-          row
-            .slice(1, -1)
-            .split('|')
-            .map((c) => c.trim());
+    if (lines[i].includes('|')) {
+      const table = parseMarkdownTable(lines, i);
+      if (table) {
         // Look for a heading above the table
         let title = null;
-        for (let j = startIdx - 1; j >= Math.max(0, startIdx - 3); j--) {
+        for (let j = i - 1; j >= Math.max(0, i - 3); j--) {
           const hMatch = lines[j].match(/^#{1,6}\s+(.+)/);
           if (hMatch) {
             title = hMatch[1];
@@ -2896,17 +2842,12 @@ function extractTablesFromContent(content) {
             break;
           }
         }
-        tables.push({
-          title,
-          headers: parseCells(tableRows[0]),
-          rows: tableRows.slice(2).map(parseCells),
-        });
+        tables.push({ title, headers: table.headers, rows: table.rows });
+        i = table.endIdx;
         continue;
       }
-      i = startIdx + 1;
-    } else {
-      i++;
     }
+    i++;
   }
   return tables;
 }

--- a/src/components/MessageList/parseMarkdownTable.js
+++ b/src/components/MessageList/parseMarkdownTable.js
@@ -1,0 +1,87 @@
+/**
+ * Detect and parse a GitHub-Flavoured Markdown table starting at `lines[startIdx]`.
+ *
+ * Tolerant of LLM output quirks (Perplexity, ChatGPT, Claude all emit at least one):
+ *   - Blank lines between rows are skipped.
+ *   - Separator cells accept one or more dashes (`-`, `--`, `---`, …) with
+ *     optional leading/trailing colon for alignment.
+ *   - Leading and trailing pipes on a row are optional.
+ *   - Body rows shorter than the header are padded with empty cells; longer
+ *     rows are truncated to the header width.
+ *
+ * Returns `null` if no valid table starts at `startIdx`. Otherwise returns
+ * `{ headers, rows, alignments, endIdx }` where `endIdx` is the line index
+ * immediately after the last consumed row.
+ *
+ * @param {string[]} lines
+ * @param {number} startIdx
+ * @returns {{
+ *   headers: string[],
+ *   rows: string[][],
+ *   alignments: Array<'left' | 'center' | 'right'>,
+ *   endIdx: number,
+ * } | null}
+ */
+export function parseMarkdownTable(lines, startIdx) {
+  const isPipeLine = (raw) => raw.includes('|');
+  const isSeparatorCell = (cell) => /^:?-+:?$/.test(cell.trim());
+
+  const splitRow = (raw) => {
+    let s = raw.trim();
+    if (s.startsWith('|')) s = s.slice(1);
+    if (s.endsWith('|')) s = s.slice(0, -1);
+    return s.split('|').map((cell) => cell.trim());
+  };
+
+  const candidateIndices = [];
+  let blankRun = 0;
+  for (let i = startIdx; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed === '') {
+      blankRun++;
+      if (blankRun >= 2) break;
+      continue;
+    }
+    if (!isPipeLine(trimmed)) break;
+    candidateIndices.push(i);
+    blankRun = 0;
+  }
+
+  if (candidateIndices.length < 2) return null;
+
+  let separatorRow = -1;
+  for (let k = 1; k < candidateIndices.length; k++) {
+    const cells = splitRow(lines[candidateIndices[k]]);
+    if (cells.length > 0 && cells.every(isSeparatorCell)) {
+      separatorRow = k;
+      break;
+    }
+  }
+  if (separatorRow < 1) return null;
+
+  const headers = splitRow(lines[candidateIndices[separatorRow - 1]]);
+  const separatorCells = splitRow(lines[candidateIndices[separatorRow]]);
+  if (separatorCells.length !== headers.length) return null;
+
+  const alignments = separatorCells.map((cell) => {
+    const trimmed = cell.trim();
+    const leftMarker = trimmed.startsWith(':');
+    const rightMarker = trimmed.endsWith(':');
+    if (leftMarker && rightMarker) return 'center';
+    if (rightMarker) return 'right';
+    return 'left';
+  });
+
+  const rows = candidateIndices.slice(separatorRow + 1).map((idx) => {
+    const cells = splitRow(lines[idx]);
+    while (cells.length < headers.length) cells.push('');
+    return cells.slice(0, headers.length);
+  });
+
+  return {
+    headers,
+    rows,
+    alignments,
+    endIdx: candidateIndices[candidateIndices.length - 1] + 1,
+  };
+}

--- a/src/components/MessageList/parseMarkdownTable.test.js
+++ b/src/components/MessageList/parseMarkdownTable.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { parseMarkdownTable } from './parseMarkdownTable';
+
+const linesOf = (s) => s.split('\n');
+
+describe('parseMarkdownTable', () => {
+  it('parses a strict GFM table', () => {
+    const lines = linesOf(
+      ['| Name | Age |', '| --- | --- |', '| Ada | 36 |', '| Lin | 28 |'].join('\n')
+    );
+    const table = parseMarkdownTable(lines, 0);
+    expect(table).not.toBeNull();
+    expect(table.headers).toEqual(['Name', 'Age']);
+    expect(table.rows).toEqual([
+      ['Ada', '36'],
+      ['Lin', '28'],
+    ]);
+    expect(table.alignments).toEqual(['left', 'left']);
+    expect(table.endIdx).toBe(4);
+  });
+
+  it('tolerates blank lines between rows (the Perplexity case)', () => {
+    const lines = linesOf(
+      [
+        '| Departure (BST) | Arrival (PDT) | Notes |',
+        '',
+        '|:-|:-|:-|',
+        '',
+        '| 23:40 PM May 25 | 01:20 AM May 26 | Very early morning |',
+        '',
+        '| 23:50 PM May 25 | 01:30 AM May 26 | Latest practical |',
+      ].join('\n')
+    );
+    const table = parseMarkdownTable(lines, 0);
+    expect(table).not.toBeNull();
+    expect(table.headers).toEqual(['Departure (BST)', 'Arrival (PDT)', 'Notes']);
+    expect(table.rows).toHaveLength(2);
+    expect(table.rows[0]).toEqual(['23:40 PM May 25', '01:20 AM May 26', 'Very early morning']);
+    expect(table.alignments).toEqual(['left', 'left', 'left']);
+  });
+
+  it('accepts single-dash separator cells', () => {
+    const lines = linesOf(['| A | B |', '| - | - |', '| 1 | 2 |'].join('\n'));
+    const table = parseMarkdownTable(lines, 0);
+    expect(table).not.toBeNull();
+    expect(table.rows).toEqual([['1', '2']]);
+  });
+
+  it('parses alignment markers correctly', () => {
+    const lines = linesOf(['| L | C | R |', '|:--|:-:|--:|', '| 1 | 2 | 3 |'].join('\n'));
+    const table = parseMarkdownTable(lines, 0);
+    expect(table.alignments).toEqual(['left', 'center', 'right']);
+  });
+
+  it('accepts rows without leading/trailing pipes', () => {
+    const lines = linesOf(['Name | Age', '--- | ---', 'Ada | 36'].join('\n'));
+    const table = parseMarkdownTable(lines, 0);
+    expect(table).not.toBeNull();
+    expect(table.headers).toEqual(['Name', 'Age']);
+    expect(table.rows).toEqual([['Ada', '36']]);
+  });
+
+  it('pads short rows and truncates over-long rows to the header width', () => {
+    const lines = linesOf(
+      ['| A | B | C |', '| - | - | - |', '| 1 | 2 |', '| 1 | 2 | 3 | 4 |'].join('\n')
+    );
+    const table = parseMarkdownTable(lines, 0);
+    expect(table.rows).toEqual([
+      ['1', '2', ''],
+      ['1', '2', '3'],
+    ]);
+  });
+
+  it('returns null for non-table content with a stray pipe', () => {
+    const lines = linesOf(['This sentence | contains a pipe.', 'Plain follow-up line.'].join('\n'));
+    expect(parseMarkdownTable(lines, 0)).toBeNull();
+  });
+
+  it('returns null when the separator row is missing', () => {
+    const lines = linesOf(['| A | B |', '| 1 | 2 |', '| 3 | 4 |'].join('\n'));
+    expect(parseMarkdownTable(lines, 0)).toBeNull();
+  });
+
+  it('returns null when separator column count does not match the header', () => {
+    const lines = linesOf(['| A | B | C |', '| - | - |', '| 1 | 2 | 3 |'].join('\n'));
+    expect(parseMarkdownTable(lines, 0)).toBeNull();
+  });
+
+  it('stops at two consecutive blank lines', () => {
+    const lines = linesOf(['| A | B |', '| - | - |', '| 1 | 2 |', '', '', '| 3 | 4 |'].join('\n'));
+    const table = parseMarkdownTable(lines, 0);
+    expect(table.rows).toEqual([['1', '2']]);
+    expect(table.endIdx).toBe(3);
+  });
+
+  it('reports endIdx pointing just past the last row, ignoring trailing blank lines', () => {
+    const lines = linesOf(['| A |', '| - |', '| 1 |', ''].join('\n'));
+    const table = parseMarkdownTable(lines, 0);
+    expect(table.endIdx).toBe(3);
+  });
+});

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -516,6 +516,26 @@
   opacity: 1;
   margin-top: 2px;
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-color) transparent;
+  -webkit-overflow-scrolling: touch;
+}
+
+.recentsContent::-webkit-scrollbar {
+  width: 4px;
+}
+
+.recentsContent::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.recentsContent::-webkit-scrollbar-thumb {
+  background-color: var(--border-color);
+  border-radius: 3px;
+}
+
+.recentsContent::-webkit-scrollbar-thumb:hover {
+  background-color: var(--text-muted);
 }
 
 /* Time groups */
@@ -1253,6 +1273,26 @@
   border-radius: 10px;
   background-color: var(--bg-primary);
   border: 1px solid var(--border-color);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-color) transparent;
+  -webkit-overflow-scrolling: touch;
+}
+
+.projectPickerList::-webkit-scrollbar {
+  width: 4px;
+}
+
+.projectPickerList::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.projectPickerList::-webkit-scrollbar-thumb {
+  background-color: var(--border-color);
+  border-radius: 3px;
+}
+
+.projectPickerList::-webkit-scrollbar-thumb:hover {
+  background-color: var(--text-muted);
 }
 
 .projectPickerItem {


### PR DESCRIPTION
… scrollbar

The markdown table parser rejected real-world LLM output for two reasons: blank lines between rows broke the row-collection loop, and the separator regex required ≥2 dashes per cell (so `|:-|:-|:-|` failed). The same brittle parser was duplicated across `renderMarkdown`, `parseMessageToSections`, and `extractTablesFromContent`.

Extracted a single tolerant `parseMarkdownTable` helper that skips blank gaps, accepts 1+ dashes with optional alignment colons, makes outer pipes optional, and pads/truncates body rows to the header width. All three call sites now share it. Covered by 11 unit tests.

The sidebar's `.recentsContent` and `.projectPickerList` had `overflow-y: auto` but no scrollbar styling, so Chrome painted its default chunky track. Added the thin themed scrollbar pattern already used in SearchModal and MainContent.attachedFilesScroll for consistency.