### PR TITLE
Logo navigates home; center breadcrumb title

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -185,6 +185,9 @@
 .breadcrumbTitle {
   font-size: 13px;
   font-weight: 500;
+  /* Drop the natural font line-box padding so the text optically
+     centers within the breadcrumb button alongside the chevron icon. */
+  line-height: 1;
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -609,10 +609,18 @@ export default function Sidebar() {
         <div className={styles.header}>
           <div className={styles.logo}>
             {showFullContent ? (
-              <>
-                <div className={styles.logoIcon}>A</div>
+              <button
+                type="button"
+                className={styles.logoHomeBtn}
+                onClick={() => {
+                  navigate('/');
+                  if (isMobile) handleCloseSidebar();
+                }}
+                aria-label="Go to home"
+              >
+                <span className={styles.logoIcon}>A</span>
                 <span className={styles.logoText}>Araviel</span>
-              </>
+              </button>
             ) : (
               <button
                 className={styles.logoExpandBtn}

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -139,6 +139,23 @@
   gap: 10px;
 }
 
+/* Clickable wrapper around logoIcon + logoText that navigates home. */
+.logoHomeBtn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  border-radius: 10px;
+}
+
+.logoHomeBtn:hover .logoIcon {
+  transform: scale(1.02);
+}
+
 .collapsed .logo {
   justify-content: center;
 }


### PR DESCRIPTION
## Summary
- **Sidebar logo navigates home.** Wrapped the "A" + "Araviel" sidebar header in a button. Clicking it calls `navigate('/')` and closes the sidebar on mobile so the home view is actually visible after the click. Visual is unchanged.
- **Breadcrumb title vertical centering.** Added `line-height: 1` to `.breadcrumbTitle` so the conversation title optically centers next to the chevron icon — the natural font line-box padding was pushing it slightly above center.

## Test plan
- [ ] Click the "Araviel" logo in the sidebar (desktop & mobile) — app navigates to `/`.
- [ ] On mobile, the sidebar closes after clicking the logo.
- [ ] In a chat, the breadcrumb title (e.g. "Bank holida...") sits vertically centered alongside the dropdown chevron.

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_