### PR TITLE
Raise mobile sources panel above the composer

### DIFF
--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1822,7 +1822,11 @@
   bottom: 12px;
   width: 380px;
   max-width: calc(100vw - 24px);
-  z-index: 100;
+  /* Above the composer container (1050) and message-list scroll
+     buttons (1100) so nothing inside .main paints over the panel on
+     mobile. Still below the sidebar overlay (1180) so the sidebar
+     wins when both happen to be open. */
+  z-index: 1150;
   display: flex;
   flex-direction: column;
   background-color: var(--bg-primary);
@@ -1985,6 +1989,17 @@
   .sourcesPanel {
     width: calc(100vw - 24px);
     max-width: calc(100vw - 24px);
+  }
+
+  /* Leave room for the fixed hamburger button (36px @ left:16px) so the
+     "Sources" title isn't hidden behind it. The close button stays
+     pinned to the right via the flex space-between. */
+  .sourcesPanelHeader {
+    padding-left: 52px;
+  }
+
+  .sourcesPanelSubheader {
+    padding-left: 52px;
   }
 }
 


### PR DESCRIPTION
## Summary
On mobile, opening the sources panel left the composer painting over its bottom half (composer container at z-index 1050 vs panel at 100), and the hamburger button overlapped the "Sources" title.

- Raise `.sourcesPanel` to z-index 1150 — above the composer (1050) and the message-list scroll buttons (1100), still below the sidebar overlay (1180) so an open sidebar still covers it.
- On viewports ≤768px, give `.sourcesPanelHeader` and `.sourcesPanelSubheader` 52px of left padding so neither the "Sources" title nor "N sources found" hides behind the fixed hamburger button at `left: 16px`. The close X stays pinned to the right via the existing flex `space-between`.

## Test plan
- [ ] Mobile chat: open the sources panel. The composer no longer paints over the panel; the close X is visible at the top right.
- [ ] Mobile: the "Sources" heading is not hidden under the hamburger button.
- [ ] Mobile: open the sidebar while the sources panel is open — sidebar still covers everything (overlay 1180 > panel 1150).
- [ ] Desktop: layout unchanged (panel on the right with content to its left).

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_