### PR TITLE
fix(web): swap message identity on PROVIDER_RETRY so badge matches ac…

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -1517,6 +1517,7 @@ export default function MainContent() {
       let receivedDone = false;
       let routeInfo = null;
       let assistantMessageId = null;
+      let currentAlternates = [];
 
       try {
         const webSearchParam =
@@ -1609,6 +1610,7 @@ export default function MainContent() {
                 score: m.score,
                 reasoning: m.reasoning,
               }));
+              currentAlternates = alternates;
 
               // Add empty assistant message
               assistantMessageId = data.messageId || `assistant-${Date.now()}`;
@@ -1751,9 +1753,28 @@ export default function MainContent() {
             } else if (type === 'done') {
               receivedDone = true;
               const totalDuration = ((Date.now() - routingStart) / 1000).toFixed(1);
+              // Authoritative final model from the backend. Reaffirms the
+              // identity already swapped on PROVIDER_RETRY, and corrects any
+              // edge case where a fallback path didn't emit one.
+              if (data.model && data.model.id) {
+                routeInfo = {
+                  modelId: data.model.id,
+                  modelName: data.model.name,
+                  provider: data.model.provider,
+                };
+              }
               if (assistantMsgAdded) {
                 dispatch(
                   updateLastMessage({
+                    ...(data.model && data.model.id
+                      ? {
+                          modelId: data.model.id,
+                          modelName: data.model.name,
+                          provider: data.model.provider,
+                          score: data.model.score,
+                          reasoning: data.model.reasoning,
+                        }
+                      : {}),
                     usage: data.usage,
                     costUsd: data.usage?.costUsd,
                     latencyMs: data.latencyMs,
@@ -1812,10 +1833,53 @@ export default function MainContent() {
               window.dispatchEvent(new CustomEvent('araviel-conversation-updated'));
             } else if (type === 'error') {
               if (data.code === 'PROVIDER_RETRY') {
-                // Non-fatal — show a brief notification but keep listening
+                // Backup is producing the authoritative response — abandon any
+                // partial primary output and swap the message identity over so
+                // the badge, analytics, and alternates list all reflect the
+                // backup that actually responded.
+                accumulatedContent = '';
+                accumulatedThinking = '';
+                accumulatedImages = null;
+                setStreamedText('');
+
                 if (assistantMsgAdded) {
+                  const prevPrimary = routeInfo;
+                  const demotedPrimary =
+                    prevPrimary && prevPrimary.modelId
+                      ? {
+                          modelId: prevPrimary.modelId,
+                          modelName: prevPrimary.modelName,
+                          provider: prevPrimary.provider,
+                        }
+                      : null;
+                  const filteredAlternates = (currentAlternates || []).filter(
+                    (m) => m.modelId !== data.toModelId
+                  );
+                  const nextAlternates = demotedPrimary
+                    ? [demotedPrimary, ...filteredAlternates]
+                    : filteredAlternates;
+
+                  currentAlternates = nextAlternates;
+                  routeInfo = {
+                    modelId: data.toModelId,
+                    modelName: data.toModel || 'Unknown',
+                    provider: data.toProvider,
+                  };
+
                   dispatch(
                     updateLastMessage({
+                      content: '',
+                      thinkingContent: '',
+                      citations: null,
+                      toolUse: null,
+                      webSearchUsed: false,
+                      modelId: data.toModelId,
+                      modelName: data.toModel || 'Unknown',
+                      provider: data.toProvider,
+                      score: data.toScore,
+                      reasoning: data.toReasoning || 'Selected after primary model failed',
+                      isManualSelection: false,
+                      alternateModels: nextAlternates,
                       providerRetry: {
                         fromModel: data.fromModel || 'Unknown',
                         toModel: data.toModel || 'Unknown',

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -5532,8 +5532,31 @@ function Message({
               costUsd: data.costUsd,
               latencyMs: data.latencyMs,
             };
+            // Authoritative final model — reaffirms identity already swapped
+            // on PROVIDER_RETRY, and corrects edge cases on fallback paths.
+            if (data.model && data.model.id) {
+              routingInfo = {
+                ...routingInfo,
+                modelName: data.model.name,
+                modelId: data.model.id,
+                provider: data.model.provider,
+              };
+            }
           } else if (type === 'error') {
-            if (data.code !== 'PROVIDER_RETRY') {
+            if (data.code === 'PROVIDER_RETRY') {
+              // Backup is now producing the response — drop primary's partial
+              // output and swap routingInfo so the finalized message records
+              // the model that actually responded.
+              accumulatedContent = '';
+              setSubConvStreamText('');
+              citationSources = null;
+              routingInfo = {
+                ...routingInfo,
+                modelName: data.toModel || routingInfo.modelName,
+                modelId: data.toModelId || routingInfo.modelId,
+                provider: data.toProvider || routingInfo.provider,
+              };
+            } else {
               accumulatedContent += `\n\n*Error: ${data.message}*`;
               setSubConvStreamText(accumulatedContent);
             }


### PR DESCRIPTION
…tual responder

When the backend retried with a backup model, the UI announced "primary → backup" via the PROVIDER_RETRY banner but the message badge kept showing the failed primary, and any partial primary content stayed in the rendered response (gets appended-to by the backup's stream). To users this looked like the switch never actually happened — the announcement contradicted what they saw right below it.

This commit makes the PROVIDER_RETRY handler treat the event as a "swap to backup identity" transaction:
- Resets accumulators (content, thinking, images, streamed text) so abandoned primary output doesn't bleed into the backup's response.
- Swaps modelId/modelName/provider/score/reasoning over to the backup so the "Responded with" badge reflects reality.
- Demotes the failed primary into the alternateModels list and removes the now-active backup from it, so the "Try another model" dropdown stays coherent.
- Clears stale citations/toolUse/webSearchUsed left over from the primary's partial attempt.
- Flips isManualSelection to false since a fallback is no longer the user's manual choice.
- Updates routeInfo so the analytics event fired on `done` records the model that actually responded, not the one that failed.

Also uses the new authoritative `model` field on the `done` SSE as a belt-and-suspenders confirmation of identity, covering any future fallback path that doesn't emit PROVIDER_RETRY.

The same pattern is applied to the sub-conversation stream handler in MessageList.jsx, which had the same bug.