### PR TITLE
Clamp composer attach dropdown to viewport on mobile

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -2864,6 +2864,11 @@
 
   .attachDropdown {
     left: -8px;
+    max-width: calc(100vw - 16px);
+  }
+
+  .attachSubmenu {
+    min-width: 0;
   }
 
   .webSearchToggle {


### PR DESCRIPTION
The Mood/Tone submenus declare min-width: 260px, which forces the parent .attachDropdown wider than narrow viewports. Anchored at left: -8px on mobile, the right edge ran past the screen and clipped options.

Cap the dropdown at calc(100vw - 16px) and drop the submenu min-width inside small viewports so the popup always fits on screen.