### PR TITLE
Portal sources and sub-conv side panels to body

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -3554,7 +3554,9 @@ function SubConversationPanel({
   const finalizedMessages = subConversation.messages;
   const showStreaming = isSending || (thinkingStatus && thinkingStatus !== 'idle');
 
-  return (
+  // Portal to body so the fixed panel escapes the MessageList scroll
+  // container (see SourcesSidePanel for the iOS-Safari rationale).
+  return createPortal(
     <>
       <div className={styles.subConvOverlay} onClick={onClose} />
       <div className={styles.subConvPanel} ref={panelRef}>
@@ -3723,7 +3725,8 @@ function SubConversationPanel({
           </form>
         </div>
       </div>
-    </>
+    </>,
+    document.body
   );
 }
 
@@ -5963,7 +5966,11 @@ function SourcesSidePanel({ citations, onClose, panelRef }) {
   // reflect unique sources.
   const uniqueCitations = useMemo(() => dedupeCitations(citations), [citations]);
 
-  return (
+  // Portal to document.body so the fixed panel escapes the MessageList
+  // scroll container — some browsers (notably iOS Safari) confine
+  // position: fixed descendants to their scrolling ancestor, which
+  // would let the composer (z-index 1050) paint over the panel.
+  return createPortal(
     <div className={styles.sourcesPanel} ref={panelRef}>
       <div className={styles.sourcesPanelHeader}>
         <span className={styles.sourcesPanelTitle}>Sources</span>
@@ -6027,7 +6034,8 @@ function SourcesSidePanel({ citations, onClose, panelRef }) {
           );
         })}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 


### PR DESCRIPTION
## Summary
Even after raising `.sourcesPanel` and `.subConvPanel` to z-index 1150 (#377, #378), the composer still painted over them on mobile. Root cause: both panels are rendered inside `.messageList`, which is an `overflow: auto` scroll container. **iOS Safari (and some other engines) confine `position: fixed` descendants to their scrolling ancestor instead of the viewport**, so the panel's z-index was actually compared inside `.messageList`'s local stacking context — where the composer (root z-index 1050) outranks it.

Render both panels through React portals targeted at `document.body` so they escape every ancestor stacking + scroll context. `CodeSidePanel` already does this; this brings the other two in line.

## Test plan
- [ ] **Mobile (iOS Safari)**: open sources panel from a chat with citations. Panel covers the composer; close X is reachable.
- [ ] Mobile: open a sub-conversation. Panel covers the composer.
- [ ] Mobile: open the sidebar while either panel is open — sidebar still wins (overlay 1180 > panel 1150).
- [ ] Desktop: no regression — panels still render in the correct spot.

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_