### PR TITLE
Pin chat top nav to the viewport on mobile

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -8,6 +8,8 @@
   background-color: var(--bg-primary);
   transition: background-color 0.2s ease, margin-right 0.4s cubic-bezier(0.16, 1, 0.3, 1);
   min-height: 100%;
+  max-height: 100%;
+  overflow: hidden;
   position: relative;
 }
 
@@ -2938,6 +2940,11 @@
   }
 
   .topNav {
+    /* Anchor to the visual viewport on mobile so the chat header doesn't
+       scroll out of view alongside iOS Safari's URL-bar collapse or any
+       internal layout shift. The sidebar overlays on mobile, so a
+       full-width fixed nav is the right reference. */
+    position: fixed;
     padding: var(--safe-area-top) 12px 0;
     height: calc(56px + var(--safe-area-top));
   }


### PR DESCRIPTION
## Summary
On mobile, the chat top nav (and composer) drifts out of view as the visual viewport changes height — typically when iOS Safari's URL bar collapses, or when long content shifts `.main`'s effective box. Both `.topNav` (`position: absolute` relative to `.main`) and the composer (a flex child of `.main`) inherit any shift in `.main`.

- Switch `.topNav` to `position: fixed` on viewports ≤768px so it's anchored to the visual viewport, not `.main`. The sidebar overlays on mobile, so a full-width fixed nav is the right reference. Desktop keeps `position: absolute` so it stays inside the `.main` column when the sidebar takes its 260px on the left.
- Add `max-height: 100%` and `overflow: hidden` to `.main` so its descendants (message list, sources panel siblings) can never push the layout taller than the allotted flex space — the composer therefore stays at the bottom of the visible viewport in chat mode.

## Test plan
- [ ] Mobile chat conversation: scroll the message list; the top nav stays pinned to the viewport top, the composer stays at the bottom.
- [ ] Mobile conversation with the sources panel open: the top nav and composer no longer "float" between scroll positions.
- [ ] Desktop: top nav still aligns within the `.main` column to the right of the sidebar (no full-width regression).
- [ ] Sidebar overlay on mobile still covers the top nav (sidebar z-index 1200 > top nav 10).

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_