### PR TITLE
Restore composer popover above hamburger and unhide Search heading

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -9,8 +9,10 @@
   transition: background-color 0.2s ease, margin-right 0.4s cubic-bezier(0.16, 1, 0.3, 1);
   min-height: 100%;
   position: relative;
-  /* Form a stacking context so the composer's high-z-index popovers
-     stay scoped here and can never paint over the mobile sidebar. */
+  /* Form a stacking context above the fixed mobile menu button (1001)
+     so composer popovers paint over it, but well below the sidebar
+     overlay (1080) / panel (1090) so the open sidebar still wins. */
+  z-index: 1050;
   isolation: isolate;
 }
 

--- a/src/components/SearchView/SearchView.module.css
+++ b/src/components/SearchView/SearchView.module.css
@@ -618,6 +618,11 @@
     padding: 32px 20px 96px;
   }
 
+  /* Leave room for the fixed mobile hamburger button (36px @ left:16px) */
+  .header {
+    padding-left: 52px;
+  }
+
   .navHints {
     display: none;
   }


### PR DESCRIPTION
## Summary
- Follow-up to #372. After adding `isolation: isolate` to `.main`, the composer popover (Mood/Tone submenus, etc.) ended up trapped in `.main`'s `z-index: auto` stacking context, so the fixed mobile hamburger (z-index 1001) painted on top of it again.
- Pin `.main` to `z-index: 1050` (still isolated) so its stacking context sits **above** the hamburger but **below** the sidebar overlay/panel (1080/1090). Composer popovers win over the hamburger; the open sidebar still covers everything inside `.main`.
- Offset `SearchView` `.header` by 52px on mobile so the page title isn't hidden under the hamburger button at `left: 16px`.

## Test plan
- [ ] Mobile (≤768px), composer closed: tap the `+` button — Mood/Tone submenu paints above the hamburger button.
- [ ] Mobile, sidebar open: still fully covers the composer, top nav, etc. (no regression from #372).
- [x] Navigate to `/search` on mobile — the "Search" heading is no longer hidden behind the hamburger button.
- [ ] Desktop unchanged.

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_