### PR TITLE
Fix mobile sidebar bleed-through from composer subtree

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -9,6 +9,9 @@
   transition: background-color 0.2s ease, margin-right 0.4s cubic-bezier(0.16, 1, 0.3, 1);
   min-height: 100%;
   position: relative;
+  /* Form a stacking context so the composer's high-z-index popovers
+     stay scoped here and can never paint over the mobile sidebar. */
+  isolation: isolate;
 }
 
 /* When there are messages, switch to column layout with input at bottom */

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -30,7 +30,7 @@
   right: 0;
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.4);
-  z-index: 1060;
+  z-index: 1080;
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.25s ease, visibility 0.25s ease;
@@ -56,7 +56,7 @@
   transition: width 0.24s cubic-bezier(0.4, 0, 0.2, 1), padding 0.24s cubic-bezier(0.4, 0, 0.2, 1),
     background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   position: relative;
-  z-index: 1070;
+  z-index: 1090;
   flex-shrink: 0;
 }
 

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -30,7 +30,7 @@
   right: 0;
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.4);
-  z-index: 999;
+  z-index: 1060;
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.25s ease, visibility 0.25s ease;
@@ -56,7 +56,7 @@
   transition: width 0.24s cubic-bezier(0.4, 0, 0.2, 1), padding 0.24s cubic-bezier(0.4, 0, 0.2, 1),
     background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   position: relative;
-  z-index: 1000;
+  z-index: 1070;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- The composer container was raised to `z-index: 1050` so its attach dropdown could paint above the mobile menu button. Side effect: when the mobile sidebar opens, the composer (and other MainContent descendants like the message-list scroll buttons at 1100) leak into the root stacking context and paint over the sidebar panel.
- Trap the whole MainContent subtree in its own stacking context with `isolation: isolate` on `.main`, so nothing inside can outrank the sidebar regardless of its internal z-index.
- Bump the mobile sidebar overlay to `z-index: 1080` and the panel to `1090` so they sit comfortably above any remaining root-level elements while staying below toasts (1500) and modals (2000+).

## Test plan
- [ ] On a narrow viewport (≤768px), open the sidebar from the hamburger button and confirm the panel fully covers `Good evening`, the composer input, the action chips, and the top-nav buttons.
- [ ] With the sidebar closed, tap the composer `+` button — the attach dropdown still paints above the hamburger menu button.
- [ ] Open a toast / modal while the sidebar is open — toasts (1500) and modals (2000+) still paint above the sidebar.
- [ ] Desktop layout unchanged (sidebar is part of the flex row, not overlaying).

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_