### PR TITLE
Restore mobile hamburger button visibility

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -9,11 +9,6 @@
   transition: background-color 0.2s ease, margin-right 0.4s cubic-bezier(0.16, 1, 0.3, 1);
   min-height: 100%;
   position: relative;
-  /* Form a stacking context above the fixed mobile menu button (1001)
-     so composer popovers paint over it, but well below the sidebar
-     overlay (1080) / panel (1090) so the open sidebar still wins. */
-  z-index: 1050;
-  isolation: isolate;
 }
 
 /* When there are messages, switch to column layout with input at bottom */

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -30,7 +30,7 @@
   right: 0;
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.4);
-  z-index: 1080;
+  z-index: 1180;
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.25s ease, visibility 0.25s ease;
@@ -56,7 +56,7 @@
   transition: width 0.24s cubic-bezier(0.4, 0, 0.2, 1), padding 0.24s cubic-bezier(0.4, 0, 0.2, 1),
     background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   position: relative;
-  z-index: 1090;
+  z-index: 1200;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #373. Pinning `.main` at `z-index: 1050` made the page form a stacking context above the fixed hamburger button (z-index 1001), so the hamburger disappeared on mobile.
- Drop the explicit stacking context from `.main` and instead push the sidebar overlay/panel above every potential bleed inside MainContent.

## New layering
| element | z-index |
| --- | --- |
| hamburger button | 1001 |
| composer container | 1050 |
| message-list scroll buttons | 1100 |
| sidebar overlay | **1180** (was 1080) |
| sidebar panel | **1200** (was 1090) |
| toasts | 1500 |
| modals | 2000+ |

Composer popovers still paint above the hamburger because they live inside `.container` at z-index 1050. The open sidebar still covers everything inside `.main` because 1200 > 1100.

## Test plan
- [ ] Mobile (≤768px), landing page: hamburger button is visible at top-left.
- [ ] Mobile, composer `+` button tapped: Mood/Tone submenu paints above the hamburger.
- [ ] Mobile, sidebar open: still fully covers the composer, top nav, etc. (no regression from #372/#373).
- [ ] Toasts and modals still paint above the sidebar.

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_