### PR TITLE
feat(web): show history-cap banner when conversation is summarized

### DIFF
--- a/src/components/MainContent/HistoryNoticeBanner.jsx
+++ b/src/components/MainContent/HistoryNoticeBanner.jsx
@@ -1,0 +1,67 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { createNewChat, selectHistoryState } from '../../store/slices/chatSlice';
+import styles from './HistoryNoticeBanner.module.css';
+
+/**
+ * HistoryNoticeBanner — Inline notice rendered directly above the
+ * message input box when the current conversation is long enough that
+ * the backend is either about to summarize older messages or has
+ * already done so. Mirrors the placement of the guest "out of usage"
+ * banner so users encounter context-related prompts in a consistent
+ * spot.
+ *
+ * Two states, driven by `chatSlice.historyState` (populated by the
+ * routing SSE event and conversation GET):
+ *  1. approachingLimit (not yet summarized)  — soft warning.
+ *  2. summarized                              — firm notice + CTA to
+ *                                              start a new conversation.
+ *
+ * When both flags are true the summarized state wins, since once a
+ * summary exists the approaching-limit warning is moot.
+ */
+export default function HistoryNoticeBanner() {
+  const dispatch = useDispatch();
+  const historyState = useSelector(selectHistoryState);
+
+  const handleStartNew = useCallback(() => {
+    dispatch(createNewChat());
+  }, [dispatch]);
+
+  if (!historyState) return null;
+
+  const { summarized, approachingLimit } = historyState;
+  if (!summarized && !approachingLimit) return null;
+
+  if (summarized) {
+    return (
+      <div className={styles.banner} role="status" data-variant="summarized">
+        <div className={styles.text}>
+          <strong>Earlier messages have been summarized.</strong>
+          <span>
+            Long conversations may lose some detail over time. Start a new conversation for the best
+            context.
+          </span>
+        </div>
+        <button type="button" className={styles.action} onClick={handleStartNew}>
+          Start new chat
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.banner} role="status" data-variant="approaching">
+      <div className={styles.text}>
+        <strong>This conversation is getting long.</strong>
+        <span>
+          Older messages will soon be summarized to fit the context window. Consider starting a new
+          conversation.
+        </span>
+      </div>
+      <button type="button" className={styles.action} onClick={handleStartNew}>
+        Start new chat
+      </button>
+    </div>
+  );
+}

--- a/src/components/MainContent/HistoryNoticeBanner.module.css
+++ b/src/components/MainContent/HistoryNoticeBanner.module.css
@@ -1,0 +1,71 @@
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+  padding: 10px 14px;
+  margin-bottom: 8px;
+  background-color: var(--bg-input);
+  border: 1px solid var(--border-input);
+  border-radius: 12px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.banner[data-variant='summarized'] {
+  border-color: var(--text-muted);
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.text strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.text span {
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.action {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  background-color: transparent;
+  border: 1px solid var(--border-input);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.action:hover {
+  background-color: var(--bg-hover, rgba(127, 127, 127, 0.08));
+  border-color: var(--text-muted);
+}
+
+.action:focus-visible {
+  outline: 2px solid var(--text-muted);
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .banner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .action {
+    align-self: stretch;
+  }
+}

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -47,6 +47,7 @@ import {
   setCreditBalance,
   setSelectedModality,
   revertQuickPromptImageOverride,
+  setHistoryState,
 } from '../../store/slices/chatSlice';
 import { recordMessage } from '../../store/slices/analyticsSlice';
 import {
@@ -104,6 +105,7 @@ import {
 import ModelSelector from '../ModelSelector/ModelSelector';
 import MessageList from '../MessageList/MessageList';
 import MarkdownTextarea from '../MarkdownTextarea/MarkdownTextarea';
+import HistoryNoticeBanner from './HistoryNoticeBanner';
 import {
   sendMessage,
   consumeSSEStream,
@@ -1099,18 +1101,26 @@ export default function MainContent() {
   useEffect(() => {
     if (!currentChatId) {
       setConversationTitle('');
+      // No active conversation → clear rolling-summary banner state so
+      // it doesn't carry over from the previous chat.
+      dispatch(setHistoryState(null));
       return;
     }
     let cancelled = false;
     fetchConversation(currentChatId)
       .then((conv) => {
-        if (!cancelled) setConversationTitle(conv.title || 'Untitled');
+        if (cancelled) return;
+        setConversationTitle(conv.title || 'Untitled');
+        // Seed banner state on page refresh — the routing event would
+        // otherwise be the only source, leaving the banner missing
+        // until the user sends the next message.
+        dispatch(setHistoryState(conv.history ?? null));
       })
       .catch(() => {});
     return () => {
       cancelled = true;
     };
-  }, [currentChatId]);
+  }, [currentChatId, dispatch]);
 
   // Fetch credit balance on mount and when modality switches to image (authenticated users only)
   useEffect(() => {
@@ -1563,6 +1573,12 @@ export default function MainContent() {
 
             if (type === 'routing') {
               const routingDuration = ((Date.now() - routingStart) / 1000).toFixed(1);
+
+              // Rolling-summary state for the active conversation —
+              // drives the HistoryNoticeBanner above the input box.
+              // Null for sub-conversations and for any older backend
+              // that doesn't send the field.
+              dispatch(setHistoryState(data.history ?? null));
 
               // Save the conversationId from backend (may be newly created)
               if (data.conversationId) {
@@ -3168,6 +3184,7 @@ export default function MainContent() {
         )}
 
         <div className={styles.inputSection}>
+          <HistoryNoticeBanner />
           <form className={styles.inputContainer} onSubmit={handleSubmit}>
             <div className={styles.inputWrapper}>
               {attachedFiles.length > 0 && (

--- a/src/store/slices/chatSlice.js
+++ b/src/store/slices/chatSlice.js
@@ -47,6 +47,17 @@ const initialState = {
   conversations: [],
   conversationsTotal: 0,
   conversationsLoading: false,
+  // Rolling-summary state for the active conversation. Mirrors the
+  // backend `history` object on the routing SSE event and the
+  // conversation GET response. Drives the HistoryNoticeBanner above
+  // the input box so the user knows older context has been summarized
+  // (or is about to be) and they may want to start a new conversation.
+  //
+  // Shape:
+  //   { summarized: boolean, approachingLimit: boolean,
+  //     summarizedMessageCount: number, recentMessageCount: number }
+  //   | null  // sub-conversations and pre-fetch state
+  historyState: null,
 };
 
 const chatSlice = createSlice({
@@ -134,6 +145,10 @@ const chatSlice = createSlice({
       state.quickPromptImageOverride = null;
       state.activeProjectId = null;
       state.importedContext = null;
+      state.historyState = null;
+    },
+    setHistoryState: (state, action) => {
+      state.historyState = action.payload ?? null;
     },
     setActiveProjectId: (state, action) => {
       state.activeProjectId = action.payload;
@@ -264,6 +279,7 @@ export const {
   appendConversations,
   setConversationsLoading,
   updateConversationTitle,
+  setHistoryState,
   resetChatState,
 } = chatSlice.actions;
 
@@ -291,5 +307,6 @@ export const selectConversations = (state) => state.chat.conversations;
 export const selectConversationsTotal = (state) => state.chat.conversationsTotal;
 export const selectConversationsLoading = (state) => state.chat.conversationsLoading;
 export const selectImportedContext = (state) => state.chat.importedContext;
+export const selectHistoryState = (state) => state.chat.historyState;
 
 export default chatSlice.reducer;


### PR DESCRIPTION
When the backend reports a long conversation via the routing SSE event (or the conversation GET on page refresh), render a notice banner directly above the input box — the same slot used for guest out-of-usage prompts — so the user understands that older messages have been summarized and they may want to start a new conversation to keep full-fidelity context. Two states: a soft "approaching" warning before summarization, and a firm "summarized" notice with a Start-new-chat CTA after.