### PR TITLE
fix(MessageList): let dragged panel width grow past CSS max cap

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -972,9 +972,17 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
   const activeLang = activeBlock.lang ? activeBlock.lang.toUpperCase() : 'CODE';
 
   // Mobile is full-screen (CSS-driven); skip inline sizing entirely there.
+  // maxWidth is set to 'none' so the JS-clamped width can grow past the CSS
+  // default cap (.codeSidePanel max-width: 680px) when the user drags wider —
+  // without this, the published --code-panel-width and the actual painted
+  // width drift apart and the chat reserves a phantom gap.
   const panelStyle =
     !viewport.isMobile && renderedWidth != null
-      ? { width: `${renderedWidth}px`, minWidth: `${PANEL_MIN_WIDTH}px` }
+      ? {
+          width: `${renderedWidth}px`,
+          maxWidth: 'none',
+          minWidth: `${PANEL_MIN_WIDTH}px`,
+        }
       : null;
 
   const panelClassName = `${styles.codeSidePanel}${


### PR DESCRIPTION
The inline style was setting width but not overriding the CSS rule's max-width: 680px, so when the user dragged the panel wider the paint width stayed pinned at 680px while --code-panel-width published the (larger) desired value. The chat reserved that larger margin against a panel that was still painting at the cap, leaving a big empty gap between the chat content and the code viewer.

Adding maxWidth: 'none' to the inline style lets the JS-clamped width win, keeping the painted panel and the published width in sync.

https://claude.ai/code/session_01SAYEZHCnxfXSj4zAerRven