### PR TITLE
Shrink composer attach dropdown height on mobile

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -2865,6 +2865,9 @@
   .attachDropdown {
     left: -8px;
     max-width: calc(100vw - 16px);
+    /* Smaller cap on mobile so the popup never reaches the top nav.
+       overflow-y on the dropdown already provides the scroll. */
+    max-height: min(320px, calc(var(--app-height, 100vh) - 200px));
   }
 
   .attachSubmenu {


### PR DESCRIPTION
The mood/tone submenu lists were tall enough to reach the top nav on phones. Cap the dropdown at min(320px, viewport - 200px) on small viewports so it stays well clear of the top edge; existing overflow-y on the dropdown lets long lists scroll.