### PR TITLE
Tighten chat bottom gap and widen content to match Claude

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -1407,9 +1407,9 @@
 
 /* When in chat mode, input sticks to bottom */
 .containerBottom {
-  max-width: 768px;
+  max-width: 800px;
   margin: 0 auto;
-  padding: 0 24px calc(24px + var(--safe-area-bottom));
+  padding: 0 24px calc(12px + var(--safe-area-bottom));
   flex-shrink: 0;
 }
 
@@ -2846,7 +2846,7 @@
   }
 
   .containerBottom {
-    padding: 0 16px calc(16px + var(--safe-area-bottom));
+    padding: 0 16px calc(10px + var(--safe-area-bottom));
   }
 
   .greeting {

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -33,7 +33,7 @@
 }
 
 .messagesInner {
-  max-width: 720px;
+  max-width: 800px;
   margin: 0 auto;
   padding: 0 24px;
   padding-top: 32px;


### PR DESCRIPTION
- Reduce containerBottom bottom padding from 24px to 12px (mobile 16px to 10px) so the gap below the disclaimer is sleeker.
- Widen messagesInner and containerBottom max-width to 800px so chat content and input box match Claude's roomier layout, with the two widths aligned to each other.