### PR TITLE
Re-apply: hydrate subscription tier on session restore + token refresh

### DIFF
--- a/src/hooks/useAuthListener.js
+++ b/src/hooks/useAuthListener.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { supabase } from '../lib/supabase';
 import { initializeAuth, setAuth, clearAuth, signOut, updateBirthDate } from '../store/slices/authSlice';
@@ -6,15 +6,14 @@ import { resetChatState, setCreditBalance } from '../store/slices/chatSlice';
 import { resetProjectsState } from '../store/slices/projectsSlice';
 import {
   resetSubscriptionState,
-  setSubscriptionData,
   setImageCredits,
+  fetchSubscriptionThunk,
 } from '../store/slices/subscriptionSlice';
 import { resetGuestPromptCount } from '../utils/guestSession';
 import { fetchCreditBalance } from '../services/credits';
-import { fetchSubscription } from '../services/subscription';
 import { fetchGoogleBirthday } from '../services/googleBirthday';
 import { clearImageCache } from '../services/imageGeneration';
-import { setLoggerUser } from '../lib/logger';
+import { setLoggerUser, logger } from '../lib/logger';
 import { isAgeAllowed, MIN_AGE } from '../utils/age';
 
 // ---------------------------------------------------------------------------
@@ -55,16 +54,128 @@ const USER_STORAGE_KEYS = [
 ];
 
 // ---------------------------------------------------------------------------
+// Refresh-policy constants
+// ---------------------------------------------------------------------------
+
+// Supabase fires TOKEN_REFRESHED every ~50 min, but it can also fire back-to-back
+// (focus + scheduled refresh, multi-tab broadcast). We piggyback subscription
+// refreshes on it to recover from any earlier silent fetch failure, but throttle
+// so a rapid sequence of refresh events doesn't storm /api/subscription.
+const TOKEN_REFRESH_THROTTLE_MS = 30_000;
+
+// When the tab regains focus after being hidden for longer than this, refresh
+// the tier. Catches the "user upgraded via Stripe portal in another tab" case
+// without polling. Short hides (alt-tab, system notification) are ignored.
+const VISIBILITY_REFRESH_THRESHOLD_MS = 60_000;
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
 /**
  * Side-effect hook that initialises auth state and keeps it in sync with
  * Supabase auth events. Call this once near the root of the component tree.
+ *
+ * Subscription tier is hydrated from the server on every auth event that
+ * could represent a state change:
+ *   - SIGNED_IN          — first authentication of a session
+ *   - INITIAL_SESSION    — page reload / new tab restoring an existing session
+ *   - TOKEN_REFRESHED    — periodic refresh; covers recovery from earlier
+ *                          silent fetch failures (throttled)
+ *
+ * Plus a visibilitychange handler that refetches after a long hide, so
+ * out-of-band Stripe updates land without requiring a manual reload.
  */
 export default function useAuthListener() {
   const dispatch = useDispatch();
 
+  // Refs survive across event firings without triggering re-runs of the
+  // effect. They're the single source of truth for refresh policy:
+  //   - subscriptionInFlightRef: dedupes concurrent fetches.
+  //   - lastSubscriptionFetchAtRef: throttles TOKEN_REFRESHED.
+  //   - hiddenSinceRef: tracks how long the tab was backgrounded.
+  //   - realUserSignedInRef: gates background refreshes off when the
+  //     current session is anonymous or signed out.
+  const subscriptionInFlightRef = useRef(false);
+  const lastSubscriptionFetchAtRef = useRef(0);
+  const hiddenSinceRef = useRef(0);
+  const realUserSignedInRef = useRef(false);
+
+  const refreshSubscription = useCallback(
+    (reason) => {
+      if (!realUserSignedInRef.current) return;
+      if (subscriptionInFlightRef.current) return;
+      subscriptionInFlightRef.current = true;
+      dispatch(fetchSubscriptionThunk())
+        .unwrap()
+        .then(() => {
+          lastSubscriptionFetchAtRef.current = Date.now();
+        })
+        .catch((err) => {
+          // Reject value from createAsyncThunk is the message string we
+          // passed to rejectWithValue, not an Error — wrap it so the
+          // logger captures a useful record.
+          logger.error(
+            'Failed to refresh subscription tier',
+            err instanceof Error ? err : new Error(String(err ?? 'unknown')),
+            { reason }
+          );
+        })
+        .finally(() => {
+          subscriptionInFlightRef.current = false;
+        });
+    },
+    [dispatch]
+  );
+
+  const refreshCreditBalance = useCallback(
+    (reason) => {
+      fetchCreditBalance()
+        .then((data) => {
+          if (!data?.balance) return;
+          dispatch(setCreditBalance(data.balance));
+          dispatch(
+            setImageCredits({
+              used: data.balance.monthly?.used ?? 0,
+              limit: data.balance.monthly?.total ?? 5,
+              remaining: data.balance.monthly?.remaining ?? 0,
+              packRemaining: data.balance.packs?.remaining ?? 0,
+              cycleResetsAt: data.balance.cycleResetsAt ?? null,
+            })
+          );
+        })
+        .catch((err) => {
+          logger.warn('Failed to refresh credit balance', {
+            reason,
+            error: err?.message,
+          });
+        });
+    },
+    [dispatch]
+  );
+
+  // ── Visibility refresh ────────────────────────────────────────────────────
+  // Refresh tier (and credits) when the tab becomes visible again after a
+  // long hide. The short-hide guard prevents storms from alt-tabbing.
+  useEffect(() => {
+    if (typeof document === 'undefined') return undefined;
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        const hiddenAt = hiddenSinceRef.current;
+        hiddenSinceRef.current = 0;
+        if (hiddenAt > 0 && Date.now() - hiddenAt > VISIBILITY_REFRESH_THRESHOLD_MS) {
+          refreshSubscription('visibility_change');
+          refreshCreditBalance('visibility_change');
+        }
+      } else {
+        hiddenSinceRef.current = Date.now();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [refreshSubscription, refreshCreditBalance]);
+
+  // ── Auth listener ─────────────────────────────────────────────────────────
   useEffect(() => {
     // 1. Kick off the initial session check
     dispatch(initializeAuth());
@@ -75,18 +186,26 @@ export default function useAuthListener() {
     } = supabase.auth.onAuthStateChange((event, session) => {
       switch (event) {
         case 'SIGNED_IN':
+        case 'INITIAL_SESSION':
         case 'TOKEN_REFRESHED':
         case 'USER_UPDATED': {
           const user = mapUser(session?.user);
           setLoggerUser(user?.id || null);
-          dispatch(
-            setAuth({
-              user,
-              session: mapSession(session),
-            })
-          );
-          // On real (non-anonymous) sign-in, sync tier/credits from backend
-          if (event === 'SIGNED_IN' && user && !user.isAnonymous) {
+
+          // INITIAL_SESSION can fire with session=null when there's no
+          // active session yet — in that case initializeAuth() is still
+          // running and will populate the slice (real or anonymous).
+          // Dispatching setAuth({ user: null }) here would wipe that work.
+          if (user && session) {
+            dispatch(setAuth({ user, session: mapSession(session) }));
+          }
+
+          const isRealUser = !!(user && !user.isAnonymous);
+          realUserSignedInRef.current = isRealUser;
+
+          // One-time side effects that only run on a true sign-in event
+          // (not on page reloads or token refreshes).
+          if (event === 'SIGNED_IN' && isRealUser) {
             resetGuestPromptCount();
 
             // Google sign-in only: try to lift the user's date of birth from
@@ -135,48 +254,47 @@ export default function useAuthListener() {
                 })
                 .catch(() => {});
             }
+          }
 
-            fetchCreditBalance()
-              .then((data) => {
-                if (data.balance) {
-                  dispatch(setCreditBalance(data.balance));
-                  dispatch(
-                    setImageCredits({
-                      used: data.balance.monthly?.used ?? 0,
-                      limit: data.balance.monthly?.total ?? 5,
-                      remaining: data.balance.monthly?.remaining ?? 0,
-                      packRemaining: data.balance.packs?.remaining ?? 0,
-                      cycleResetsAt: data.balance.cycleResetsAt ?? null,
-                    })
-                  );
-                }
-              })
-              .catch(() => {});
-            // Hydrate subscription state from server
-            fetchSubscription()
-              .then((data) => {
-                dispatch(setSubscriptionData(data));
-              })
-              .catch(() => {});
+          // Hydrate tier + credits on every auth event that could reflect
+          // a real change. INITIAL_SESSION is the critical one — without it
+          // a page reload leaves the slice at its 'free' initialState until
+          // the user happens to visit /subscription.
+          if (isRealUser) {
+            if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION') {
+              refreshSubscription(event.toLowerCase());
+              refreshCreditBalance(event.toLowerCase());
+            } else if (event === 'TOKEN_REFRESHED') {
+              const since = Date.now() - lastSubscriptionFetchAtRef.current;
+              if (since > TOKEN_REFRESH_THROTTLE_MS) {
+                refreshSubscription('token_refreshed');
+              }
+            }
+            // USER_UPDATED carries metadata changes (display name, etc.) and
+            // doesn't affect tier or credits — no refresh needed.
           }
           break;
         }
         case 'SIGNED_OUT': {
-          // 1. Reset guest prompt counters and clear image cache
+          // 1. Reset refs so background refreshes stop firing
+          realUserSignedInRef.current = false;
+          lastSubscriptionFetchAtRef.current = 0;
+
+          // 2. Reset guest prompt counters and clear image cache
           setLoggerUser(null);
           resetGuestPromptCount();
           clearImageCache();
 
-          // 2. Clear user-specific localStorage
+          // 3. Clear user-specific localStorage
           USER_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
 
-          // 3. Reset all Redux slices
+          // 4. Reset all Redux slices
           dispatch(clearAuth());
           dispatch(resetChatState());
           dispatch(resetProjectsState());
           dispatch(resetSubscriptionState());
 
-          // 4. Re-create anonymous session so guest flow works
+          // 5. Re-create anonymous session so guest flow works
           dispatch(initializeAuth());
           break;
         }
@@ -189,5 +307,5 @@ export default function useAuthListener() {
     return () => {
       subscription.unsubscribe();
     };
-  }, [dispatch]);
+  }, [dispatch, refreshSubscription, refreshCreditBalance]);
 }

--- a/src/services/subscription.js
+++ b/src/services/subscription.js
@@ -4,15 +4,43 @@ const API_BASE =
   import.meta.env.VITE_ARAVIEL_API_BASE ||
   (import.meta.env.DEV ? '' : 'https://araviel-api.vercel.app');
 
-/**
- * Fetch the current user's subscription and daily credit status.
- * @returns {Promise<{ tier, status, billingInterval, credits: { used, limit, bonus }, periodEnd, cancelAtPeriodEnd, firstMonth }>}
- */
-export async function fetchSubscription() {
+const SUBSCRIPTION_RETRY_DELAY_MS = 500;
+
+async function fetchSubscriptionOnce() {
   const headers = await getAuthHeaders();
   const res = await fetch(`${API_BASE}/api/subscription`, { headers });
-  if (!res.ok) throw new Error(`Failed to fetch subscription: ${res.status}`);
+  if (!res.ok) {
+    const err = new Error(`Failed to fetch subscription: ${res.status}`);
+    err.status = res.status;
+    throw err;
+  }
   return res.json();
+}
+
+/**
+ * Fetch the current user's subscription and daily credit status.
+ *
+ * Transient failures (network errors, 5xx, 408, 429) are retried once after
+ * a short delay. Client-class failures (401/403/404 and other 4xx) surface
+ * immediately — retrying won't change a permanent rejection, and masking a
+ * 401 as transient would hide token problems from the caller.
+ *
+ * @returns {Promise<{ tier, status, billingInterval, periodEnd, cancelAtPeriodEnd, firstMonth, textCredits, imageCredits }>}
+ */
+export async function fetchSubscription() {
+  try {
+    return await fetchSubscriptionOnce();
+  } catch (err) {
+    const status = err?.status;
+    const isTransient =
+      status === undefined ||
+      status === 408 ||
+      status === 429 ||
+      status >= 500;
+    if (!isTransient) throw err;
+    await new Promise((resolve) => setTimeout(resolve, SUBSCRIPTION_RETRY_DELAY_MS));
+    return fetchSubscriptionOnce();
+  }
 }
 
 /**

--- a/src/services/subscription.test.js
+++ b/src/services/subscription.test.js
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./authHeaders', () => ({
+  getAuthHeaders: vi.fn().mockResolvedValue({
+    'Content-Type': 'application/json',
+    Authorization: 'Bearer test-token',
+  }),
+}));
+
+import { fetchSubscription } from './subscription';
+
+/** Build a minimal Response-shaped mock for fetch. */
+function mockResponse(status, body = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+describe('subscription service', () => {
+  let fetchSpy;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('fetchSubscription', () => {
+    it('returns parsed JSON on first-attempt success', async () => {
+      fetchSpy.mockResolvedValue(mockResponse(200, { tier: 'pro' }));
+
+      const result = await fetchSubscription();
+
+      expect(result).toEqual({ tier: 'pro' });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries once after a 500 and returns the second attempt', async () => {
+      fetchSpy
+        .mockResolvedValueOnce(mockResponse(500))
+        .mockResolvedValueOnce(mockResponse(200, { tier: 'pro' }));
+
+      const promise = fetchSubscription();
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(promise).resolves.toEqual({ tier: 'pro' });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries once after a 429', async () => {
+      fetchSpy
+        .mockResolvedValueOnce(mockResponse(429))
+        .mockResolvedValueOnce(mockResponse(200, { tier: 'lite' }));
+
+      const promise = fetchSubscription();
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(promise).resolves.toEqual({ tier: 'lite' });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries once after a 408', async () => {
+      fetchSpy
+        .mockResolvedValueOnce(mockResponse(408))
+        .mockResolvedValueOnce(mockResponse(200, { tier: 'pro' }));
+
+      const promise = fetchSubscription();
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(promise).resolves.toEqual({ tier: 'pro' });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries once after a network error', async () => {
+      fetchSpy
+        .mockRejectedValueOnce(new TypeError('Network error'))
+        .mockResolvedValueOnce(mockResponse(200, { tier: 'pro' }));
+
+      const promise = fetchSubscription();
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(promise).resolves.toEqual({ tier: 'pro' });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT retry on 401 — surfaces auth errors immediately', async () => {
+      fetchSpy.mockResolvedValue(mockResponse(401));
+
+      await expect(fetchSubscription()).rejects.toThrow(/401/);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry on 403', async () => {
+      fetchSpy.mockResolvedValue(mockResponse(403));
+
+      await expect(fetchSubscription()).rejects.toThrow(/403/);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry on 404', async () => {
+      fetchSpy.mockResolvedValue(mockResponse(404));
+
+      await expect(fetchSubscription()).rejects.toThrow(/404/);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws after both attempts fail with 5xx', async () => {
+      fetchSpy.mockResolvedValue(mockResponse(503));
+
+      const promise = fetchSubscription();
+      // Pre-attach a noop handler so the rejection isn't reported as
+      // unhandled while we advance the fake-timer delay between attempts.
+      promise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(promise).rejects.toThrow(/503/);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('attaches status code to the thrown error', async () => {
+      fetchSpy.mockResolvedValue(mockResponse(401));
+
+      try {
+        await fetchSubscription();
+        throw new Error('expected fetchSubscription to throw');
+      } catch (err) {
+        expect(err.status).toBe(401);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Re-applies the listener fix from #384 after #385 rolled it back for testing. The diff is identical to #384.

## Why re-land

The conversations/projects load errors that prompted the rollback have been verified as **unrelated to this change** — they reproduce on the reverted state too. The tier-loading bugs the listener fix addresses are real and currently affecting production:

1. After a page reload or session restore, `INITIAL_SESSION` fires but the listener's switch falls through to `default`, so tier stays at the `"free"` initialState until the user opens `/subscription`.
2. After token refresh, `TOKEN_REFRESHED` updates auth state but never refetches subscription, so any earlier silent fetch failure goes unrecovered.
3. Cross-tab Stripe portal changes don't reach the original tab until manual refresh.

## What this re-introduces (identical to #384)

- `useAuthListener.js` — refetch subscription on `SIGNED_IN`, `INITIAL_SESSION`, and `TOKEN_REFRESHED` (throttled to 30s) for real users. Visibility-change handler refetches tier + credits when the tab returns to focus after > 60s hidden. In-flight dedup via ref. Failures route through `logger.error` instead of silent `.catch(() => {})`.
- `subscription.js` — one transient-error retry with 500ms back-off for network errors, 5xx, 408, 429. Auth-class failures (401/403/404) surface immediately. Status code attached to thrown errors.
- `subscription.test.js` — 10 tests covering the retry policy.

## Verification

- `npm run test`: **542/543 passing**. The one failure (`authSlice.test.js > signUpWithEmail.fulfilled`) is pre-existing on `main` and predates both #384 and this PR.
- `npm run build`: clean.
- Conversations/projects loading is untouched.

## Follow-ups (out of scope)

- Diagnose the "Couldn't load your conversations / projects" toasts independently — needs the real status code from the network tab; the catch block at `Sidebar.jsx:208` swallows the error and shows a generic message.
- Per-component gating on `subscriptionStatus` to fully satisfy AC1 (no "free" flash during initial fetch).
- Longer-term: the JWT custom-claim approach (Option A) to eliminate the fetch race entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_013uu2ct2NpawdTfYrTWgtJH)_