### PR TITLE
Match sub-conv and code panel layering on mobile

### DIFF
--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -4516,7 +4516,9 @@
     border-radius: 0;
     border: none;
     box-shadow: none;
-    z-index: 1101;
+    /* Match sourcesPanel: above composer (1050) and scroll buttons (1100),
+       below sidebar overlay (1180). */
+    z-index: 1150;
   }
 
   .subConvPanelFadeTop {
@@ -4524,7 +4526,7 @@
   }
 
   .subConvPanelHeader {
-    padding: 18px 16px 14px;
+    padding: 18px 16px 14px 52px;
   }
 
   .subConvMessages {
@@ -7507,6 +7509,15 @@
     max-width: none;
     min-width: 0;
     border-radius: 0;
+    /* Match sourcesPanel/subConvPanel: above composer (1050) and scroll
+       buttons (1100), below sidebar overlay (1180). */
+    z-index: 1150;
+  }
+
+  /* Leave room for the fixed hamburger button (36px @ left:16px) so the
+     code panel header isn't hidden behind it. */
+  .codeSidePanelHeader {
+    padding-left: 52px;
   }
 
   /* Touch devices can't drag-resize — hide the grip so its dots don't bleed


### PR DESCRIPTION
## Summary
Follow-up to #377. Apply the same mobile layering to the two remaining side panels so the composer can't paint over them and the hamburger button doesn't clip their headers.

| panel | mobile z-index before | mobile z-index after | header padding-left |
| --- | --- | --- | --- |
| `.sourcesPanel` | 1150 (PR #377) | 1150 | 52px (PR #377) |
| `.subConvPanel` | 1101 | **1150** | **52px** (new) |
| `.codeSidePanel` | 100 (no mobile rule) | **1150** | **52px** (new) |

All three now share the same mobile tier: above the composer (1050) and message-list scroll buttons (1100), below the sidebar overlay (1180).

## Test plan
- [ ] Mobile: open a sub-conversation. Composer no longer paints over the panel. "Sub Conversation" title is not hidden by the hamburger.
- [ ] Mobile: open the code side panel. Composer no longer paints over it. Panel header isn't hidden by the hamburger.
- [ ] Sidebar still covers all three panels when open on mobile.
- [ ] Desktop: unchanged.

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_