### PR TITLE
Lift composer container above the mobile menu button

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -1393,10 +1393,11 @@
   flex-direction: column;
   align-items: center;
   position: relative;
-  /* Sit above the top nav (z-index: 10) so popovers anchored to the
-     composer (e.g. attach dropdown / mood submenu) render above it.
-     Modals and overlays still win — they live at z-index ≥ 1000. */
-  z-index: 20;
+  /* Sit above the top nav (z-index: 10) AND the mobile menu button
+     (z-index: 1001) so popovers anchored to the composer (attach
+     dropdown / mood submenu) render above them when they overlap on
+     small viewports. Stays below modals (z-index ≥ 2000). */
+  z-index: 1050;
 }
 
 /* When in chat mode, input sticks to bottom */


### PR DESCRIPTION
The composer .container creates a stacking context at z-index 20, so the attach dropdown's local z-index couldn't escape it — the whole composer still sat below the mobile hamburger button (z-index 1001), and the button painted on top of the popup on small viewports.

Raised the container to z-index 1050 so the entire composer (including any popovers anchored to it) sits above the menu button. Modals at z-index ≥ 2000 still win.