### PR TITLE
feat(weather): premium glassmorphic weather card with animated effects

### DIFF
--- a/src/components/WeatherCard/WeatherCard.jsx
+++ b/src/components/WeatherCard/WeatherCard.jsx
@@ -2,140 +2,214 @@ import { useMemo } from 'react';
 import { mapConditionToTheme } from './weatherParser';
 import styles from './WeatherCard.module.css';
 
-// ── Weather Icons (inline SVGs — white strokes for immersive backgrounds) ──
+/* ─────────────────────────────────────────────────────────────────
+   Premium weather icons — gradient-rich SVGs, color-aware
+   ───────────────────────────────────────────────────────────────── */
 
-function SunIcon({ size = 32 }) {
+function SunIcon({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
-      <circle cx="16" cy="16" r="6" fill="#FBBF24" />
-      <g stroke="#FBBF24" strokeWidth="2" strokeLinecap="round">
-        <line x1="16" y1="2" x2="16" y2="6" />
-        <line x1="16" y1="26" x2="16" y2="30" />
-        <line x1="2" y1="16" x2="6" y2="16" />
-        <line x1="26" y1="16" x2="30" y2="16" />
-        <line x1="6.1" y1="6.1" x2="8.9" y2="8.9" />
-        <line x1="23.1" y1="23.1" x2="25.9" y2="25.9" />
-        <line x1="6.1" y1="25.9" x2="8.9" y2="23.1" />
-        <line x1="23.1" y1="8.9" x2="25.9" y2="6.1" />
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden="true">
+      <defs>
+        <radialGradient id="wc-sun-core" cx="50%" cy="45%" r="55%">
+          <stop offset="0%" stopColor="#FFE08A" />
+          <stop offset="55%" stopColor="#FFB347" />
+          <stop offset="100%" stopColor="#FF8A1E" />
+        </radialGradient>
+        <radialGradient id="wc-sun-halo" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#FFD56B" stopOpacity="0.45" />
+          <stop offset="100%" stopColor="#FFD56B" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <circle cx="20" cy="20" r="16" fill="url(#wc-sun-halo)" />
+      <g stroke="#FFB347" strokeWidth="2" strokeLinecap="round" opacity="0.9">
+        <line x1="20" y1="3" x2="20" y2="7" />
+        <line x1="20" y1="33" x2="20" y2="37" />
+        <line x1="3" y1="20" x2="7" y2="20" />
+        <line x1="33" y1="20" x2="37" y2="20" />
+        <line x1="7.5" y1="7.5" x2="10.4" y2="10.4" />
+        <line x1="29.6" y1="29.6" x2="32.5" y2="32.5" />
+        <line x1="7.5" y1="32.5" x2="10.4" y2="29.6" />
+        <line x1="29.6" y1="10.4" x2="32.5" y2="7.5" />
       </g>
+      <circle cx="20" cy="20" r="8.5" fill="url(#wc-sun-core)" />
     </svg>
   );
 }
 
-function CloudIcon({ size = 32 }) {
+function CloudIcon({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden="true">
+      <defs>
+        <linearGradient id="wc-cloud-fill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.95" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.65" />
+        </linearGradient>
+      </defs>
       <path
-        d="M8 24h16a6 6 0 001.5-11.8A8 8 0 009.2 14 5 5 0 008 24z"
-        fill="rgba(255,255,255,0.7)"
+        d="M11 30h18a7 7 0 001.6-13.8 9 9 0 00-17.5-1.3A6 6 0 0011 30z"
+        fill="url(#wc-cloud-fill)"
       />
     </svg>
   );
 }
 
-function PartlyCloudyIcon({ size = 32 }) {
+function PartlyCloudyIcon({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
-      <circle cx="12" cy="14" r="5" fill="#FBBF24" />
-      <g stroke="#FBBF24" strokeWidth="1.5" strokeLinecap="round">
-        <line x1="12" y1="4" x2="12" y2="6.5" />
-        <line x1="12" y1="21.5" x2="12" y2="24" />
-        <line x1="4" y1="14" x2="6.5" y2="14" />
-        <line x1="5.3" y1="7.3" x2="7.1" y2="9.1" />
-        <line x1="5.3" y1="20.7" x2="7.1" y2="18.9" />
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden="true">
+      <defs>
+        <radialGradient id="wc-pc-sun" cx="50%" cy="45%" r="55%">
+          <stop offset="0%" stopColor="#FFE08A" />
+          <stop offset="60%" stopColor="#FFB347" />
+          <stop offset="100%" stopColor="#FF8A1E" />
+        </radialGradient>
+        <linearGradient id="wc-pc-cloud" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.95" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.6" />
+        </linearGradient>
+      </defs>
+      <g stroke="#FFB347" strokeWidth="1.6" strokeLinecap="round" opacity="0.85">
+        <line x1="15" y1="4" x2="15" y2="7" />
+        <line x1="5" y1="14" x2="8" y2="14" />
+        <line x1="7.5" y1="6.5" x2="9.6" y2="8.6" />
+        <line x1="22.5" y1="6.5" x2="20.4" y2="8.6" />
       </g>
+      <circle cx="15" cy="14" r="6.5" fill="url(#wc-pc-sun)" />
       <path
-        d="M12 26h14a5 5 0 001.2-9.8 6.5 6.5 0 00-12.5-1.2A4 4 0 0012 26z"
-        fill="rgba(255,255,255,0.65)"
+        d="M14 32h16a6.5 6.5 0 001.4-12.8 8 8 0 00-15.2 0A5 5 0 0014 32z"
+        fill="url(#wc-pc-cloud)"
       />
     </svg>
   );
 }
 
-function RainIcon({ size = 32 }) {
+function RainIcon({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden="true">
+      <defs>
+        <linearGradient id="wc-rain-cloud" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.9" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.55" />
+        </linearGradient>
+        <linearGradient id="wc-rain-drop" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#6CA9FF" stopOpacity="0.4" />
+          <stop offset="100%" stopColor="#3D7FFF" />
+        </linearGradient>
+      </defs>
       <path
-        d="M8 18h16a6 6 0 001.5-11.8A8 8 0 009.2 8 5 5 0 008 18z"
-        fill="rgba(255,255,255,0.6)"
+        d="M10 22h18a6.5 6.5 0 001.5-12.8 8.5 8.5 0 00-16 0A5.5 5.5 0 0010 22z"
+        fill="url(#wc-rain-cloud)"
       />
-      <g stroke="rgba(255,255,255,0.8)" strokeWidth="1.5" strokeLinecap="round">
-        <line x1="11" y1="21" x2="10" y2="25" />
-        <line x1="16" y1="21" x2="15" y2="27" />
-        <line x1="21" y1="21" x2="20" y2="25" />
+      <g stroke="url(#wc-rain-drop)" strokeWidth="2.2" strokeLinecap="round">
+        <line x1="14" y1="26" x2="12.5" y2="32" />
+        <line x1="20" y1="26" x2="18.5" y2="34" />
+        <line x1="26" y1="26" x2="24.5" y2="32" />
       </g>
     </svg>
   );
 }
 
-function HeavyRainIcon({ size = 32 }) {
+function HeavyRainIcon({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden="true">
+      <defs>
+        <linearGradient id="wc-hrain-cloud" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.95" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.5" />
+        </linearGradient>
+        <linearGradient id="wc-hrain-drop" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#6CA9FF" stopOpacity="0.4" />
+          <stop offset="100%" stopColor="#3D7FFF" />
+        </linearGradient>
+      </defs>
       <path
-        d="M8 16h16a6 6 0 001.5-11.8A8 8 0 009.2 6 5 5 0 008 16z"
-        fill="rgba(255,255,255,0.55)"
+        d="M10 20h18a6.5 6.5 0 001.5-12.8 8.5 8.5 0 00-16 0A5.5 5.5 0 0010 20z"
+        fill="url(#wc-hrain-cloud)"
       />
-      <g stroke="rgba(255,255,255,0.8)" strokeWidth="1.5" strokeLinecap="round">
-        <line x1="9" y1="19" x2="7" y2="26" />
-        <line x1="13" y1="19" x2="11" y2="28" />
-        <line x1="17" y1="19" x2="15" y2="26" />
-        <line x1="21" y1="19" x2="19" y2="28" />
-        <line x1="25" y1="19" x2="23" y2="26" />
+      <g stroke="url(#wc-hrain-drop)" strokeWidth="2" strokeLinecap="round">
+        <line x1="12" y1="24" x2="10" y2="33" />
+        <line x1="17" y1="24" x2="15" y2="35" />
+        <line x1="22" y1="24" x2="20" y2="33" />
+        <line x1="27" y1="24" x2="25" y2="35" />
+        <line x1="32" y1="24" x2="30" y2="33" />
       </g>
     </svg>
   );
 }
 
-function SnowIcon({ size = 32 }) {
+function SnowIcon({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden="true">
+      <defs>
+        <linearGradient id="wc-snow-cloud" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.92" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.55" />
+        </linearGradient>
+      </defs>
       <path
-        d="M8 18h16a6 6 0 001.5-11.8A8 8 0 009.2 8 5 5 0 008 18z"
-        fill="rgba(255,255,255,0.65)"
+        d="M10 22h18a6.5 6.5 0 001.5-12.8 8.5 8.5 0 00-16 0A5.5 5.5 0 0010 22z"
+        fill="url(#wc-snow-cloud)"
       />
-      <g fill="rgba(255,255,255,0.9)">
-        <circle cx="11" cy="23" r="1.5" />
-        <circle cx="16" cy="25" r="1.5" />
-        <circle cx="21" cy="22" r="1.5" />
-        <circle cx="14" cy="28" r="1.2" />
-        <circle cx="19" cy="28" r="1.2" />
+      <g fill="#E8F1FF" opacity="0.95">
+        <circle cx="13" cy="28" r="1.6" />
+        <circle cx="20" cy="30.5" r="1.6" />
+        <circle cx="27" cy="27.5" r="1.6" />
+        <circle cx="16" cy="34" r="1.3" />
+        <circle cx="24" cy="34" r="1.3" />
       </g>
     </svg>
   );
 }
 
-function StormIcon({ size = 32 }) {
+function StormIcon({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden="true">
+      <defs>
+        <linearGradient id="wc-storm-cloud" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.9" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0.45" />
+        </linearGradient>
+        <linearGradient id="wc-bolt" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#FFE57A" />
+          <stop offset="100%" stopColor="#FFB347" />
+        </linearGradient>
+      </defs>
       <path
-        d="M8 16h16a6 6 0 001.5-11.8A8 8 0 009.2 6 5 5 0 008 16z"
-        fill="rgba(255,255,255,0.5)"
+        d="M10 20h18a6.5 6.5 0 001.5-12.8 8.5 8.5 0 00-16 0A5.5 5.5 0 0010 20z"
+        fill="url(#wc-storm-cloud)"
       />
-      <polygon points="17,16 14,23 17,23 15,30 22,20 18,20 21,16" fill="#FBBF24" />
+      <polygon points="22,20 17,29 21,29 18,37 27,26 22,26 26,20" fill="url(#wc-bolt)" />
     </svg>
   );
 }
 
-function FogIcon({ size = 32 }) {
+function FogIcon({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
-      <g stroke="rgba(255,255,255,0.6)" strokeWidth="2" strokeLinecap="round">
-        <line x1="6" y1="12" x2="26" y2="12" />
-        <line x1="8" y1="17" x2="24" y2="17" />
-        <line x1="6" y1="22" x2="26" y2="22" />
-        <line x1="10" y1="27" x2="22" y2="27" />
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden="true">
+      <g stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" opacity="0.75">
+        <path
+          d="M7 13c2 0 3-1.5 5-1.5s3 1.5 5 1.5 3-1.5 5-1.5 3 1.5 5 1.5 3-1.5 5-1.5"
+          fill="none"
+        />
+        <path
+          d="M5 20c2 0 3-1.5 5-1.5s3 1.5 5 1.5 3-1.5 5-1.5 3 1.5 5 1.5 3-1.5 5-1.5"
+          fill="none"
+        />
+        <path
+          d="M7 27c2 0 3-1.5 5-1.5s3 1.5 5 1.5 3-1.5 5-1.5 3 1.5 5 1.5 3-1.5 5-1.5"
+          fill="none"
+        />
       </g>
     </svg>
   );
 }
 
-function WindyIcon({ size = 32 }) {
+function WindyIcon({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 32 32" fill="none">
-      <g stroke="rgba(255,255,255,0.7)" strokeWidth="2" strokeLinecap="round">
-        <path d="M4 12h18a3 3 0 10-3-3" fill="none" />
-        <path d="M6 18h14a2.5 2.5 0 11-2.5 2.5" fill="none" />
-        <path d="M4 24h10a2 2 0 10-2-2" fill="none" />
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" aria-hidden="true">
+      <g stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" fill="none" opacity="0.85">
+        <path d="M5 14h22a4 4 0 10-4-4" />
+        <path d="M5 22h17a3 3 0 11-3 3" />
+        <path d="M5 30h13a2.5 2.5 0 10-2.5-2.5" />
       </g>
     </svg>
   );
@@ -153,62 +227,58 @@ const ICON_MAP = {
   windy: WindyIcon,
 };
 
-// ── Mini icons for detail tiles (16px, white strokes) ────────────────────
+/* ─────────────────────────────────────────────────────────────────
+   Mini icons for detail pills (use currentColor so light/dark works)
+   ───────────────────────────────────────────────────────────────── */
+
+const miniStroke = {
+  stroke: 'currentColor',
+  strokeWidth: 1.4,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+  fill: 'none',
+};
 
 function WindMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <path
-        d="M2 6h9a1.5 1.5 0 10-1.5-1.5"
-        stroke="#fff"
-        strokeWidth="1.2"
-        strokeLinecap="round"
-        fill="none"
-      />
-      <path
-        d="M3 9h7a1.2 1.2 0 11-1.2 1.2"
-        stroke="#fff"
-        strokeWidth="1.2"
-        strokeLinecap="round"
-        fill="none"
-      />
-      <path
-        d="M2 12h5a1 1 0 10-1-1"
-        stroke="#fff"
-        strokeWidth="1.2"
-        strokeLinecap="round"
-        fill="none"
-      />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M2 6h9a1.5 1.5 0 10-1.5-1.5" {...miniStroke} />
+      <path d="M3 9h7a1.2 1.2 0 11-1.2 1.2" {...miniStroke} />
+      <path d="M2 12h5a1 1 0 10-1-1" {...miniStroke} />
     </svg>
   );
 }
 
 function HumidityMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <path d="M8 2L4.5 8a3.5 3.5 0 107 0L8 2z" stroke="#fff" strokeWidth="1.2" fill="none" />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 2.5C5.5 6 4 8.2 4 10a4 4 0 008 0c0-1.8-1.5-4-4-7.5z" {...miniStroke} />
     </svg>
   );
 }
 
 function PressureMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <circle cx="8" cy="8" r="5.5" stroke="#fff" strokeWidth="1.2" fill="none" />
-      <path d="M8 5v3l2.5 1.5" stroke="#fff" strokeWidth="1.2" strokeLinecap="round" fill="none" />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <circle cx="8" cy="8" r="5.5" {...miniStroke} />
+      <path d="M8 5v3l2.3 1.4" {...miniStroke} />
     </svg>
   );
 }
 
 function UVMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <circle cx="8" cy="8" r="3" stroke="#fff" strokeWidth="1.2" fill="none" />
-      <g stroke="#fff" strokeWidth="1" strokeLinecap="round">
-        <line x1="8" y1="1.5" x2="8" y2="3" />
-        <line x1="8" y1="13" x2="8" y2="14.5" />
-        <line x1="1.5" y1="8" x2="3" y2="8" />
-        <line x1="13" y1="8" x2="14.5" y2="8" />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <circle cx="8" cy="8" r="3" {...miniStroke} />
+      <g {...miniStroke}>
+        <line x1="8" y1="1.5" x2="8" y2="3.2" />
+        <line x1="8" y1="12.8" x2="8" y2="14.5" />
+        <line x1="1.5" y1="8" x2="3.2" y2="8" />
+        <line x1="12.8" y1="8" x2="14.5" y2="8" />
+        <line x1="3.5" y1="3.5" x2="4.7" y2="4.7" />
+        <line x1="11.3" y1="11.3" x2="12.5" y2="12.5" />
+        <line x1="3.5" y1="12.5" x2="4.7" y2="11.3" />
+        <line x1="11.3" y1="4.7" x2="12.5" y2="3.5" />
       </g>
     </svg>
   );
@@ -216,98 +286,60 @@ function UVMini() {
 
 function RainChanceMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <path
-        d="M5 5h8a3 3 0 00.7-5.9A4 4 0 005.1 1 2.5 2.5 0 005 5z"
-        stroke="#fff"
-        strokeWidth="1"
-        fill="none"
-        transform="translate(-1,3)"
-      />
-      <line x1="6" y1="10" x2="5.5" y2="12.5" stroke="#fff" strokeWidth="1" strokeLinecap="round" />
-      <line x1="9" y1="10" x2="8.5" y2="13" stroke="#fff" strokeWidth="1" strokeLinecap="round" />
-      <line
-        x1="12"
-        y1="10"
-        x2="11.5"
-        y2="12.5"
-        stroke="#fff"
-        strokeWidth="1"
-        strokeLinecap="round"
-      />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3 8h8a2.5 2.5 0 00.6-4.9 3.5 3.5 0 00-6.6-.6A2.2 2.2 0 003 8z" {...miniStroke} />
+      <line x1="5" y1="11" x2="4.5" y2="13.5" {...miniStroke} />
+      <line x1="8" y1="11" x2="7.5" y2="14" {...miniStroke} />
+      <line x1="11" y1="11" x2="10.5" y2="13.5" {...miniStroke} />
     </svg>
   );
 }
 
 function VisibilityMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <path
-        d="M1 8s2.5-4 7-4 7 4 7 4-2.5 4-7 4-7-4-7-4z"
-        stroke="#fff"
-        strokeWidth="1.2"
-        fill="none"
-      />
-      <circle cx="8" cy="8" r="2" stroke="#fff" strokeWidth="1.2" fill="none" />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M1.5 8s2.3-4 6.5-4 6.5 4 6.5 4-2.3 4-6.5 4-6.5-4-6.5-4z" {...miniStroke} />
+      <circle cx="8" cy="8" r="2" {...miniStroke} />
     </svg>
   );
 }
 
 function DewPointMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <path d="M8 2L5 8.5a3 3 0 106 0L8 2z" stroke="#fff" strokeWidth="1.2" fill="none" />
-      <circle cx="8" cy="10" r="1" fill="#fff" opacity="0.6" />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M8 2.5C5.5 6 4 8.2 4 10a4 4 0 008 0c0-1.8-1.5-4-4-7.5z" {...miniStroke} />
+      <circle cx="8" cy="10.2" r="1" fill="currentColor" />
     </svg>
   );
 }
 
 function SunriseMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <path d="M2 12h12" stroke="#fff" strokeWidth="1.2" strokeLinecap="round" />
-      <path d="M4 12a4 4 0 018 0" stroke="#fff" strokeWidth="1.2" fill="none" />
-      <path d="M8 3v2" stroke="#fff" strokeWidth="1.2" strokeLinecap="round" />
-      <path d="M8 6l0 -2" stroke="#fff" strokeWidth="1.2" strokeLinecap="round" />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M2 12.5h12" {...miniStroke} />
+      <path d="M4.5 12.5a3.5 3.5 0 017 0" {...miniStroke} />
+      <path d="M8 3.5v3" {...miniStroke} />
+      <path d="M6 6l2-2.2 2 2.2" {...miniStroke} />
     </svg>
   );
 }
 
 function SunsetMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <path d="M2 12h12" stroke="#fff" strokeWidth="1.2" strokeLinecap="round" />
-      <path d="M4 12a4 4 0 018 0" stroke="#fff" strokeWidth="1.2" fill="none" />
-      <path d="M8 3v2" stroke="#fff" strokeWidth="1.2" strokeLinecap="round" />
-      <path
-        d="M6.5 4.5L8 6l1.5-1.5"
-        stroke="#fff"
-        strokeWidth="1"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
-      />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M2 12.5h12" {...miniStroke} />
+      <path d="M4.5 12.5a3.5 3.5 0 017 0" {...miniStroke} />
+      <path d="M8 7v-3" {...miniStroke} />
+      <path d="M6 4l2 2.2 2-2.2" {...miniStroke} />
     </svg>
   );
 }
 
 function GustsMini() {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <path
-        d="M1 7h10a1.5 1.5 0 10-1.5-1.5"
-        stroke="#fff"
-        strokeWidth="1.2"
-        strokeLinecap="round"
-        fill="none"
-      />
-      <path
-        d="M3 10h8a1.2 1.2 0 11-1.2 1.2"
-        stroke="#fff"
-        strokeWidth="1.2"
-        strokeLinecap="round"
-        fill="none"
-      />
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M2 7h10a1.5 1.5 0 10-1.5-1.5" {...miniStroke} />
+      <path d="M3 10h7.5a1.3 1.3 0 11-1.3 1.3" {...miniStroke} />
     </svg>
   );
 }
@@ -325,55 +357,9 @@ const MINI_ICON_MAP = {
   gusts: GustsMini,
 };
 
-// ── Detail Tile ──────────────────────────────────────────────────────────
-
-function DetailTile({ icon, label, value }) {
-  if (!value) return null;
-  const MiniIcon = MINI_ICON_MAP[icon];
-  return (
-    <div className={styles.detailTile}>
-      {MiniIcon && (
-        <div className={styles.detailTileIcon}>
-          <MiniIcon />
-        </div>
-      )}
-      <div className={styles.detailTileContent}>
-        <span className={styles.detailTileLabel}>{label}</span>
-        <span className={styles.detailTileValue}>{value}</span>
-      </div>
-    </div>
-  );
-}
-
-// ── Period & Forecast helpers ────────────────────────────────────────────
-
-function PeriodChip({ period }) {
-  const theme = mapConditionToTheme(inferConditionFromLabel(period.condition));
-  const IconComp = ICON_MAP[theme.icon] || CloudIcon;
-  return (
-    <div className={styles.periodChip}>
-      <IconComp size={18} />
-      <div className={styles.periodInfo}>
-        <span className={styles.periodLabel}>{period.label}</span>
-        {period.temp && <span className={styles.periodTemp}>{period.temp}</span>}
-        {period.condition && <span className={styles.periodCondition}>{period.condition}</span>}
-      </div>
-    </div>
-  );
-}
-
-function ForecastDay({ item }) {
-  const theme = mapConditionToTheme(item.condition);
-  const IconComp = ICON_MAP[theme.icon] || CloudIcon;
-  return (
-    <div className={styles.forecastDay}>
-      <span className={styles.forecastDayName}>{item.day}</span>
-      <IconComp size={20} />
-      <span className={styles.forecastHigh}>{item.high || '--'}</span>
-      {item.low && <span className={styles.forecastLow}>{item.low}</span>}
-    </div>
-  );
-}
+/* ─────────────────────────────────────────────────────────────────
+   Helpers
+   ───────────────────────────────────────────────────────────────── */
 
 function inferConditionFromLabel(label) {
   if (!label) return null;
@@ -391,7 +377,286 @@ function inferConditionFromLabel(label) {
   return null;
 }
 
-// ── Main Component ──────────────────────────────────────────────────────
+function parseTempNumber(tempStr) {
+  if (!tempStr) return null;
+  const match = String(tempStr).match(/-?\d+(?:\.\d+)?/);
+  return match ? parseFloat(match[0]) : null;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   Animated weather overlays — falling rain, drifting snow, etc.
+   ───────────────────────────────────────────────────────────────── */
+
+function WeatherAnimations({ kind }) {
+  if (kind === 'rain' || kind === 'heavyRain') {
+    const drops = kind === 'heavyRain' ? 26 : 16;
+    return (
+      <div className={styles.fxLayer} aria-hidden="true">
+        {Array.from({ length: drops }).map((_, i) => {
+          const left = (i * 37 + 13) % 100;
+          const delay = ((i * 31) % 180) / 100;
+          const duration = 0.7 + ((i * 17) % 60) / 100;
+          const height = 12 + ((i * 7) % 16);
+          return (
+            <span
+              key={i}
+              className={styles.rainDrop}
+              style={{
+                left: `${left}%`,
+                height: `${height}px`,
+                animationDelay: `${delay}s`,
+                animationDuration: `${duration}s`,
+              }}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (kind === 'snow') {
+    return (
+      <div className={styles.fxLayer} aria-hidden="true">
+        {Array.from({ length: 20 }).map((_, i) => {
+          const left = (i * 23 + 7) % 100;
+          const fallDelay = ((i * 29) % 400) / 100;
+          const fallDuration = 6 + ((i * 13) % 50) / 10;
+          const swayDuration = 2.5 + ((i * 7) % 30) / 10;
+          const size = 2 + (i % 4);
+          const opacity = 0.55 + ((i * 11) % 40) / 100;
+          return (
+            <span
+              key={i}
+              className={styles.snowflake}
+              style={{
+                left: `${left}%`,
+                width: `${size}px`,
+                height: `${size}px`,
+                opacity,
+                animationDelay: `${fallDelay}s, ${fallDelay / 2}s`,
+                animationDuration: `${fallDuration}s, ${swayDuration}s`,
+              }}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (kind === 'storm') {
+    return (
+      <div className={styles.fxLayer} aria-hidden="true">
+        {Array.from({ length: 22 }).map((_, i) => {
+          const left = (i * 41 + 5) % 100;
+          const delay = ((i * 19) % 150) / 100;
+          const duration = 0.55 + ((i * 11) % 45) / 100;
+          const height = 14 + ((i * 7) % 18);
+          return (
+            <span
+              key={i}
+              className={styles.rainDrop}
+              style={{
+                left: `${left}%`,
+                height: `${height}px`,
+                animationDelay: `${delay}s`,
+                animationDuration: `${duration}s`,
+              }}
+            />
+          );
+        })}
+        <span className={styles.lightningFlash} />
+      </div>
+    );
+  }
+
+  if (kind === 'sunny') {
+    return (
+      <div className={styles.fxLayer} aria-hidden="true">
+        <span className={styles.sunGlow} />
+      </div>
+    );
+  }
+
+  if (kind === 'partlyCloudy' || kind === 'cloudy') {
+    return (
+      <div className={styles.fxLayer} aria-hidden="true">
+        <span
+          className={styles.cloudShape}
+          style={{ top: '18%', width: '55%', height: '50px', animationDuration: '42s' }}
+        />
+        <span
+          className={styles.cloudShape}
+          style={{
+            top: '52%',
+            width: '45%',
+            height: '40px',
+            animationDuration: '58s',
+            animationDelay: '-18s',
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (kind === 'fog') {
+    return (
+      <div className={styles.fxLayer} aria-hidden="true">
+        <span className={styles.fogBand} style={{ top: '22%', animationDuration: '14s' }} />
+        <span
+          className={styles.fogBand}
+          style={{ top: '48%', animationDuration: '18s', animationDelay: '-6s' }}
+        />
+        <span
+          className={styles.fogBand}
+          style={{ top: '74%', animationDuration: '15s', animationDelay: '-3s' }}
+        />
+      </div>
+    );
+  }
+
+  if (kind === 'windy') {
+    return (
+      <div className={styles.fxLayer} aria-hidden="true">
+        <span className={styles.windStreak} style={{ top: '28%', animationDuration: '6s' }} />
+        <span
+          className={styles.windStreak}
+          style={{ top: '52%', animationDuration: '8s', animationDelay: '-2s' }}
+        />
+        <span
+          className={styles.windStreak}
+          style={{ top: '74%', animationDuration: '7s', animationDelay: '-4s' }}
+        />
+      </div>
+    );
+  }
+
+  return null;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   Period sparkline — smooth curve through the day's named periods
+   ───────────────────────────────────────────────────────────────── */
+
+function PeriodSparkline({ periods, isDark }) {
+  const data = useMemo(() => {
+    return periods.map((p) => ({ ...p, num: parseTempNumber(p.temp) }));
+  }, [periods]);
+
+  const validIdx = data.map((d, i) => (d.num !== null ? i : -1)).filter((i) => i !== -1);
+  if (validIdx.length < 2) return null;
+
+  const validTemps = validIdx.map((i) => data[i].num);
+  const min = Math.min(...validTemps);
+  const max = Math.max(...validTemps);
+  const range = max - min || 1;
+
+  const W = 400;
+  const H = 64;
+  const padX = 24;
+  const padTop = 18;
+  const padBottom = 10;
+  const chartW = W - padX * 2;
+  const chartH = H - padTop - padBottom;
+
+  const xFor = (i) => padX + (i / Math.max(data.length - 1, 1)) * chartW;
+  const yFor = (t) => padTop + ((max - t) / range) * chartH;
+
+  let pathD = '';
+  validIdx.forEach((i, idx) => {
+    const x = xFor(i);
+    const y = yFor(data[i].num);
+    if (idx === 0) {
+      pathD += `M ${x.toFixed(2)} ${y.toFixed(2)}`;
+    } else {
+      const prevI = validIdx[idx - 1];
+      const px = xFor(prevI);
+      const py = yFor(data[prevI].num);
+      const midX = (px + x) / 2;
+      pathD += ` C ${midX.toFixed(2)} ${py.toFixed(2)}, ${midX.toFixed(2)} ${y.toFixed(
+        2
+      )}, ${x.toFixed(2)} ${y.toFixed(2)}`;
+    }
+  });
+
+  const firstX = xFor(validIdx[0]);
+  const lastX = xFor(validIdx[validIdx.length - 1]);
+  const fillD = `${pathD} L ${lastX.toFixed(2)} ${H - padBottom} L ${firstX.toFixed(2)} ${
+    H - padBottom
+  } Z`;
+
+  const stroke = isDark ? 'rgba(255,255,255,0.82)' : 'rgba(40,40,60,0.78)';
+  const fillTop = isDark ? 'rgba(255,255,255,0.18)' : 'rgba(40,40,60,0.18)';
+  const fillBot = isDark ? 'rgba(255,255,255,0)' : 'rgba(40,40,60,0)';
+
+  const gradId = `wc-spark-fill-${isDark ? 'd' : 'l'}`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      className={styles.periodSparkline}
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id={gradId} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor={fillTop} />
+          <stop offset="100%" stopColor={fillBot} />
+        </linearGradient>
+      </defs>
+      <path d={fillD} fill={`url(#${gradId})`} />
+      <path
+        d={pathD}
+        stroke={stroke}
+        strokeWidth="2"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   Small composables
+   ───────────────────────────────────────────────────────────────── */
+
+function DetailPill({ iconKey, label, value }) {
+  if (!value) return null;
+  const MiniIcon = MINI_ICON_MAP[iconKey];
+  return (
+    <span className={styles.detailPill}>
+      {MiniIcon && (
+        <span className={styles.detailPillIcon}>
+          <MiniIcon />
+        </span>
+      )}
+      <span className={styles.detailPillLabel}>{label}</span>
+      <span className={styles.detailPillValue}>{value}</span>
+    </span>
+  );
+}
+
+function ForecastDay({ item, index }) {
+  const theme = mapConditionToTheme(item.condition);
+  const IconComp = ICON_MAP[theme.icon] || CloudIcon;
+  return (
+    <div className={styles.forecastDay} style={{ animationDelay: `${0.08 * index + 0.15}s` }}>
+      <span className={styles.forecastDayName}>{item.day}</span>
+      <span className={styles.forecastIcon}>
+        <IconComp size={28} />
+      </span>
+      <div className={styles.forecastTemps}>
+        <span className={styles.forecastHigh}>{item.high || '--'}</span>
+        {item.low && <span className={styles.forecastLow}>{item.low}</span>}
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   Main component
+   ───────────────────────────────────────────────────────────────── */
 
 export default function WeatherCard({ weatherData, isDark, renderMarkdown }) {
   const { location, date, current, periods, forecast, source, remainingText } = weatherData;
@@ -405,97 +670,131 @@ export default function WeatherCard({ weatherData, isDark, renderMarkdown }) {
   const displayDate =
     date ||
     new Date().toLocaleDateString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
+      weekday: 'short',
+      month: 'short',
       day: 'numeric',
     });
 
-  // Build detail tiles array from available data
   const details = [
-    { icon: 'wind', label: 'Wind', value: current?.wind },
-    { icon: 'humidity', label: 'Humidity', value: current?.humidity },
-    { icon: 'pressure', label: 'Pressure', value: current?.pressure },
-    { icon: 'uv', label: 'UV Index', value: current?.uvIndex },
-    { icon: 'rainChance', label: 'Rain Chance', value: current?.chanceOfRain },
-    { icon: 'visibility', label: 'Visibility', value: current?.visibility },
-    { icon: 'dewPoint', label: 'Dew Point', value: current?.dewPoint },
-    { icon: 'gusts', label: 'Gusts', value: current?.gusts },
-    { icon: 'sunrise', label: 'Sunrise', value: current?.sunrise },
-    { icon: 'sunset', label: 'Sunset', value: current?.sunset },
+    { iconKey: 'wind', label: 'Wind', value: current?.wind },
+    { iconKey: 'humidity', label: 'Humidity', value: current?.humidity },
+    { iconKey: 'rainChance', label: 'Rain', value: current?.chanceOfRain },
+    { iconKey: 'uv', label: 'UV', value: current?.uvIndex },
+    { iconKey: 'visibility', label: 'Visibility', value: current?.visibility },
+    { iconKey: 'pressure', label: 'Pressure', value: current?.pressure },
+    { iconKey: 'dewPoint', label: 'Dew point', value: current?.dewPoint },
+    { iconKey: 'gusts', label: 'Gusts', value: current?.gusts },
+    { iconKey: 'sunrise', label: 'Sunrise', value: current?.sunrise },
+    { iconKey: 'sunset', label: 'Sunset', value: current?.sunset },
   ].filter((d) => d.value);
 
   const hasDetails = details.length > 0;
+  const periodsHaveTemps = hasPeriods && periods.some((p) => parseTempNumber(p.temp) !== null);
 
   return (
     <>
       <div
-        className={`${styles.weatherCard} ${styles[`gradient_${theme.gradient}`] || ''}`}
+        className={`${styles.weatherCard} ${styles[`tone_${theme.gradient}`] || ''}`}
         data-theme-mode={isDark ? 'dark' : 'light'}
+        data-condition={theme.icon}
       >
-        {/* Location & Date bar */}
-        <div className={styles.locationBar}>
-          <h3 className={styles.location}>{displayLocation}</h3>
-          <span className={styles.date}>{displayDate}</span>
-        </div>
+        <WeatherAnimations kind={theme.icon} />
 
-        {/* Hero: icon + temp + condition + side info */}
-        <div className={styles.heroSection}>
-          <div className={styles.heroIcon}>
-            <IconComp size={60} />
+        <div className={styles.content}>
+          <div className={styles.locationBar}>
+            <h3 className={styles.location}>{displayLocation}</h3>
+            <span className={styles.date}>{displayDate}</span>
           </div>
-          <div className={styles.heroCenter}>
-            {current?.temp && <span className={styles.heroTemp}>{current.temp}</span>}
-            {current?.altTemp && <span className={styles.heroAltTemp}>{current.altTemp}</span>}
-            {current?.condition && (
-              <span className={styles.heroCondition}>{current.condition}</span>
-            )}
-          </div>
-          <div className={styles.heroSide}>
-            {current?.feelsLike && (
-              <span className={styles.feelsLike}>Feels like {current.feelsLike}</span>
-            )}
-            {(current?.minTemp || current?.maxTemp) && (
-              <div className={styles.minMaxRow}>
-                {current.maxTemp && <span>H: {current.maxTemp}</span>}
-                {current.minTemp && <span>L: {current.minTemp}</span>}
+
+          <div className={styles.hero}>
+            <div className={styles.heroLeft}>
+              <div className={styles.heroIcon}>
+                <IconComp size={68} />
+              </div>
+              <div className={styles.heroTempBlock}>
+                <div className={styles.heroTempRow}>
+                  {current?.temp && <span className={styles.heroTemp}>{current.temp}</span>}
+                  {current?.altTemp && (
+                    <span className={styles.heroAltTemp}>{current.altTemp}</span>
+                  )}
+                </div>
+                {current?.condition && (
+                  <span className={styles.heroCondition}>{current.condition}</span>
+                )}
+              </div>
+            </div>
+
+            {(current?.maxTemp || current?.minTemp || current?.feelsLike) && (
+              <div className={styles.heroRight}>
+                {(current?.maxTemp || current?.minTemp) && (
+                  <div className={styles.minMax}>
+                    {current.maxTemp && (
+                      <span>
+                        <span className={styles.minMaxLabel}>H</span>
+                        {current.maxTemp}
+                      </span>
+                    )}
+                    {current.minTemp && (
+                      <span>
+                        <span className={styles.minMaxLabel}>L</span>
+                        {current.minTemp}
+                      </span>
+                    )}
+                  </div>
+                )}
+                {current?.feelsLike && (
+                  <span className={styles.feelsLikeHero}>Feels like {current.feelsLike}</span>
+                )}
               </div>
             )}
           </div>
+
+          {hasDetails && (
+            <div className={styles.details}>
+              {details.map((d) => (
+                <DetailPill key={d.iconKey} iconKey={d.iconKey} label={d.label} value={d.value} />
+              ))}
+            </div>
+          )}
+
+          {hasPeriods && (
+            <div className={styles.periodSection}>
+              {periodsHaveTemps && <PeriodSparkline periods={periods} isDark={isDark} />}
+              <div className={styles.periodRow}>
+                {periods.map((p, i) => {
+                  const periodTheme = mapConditionToTheme(inferConditionFromLabel(p.condition));
+                  const PIcon = ICON_MAP[periodTheme.icon] || CloudIcon;
+                  return (
+                    <div
+                      key={i}
+                      className={styles.periodChip}
+                      style={{ animationDelay: `${0.05 * i + 0.1}s` }}
+                    >
+                      <span className={styles.periodLabel}>{p.label}</span>
+                      <PIcon size={22} />
+                      {p.temp && <span className={styles.periodTemp}>{p.temp}</span>}
+                      {p.condition && !p.temp && (
+                        <span className={styles.periodCondition}>{p.condition}</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {hasForecast && (
+            <div className={styles.forecast}>
+              {forecast.map((f, i) => (
+                <ForecastDay key={`${f.day}-${i}`} item={f} index={i} />
+              ))}
+            </div>
+          )}
+
+          {source && <div className={styles.source}>{source}</div>}
         </div>
-
-        {/* Detail grid */}
-        {hasDetails && (
-          <div className={styles.detailGrid}>
-            {details.map((d) => (
-              <DetailTile key={d.icon} icon={d.icon} label={d.label} value={d.value} />
-            ))}
-          </div>
-        )}
-
-        {/* Time periods */}
-        {hasPeriods && (
-          <div className={styles.periods}>
-            {periods.map((p, i) => (
-              <PeriodChip key={i} period={p} />
-            ))}
-          </div>
-        )}
-
-        {/* Multi-day forecast */}
-        {hasForecast && (
-          <div className={styles.forecast}>
-            {forecast.map((f, i) => (
-              <ForecastDay key={i} item={f} />
-            ))}
-          </div>
-        )}
-
-        {/* Source */}
-        {source && <div className={styles.source}>{source}</div>}
       </div>
 
-      {/* Remaining text (news, articles, links) */}
       {remainingText && renderMarkdown && (
         <div className={styles.remainingContent}>{renderMarkdown(remainingText)}</div>
       )}

--- a/src/components/WeatherCard/WeatherCard.module.css
+++ b/src/components/WeatherCard/WeatherCard.module.css
@@ -1,42 +1,374 @@
-/* ─── WeatherCard v3 — Immersive, Compact, Premium ─── */
+/* ═══════════════════════════════════════════════════════════════════
+   WeatherCard v4 — Premium glassmorphic card with animated weather
+   ─ Transparent base + backdrop-filter
+   ─ Theme-aware (light & dark) via data-theme-mode
+   ─ Per-condition tint overlays
+   ─ Pure-CSS rain / snow / lightning / sun / cloud / fog animations
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ─── Base card ─────────────────────────────────────────────────── */
 
 .weatherCard {
-  margin: 8px 0 14px;
-  border-radius: 20px;
-  padding: 22px 24px;
-  color: #fff;
+  --w-text: var(--text-primary);
+  --w-text-muted: var(--text-secondary);
+  --w-text-soft: var(--text-muted);
+  --w-glass: rgba(255, 255, 255, 0.55);
+  --w-border: rgba(20, 20, 30, 0.07);
+  --w-tile-bg: rgba(20, 20, 30, 0.035);
+  --w-tile-border: rgba(20, 20, 30, 0.05);
+  --w-tile-hover: rgba(20, 20, 30, 0.06);
+  --w-shadow: 0 10px 36px rgba(20, 20, 30, 0.08), 0 2px 8px rgba(20, 20, 30, 0.04);
+  --w-inset: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+  --w-divider: rgba(20, 20, 30, 0.07);
+  --w-cloud-icon: #c5d3e6;
+
   position: relative;
+  margin: 8px 0 14px;
+  padding: 22px 24px 18px;
+  border-radius: 24px;
+  color: var(--w-text);
+  background: var(--w-glass);
+  -webkit-backdrop-filter: blur(28px) saturate(180%);
+  backdrop-filter: blur(28px) saturate(180%);
+  border: 1px solid var(--w-border);
+  box-shadow: var(--w-shadow), var(--w-inset);
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25), 0 2px 8px rgba(0, 0, 0, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  animation: weatherFadeIn 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+  isolation: isolate;
+  animation: weatherFadeIn 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-/* Shimmer — subtle glass reflection */
+.weatherCard[data-theme-mode='dark'] {
+  --w-glass: rgba(28, 28, 38, 0.45);
+  --w-border: rgba(255, 255, 255, 0.08);
+  --w-tile-bg: rgba(255, 255, 255, 0.05);
+  --w-tile-border: rgba(255, 255, 255, 0.08);
+  --w-tile-hover: rgba(255, 255, 255, 0.085);
+  --w-shadow: 0 10px 36px rgba(0, 0, 0, 0.35), 0 2px 8px rgba(0, 0, 0, 0.2);
+  --w-inset: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --w-divider: rgba(255, 255, 255, 0.08);
+  --w-cloud-icon: #8a9bb5;
+}
+
+/* Cloud SVGs use currentColor in their gradient stops — set color here */
+.heroIcon,
+.forecastIcon,
+.periodChip svg {
+  color: var(--w-cloud-icon);
+}
+
+/* Weather tint overlay */
 .weatherCard::before {
   content: '';
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 45%;
-  background: linear-gradient(
-    108deg,
-    transparent 38%,
-    rgba(255, 255, 255, 0.07) 44%,
-    rgba(255, 255, 255, 0.03) 52%,
-    transparent 56%
-  );
+  inset: 0;
+  z-index: 0;
   pointer-events: none;
-  border-radius: 20px 20px 0 0;
-  z-index: 1;
+  opacity: 0.85;
+  transition: opacity 0.5s;
+  border-radius: inherit;
 }
 
-@keyframes weatherFadeIn {
+/* Top sheen for glass feel */
+.weatherCard::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.18) 0%,
+    rgba(255, 255, 255, 0.04) 30%,
+    transparent 60%
+  );
+  border-radius: inherit;
+}
+.weatherCard[data-theme-mode='dark']::after {
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.07) 0%,
+    rgba(255, 255, 255, 0.02) 30%,
+    transparent 60%
+  );
+}
+
+/* ─── Weather tints per condition × mode ─────────────────────────── */
+
+/* SUNNY — warm amber */
+.tone_sunny[data-theme-mode='light']::before {
+  background: radial-gradient(circle at 88% 12%, rgba(255, 190, 80, 0.45), transparent 55%),
+    linear-gradient(135deg, rgba(255, 215, 140, 0.35) 0%, rgba(255, 185, 110, 0.08) 100%);
+}
+.tone_sunny[data-theme-mode='dark']::before {
+  background: radial-gradient(circle at 88% 14%, rgba(255, 195, 95, 0.45), transparent 48%),
+    linear-gradient(135deg, rgba(80, 130, 210, 0.22) 0%, rgba(30, 50, 110, 0.38) 100%);
+}
+
+/* RAIN — cool blue */
+.tone_rain[data-theme-mode='light']::before {
+  background: radial-gradient(circle at 50% 0%, rgba(120, 150, 220, 0.35), transparent 70%),
+    linear-gradient(135deg, rgba(140, 170, 230, 0.25) 0%, rgba(90, 120, 200, 0.08) 100%);
+}
+.tone_rain[data-theme-mode='dark']::before {
+  background: radial-gradient(circle at 50% 0%, rgba(80, 120, 220, 0.4), transparent 70%),
+    linear-gradient(135deg, rgba(30, 55, 110, 0.5) 0%, rgba(15, 25, 55, 0.45) 100%);
+}
+
+/* CLOUDY — neutral grey-blue */
+.tone_cloudy[data-theme-mode='light']::before {
+  background: radial-gradient(circle at 30% 15%, rgba(170, 185, 210, 0.4), transparent 65%),
+    linear-gradient(135deg, rgba(190, 200, 220, 0.25) 0%, rgba(150, 165, 190, 0.08) 100%);
+}
+.tone_cloudy[data-theme-mode='dark']::before {
+  background: radial-gradient(circle at 30% 15%, rgba(100, 120, 155, 0.4), transparent 65%),
+    linear-gradient(135deg, rgba(50, 65, 90, 0.5) 0%, rgba(25, 35, 55, 0.4) 100%);
+}
+
+/* SNOW — icy pale blue */
+.tone_snow[data-theme-mode='light']::before {
+  background: radial-gradient(circle at 50% 10%, rgba(200, 225, 245, 0.55), transparent 60%),
+    linear-gradient(135deg, rgba(225, 240, 255, 0.45) 0%, rgba(190, 215, 240, 0.15) 100%);
+}
+.tone_snow[data-theme-mode='dark']::before {
+  background: radial-gradient(circle at 50% 10%, rgba(160, 200, 240, 0.35), transparent 60%),
+    linear-gradient(135deg, rgba(55, 90, 130, 0.5) 0%, rgba(25, 45, 75, 0.4) 100%);
+}
+
+/* STORM — moody purple */
+.tone_storm[data-theme-mode='light']::before {
+  background: radial-gradient(circle at 70% 25%, rgba(130, 100, 200, 0.4), transparent 60%),
+    linear-gradient(135deg, rgba(150, 130, 210, 0.28) 0%, rgba(90, 75, 165, 0.15) 100%);
+}
+.tone_storm[data-theme-mode='dark']::before {
+  background: radial-gradient(circle at 70% 25%, rgba(100, 70, 200, 0.5), transparent 60%),
+    linear-gradient(135deg, rgba(40, 25, 80, 0.6) 0%, rgba(18, 12, 45, 0.45) 100%);
+}
+
+/* FOG — warm tan-grey */
+.tone_fog[data-theme-mode='light']::before {
+  background: linear-gradient(180deg, rgba(210, 200, 190, 0.4), rgba(190, 180, 170, 0.18));
+}
+.tone_fog[data-theme-mode='dark']::before {
+  background: linear-gradient(180deg, rgba(130, 120, 110, 0.5), rgba(70, 65, 60, 0.35));
+}
+
+/* ─── FX animation layer ─────────────────────────────────────────── */
+
+.fxLayer {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+/* ─── Content layer ──────────────────────────────────────────────── */
+
+.content {
+  position: relative;
+  z-index: 3;
+}
+
+/* ─── Location bar ───────────────────────────────────────────────── */
+
+.locationBar {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.location {
+  margin: 0;
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--w-text);
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+.weatherCard[data-theme-mode='dark'] .location {
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.3);
+}
+
+.date {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--w-text-soft);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Hero ───────────────────────────────────────────────────────── */
+
+.hero {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.heroLeft {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex: 1;
+  min-width: 0;
+}
+
+.heroIcon {
+  flex-shrink: 0;
+  width: 68px;
+  height: 68px;
+  display: grid;
+  place-items: center;
+  animation: heroIconBreath 5s ease-in-out infinite;
+  filter: drop-shadow(0 4px 10px rgba(20, 20, 40, 0.18));
+}
+.weatherCard[data-theme-mode='dark'] .heroIcon {
+  filter: drop-shadow(0 4px 14px rgba(0, 0, 0, 0.5));
+}
+
+@keyframes heroIconBreath {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.045);
+  }
+}
+
+.heroTempBlock {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.heroTempRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.heroTemp {
+  font-size: 68px;
+  font-weight: 300;
+  line-height: 0.95;
+  color: var(--w-text);
+  letter-spacing: -0.05em;
+  font-variant-numeric: tabular-nums;
+}
+
+.heroAltTemp {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--w-text-soft);
+  padding-top: 9px;
+}
+
+.heroCondition {
+  margin-top: 4px;
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--w-text-muted);
+  letter-spacing: -0.005em;
+  line-height: 1.2;
+}
+
+.heroRight {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  text-align: right;
+  gap: 4px;
+  flex-shrink: 0;
+  padding-top: 6px;
+}
+
+.minMax {
+  display: inline-flex;
+  gap: 10px;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--w-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.minMax > span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 3px;
+}
+
+.minMaxLabel {
+  font-weight: 500;
+  color: var(--w-text-soft);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+.feelsLikeHero {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--w-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Detail pills (inline row) ───────────────────────────────────── */
+
+.details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.detailPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 11px 6px 9px;
+  border-radius: 99px;
+  background: var(--w-tile-bg);
+  border: 1px solid var(--w-tile-border);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--w-text-muted);
+  letter-spacing: -0.003em;
+  transition: background 0.18s ease, transform 0.18s ease, border-color 0.18s ease;
+  animation: pillFadeIn 0.5s both;
+}
+
+.detailPill:hover {
+  background: var(--w-tile-hover);
+  transform: translateY(-1px);
+}
+
+.detailPillIcon {
+  display: grid;
+  place-items: center;
+  opacity: 0.7;
+  flex-shrink: 0;
+  color: var(--w-text-muted);
+}
+
+.detailPillLabel {
+  color: var(--w-text-soft);
+}
+
+.detailPillValue {
+  color: var(--w-text);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+@keyframes pillFadeIn {
   from {
     opacity: 0;
-    transform: translateY(10px);
+    transform: translateY(4px);
   }
   to {
     opacity: 1;
@@ -44,387 +376,612 @@
   }
 }
 
-/* ── Immersive condition gradients — deep, opaque, weather-embodying ── */
-
-.gradient_sunny {
-  background: linear-gradient(135deg, #1a3a5c 0%, #2d6a9f 50%, #1e4d7b 100%);
+.detailPill:nth-child(1) {
+  animation-delay: 0.05s;
+}
+.detailPill:nth-child(2) {
+  animation-delay: 0.09s;
+}
+.detailPill:nth-child(3) {
+  animation-delay: 0.13s;
+}
+.detailPill:nth-child(4) {
+  animation-delay: 0.17s;
+}
+.detailPill:nth-child(5) {
+  animation-delay: 0.21s;
+}
+.detailPill:nth-child(6) {
+  animation-delay: 0.25s;
+}
+.detailPill:nth-child(7) {
+  animation-delay: 0.29s;
+}
+.detailPill:nth-child(8) {
+  animation-delay: 0.33s;
 }
 
-.gradient_rain {
-  background: linear-gradient(135deg, #2c3e6b 0%, #3d5a8e 50%, #1e2f52 100%);
-}
+/* ─── Period section (sparkline + chips) ─────────────────────────── */
 
-.gradient_cloudy {
-  background: linear-gradient(135deg, #3a4a6b 0%, #556b8a 50%, #2d3d5c 100%);
-}
-
-.gradient_snow {
-  background: linear-gradient(135deg, #4a6b8a 0%, #7a9bb5 50%, #3d5f7e 100%);
-}
-
-.gradient_storm {
-  background: linear-gradient(135deg, #2a1f4e 0%, #4a3578 50%, #1e1640 100%);
-}
-
-.gradient_fog {
-  background: linear-gradient(135deg, #5a4a3a 0%, #8a7565 50%, #6b5d4e 100%);
-}
-
-/* ── Location & Date (compact top bar) ── */
-
-.locationBar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 14px;
-  position: relative;
-  z-index: 2;
-}
-
-.location {
-  margin: 0;
-  font-size: 15px;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.95);
-  line-height: 1.3;
-  letter-spacing: -0.01em;
-}
-
-.date {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.55);
-  line-height: 1.3;
-  white-space: nowrap;
-}
-
-/* ── Hero Section ── */
-
-.heroSection {
-  display: flex;
-  align-items: center;
-  gap: 16px;
+.periodSection {
   margin-bottom: 18px;
-  position: relative;
-  z-index: 2;
 }
 
-.heroIcon {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.periodSparkline {
+  width: 100%;
+  height: 56px;
+  display: block;
+  margin-bottom: 6px;
 }
 
-.heroCenter {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-width: 0;
-}
-
-.heroTemp {
-  font-size: 64px;
-  font-weight: 700;
-  color: #fff;
-  line-height: 1;
-  letter-spacing: -0.03em;
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-}
-
-.heroAltTemp {
-  font-size: 16px;
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.6);
-  margin-top: 2px;
-}
-
-.heroCondition {
-  font-size: 14px;
-  font-weight: 550;
-  color: rgba(255, 255, 255, 0.75);
-  margin-top: 2px;
-}
-
-.heroSide {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 4px;
-  flex-shrink: 0;
-}
-
-.feelsLike {
-  font-size: 12.5px;
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.65);
-}
-
-.minMaxRow {
-  display: flex;
-  gap: 10px;
-  font-size: 12.5px;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.minMaxRow span {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-}
-
-/* ── Detail Grid ── */
-
-.detailGrid {
+.periodRow {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
-  gap: 8px;
-  margin-bottom: 14px;
-  position: relative;
-  z-index: 2;
-}
-
-.detailTile {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 10px 12px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-}
-
-.detailTileIcon {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: 1px;
-  opacity: 0.5;
-}
-
-.detailTileContent {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
-}
-
-.detailTileLabel {
-  font-size: 10.5px;
-  font-weight: 600;
-  color: rgba(255, 255, 255, 0.5);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.detailTileValue {
-  font-size: 15px;
-  font-weight: 650;
-  color: #fff;
-}
-
-/* ── Periods (Afternoon, Overnight, etc.) ── */
-
-.periods {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 14px;
-  position: relative;
-  z-index: 2;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
+  gap: 6px;
 }
 
 .periodChip {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  flex: 1;
-  min-width: 140px;
-  padding: 10px 14px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  gap: 4px;
+  padding: 10px 6px;
+  border-radius: 14px;
+  background: var(--w-tile-bg);
+  border: 1px solid var(--w-tile-border);
+  transition: background 0.2s, transform 0.2s, border-color 0.2s;
+  animation: periodChipIn 0.5s both;
 }
 
-.periodInfo {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  min-width: 0;
+.periodChip:hover {
+  background: var(--w-tile-hover);
+  transform: translateY(-1px);
 }
 
 .periodLabel {
-  font-size: 11.5px;
+  font-size: 10.5px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--w-text-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
 }
 
 .periodTemp {
   font-size: 14.5px;
-  font-weight: 650;
-  color: #fff;
+  font-weight: 600;
+  color: var(--w-text);
+  font-variant-numeric: tabular-nums;
 }
 
 .periodCondition {
-  font-size: 11.5px;
-  color: rgba(255, 255, 255, 0.5);
+  font-size: 11px;
+  color: var(--w-text-muted);
+  text-align: center;
+  line-height: 1.2;
+  max-width: 100%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-/* ── Multi-day Forecast ── */
-
-.forecast {
-  display: flex;
-  gap: 6px;
-  overflow-x: auto;
-  padding: 4px 0;
-  margin-bottom: 10px;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-  position: relative;
-  z-index: 2;
+@keyframes periodChipIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-.forecast::-webkit-scrollbar {
-  display: none;
+/* ─── Forecast row ───────────────────────────────────────────────── */
+
+.forecast {
+  display: grid;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
+  gap: 2px;
+  padding-top: 14px;
+  border-top: 1px solid var(--w-divider);
 }
 
 .forecastDay {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  flex: 1;
-  min-width: 56px;
-  padding: 10px 8px;
+  gap: 6px;
+  padding: 8px 4px;
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  transition: background 0.2s, transform 0.2s;
+  animation: forecastDayIn 0.5s both;
+}
+
+.forecastDay:hover {
+  background: var(--w-tile-bg);
+  transform: translateY(-1px);
 }
 
 .forecastDayName {
-  font-size: 11.5px;
+  font-size: 11px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--w-text-soft);
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.05em;
+}
+
+.forecastIcon {
+  display: grid;
+  place-items: center;
+  filter: drop-shadow(0 2px 4px rgba(20, 20, 40, 0.12));
+}
+.weatherCard[data-theme-mode='dark'] .forecastIcon {
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.4));
+}
+
+.forecastTemps {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  font-variant-numeric: tabular-nums;
 }
 
 .forecastHigh {
   font-size: 13.5px;
-  font-weight: 650;
-  color: #fff;
+  font-weight: 600;
+  color: var(--w-text);
 }
 
 .forecastLow {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--w-text-soft);
 }
 
-/* ── Source ── */
+@keyframes forecastDayIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ─── Source attribution ─────────────────────────────────────────── */
 
 .source {
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.4);
-  margin-top: 6px;
-  padding-top: 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  position: relative;
-  z-index: 2;
+  margin-top: 12px;
+  font-size: 10.5px;
+  color: var(--w-text-soft);
+  opacity: 0.75;
+  letter-spacing: 0.01em;
 }
 
-/* ── Remaining text below card ── */
+/* ─── Below-card content ─────────────────────────────────────────── */
 
 .remainingContent {
   margin-top: 14px;
 }
 
-/* ── Responsive — Mobile ── */
+/* ═══════════════════════════════════════════════════════════════════
+   Card entry animation
+   ═══════════════════════════════════════════════════════════════════ */
 
-@media (max-width: 480px) {
-  .weatherCard {
-    padding: 16px;
-    border-radius: 16px;
+@keyframes weatherFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.992);
   }
-
-  .weatherCard::before {
-    border-radius: 16px 16px 0 0;
-  }
-
-  .locationBar {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 2px;
-    margin-bottom: 10px;
-  }
-
-  .heroSection {
-    flex-wrap: wrap;
-    gap: 10px;
-  }
-
-  .heroTemp {
-    font-size: 44px;
-  }
-
-  .heroIcon svg {
-    width: 44px;
-    height: 44px;
-  }
-
-  .heroSide {
-    align-items: flex-start;
-    width: 100%;
-    flex-direction: row;
-    gap: 12px;
-  }
-
-  .detailGrid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .periods {
-    flex-direction: column;
-  }
-
-  .periodChip {
-    min-width: unset;
-  }
-
-  .forecastDay {
-    min-width: 48px;
-    padding: 8px 6px;
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
   }
 }
 
-/* ── Responsive — Tablet ── */
+/* ═══════════════════════════════════════════════════════════════════
+   Weather effect animations
+   ═══════════════════════════════════════════════════════════════════ */
 
-@media (min-width: 481px) and (max-width: 768px) {
+/* ── Rain ── */
+.rainDrop {
+  position: absolute;
+  top: 0;
+  width: 1.2px;
+  height: 16px;
+  background: linear-gradient(180deg, transparent 0%, rgba(170, 195, 230, 0.85) 100%);
+  border-radius: 1px;
+  animation: rainFall linear infinite;
+  filter: blur(0.3px);
+  will-change: transform, opacity;
+}
+
+.weatherCard[data-theme-mode='dark'] .rainDrop {
+  background: linear-gradient(180deg, transparent 0%, rgba(200, 220, 255, 0.75) 100%);
+}
+
+@keyframes rainFall {
+  0% {
+    transform: translateY(-30px);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  85% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(calc(100% + 30px));
+    opacity: 0;
+  }
+}
+
+/* ── Snowflakes ── */
+.snowflake {
+  position: absolute;
+  top: 0;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 0 4px rgba(255, 255, 255, 0.4);
+  filter: blur(0.4px);
+  animation: snowFall linear infinite, snowSway ease-in-out infinite;
+  will-change: transform, margin-left;
+}
+
+.weatherCard[data-theme-mode='light'] .snowflake {
+  background: rgba(220, 235, 255, 0.95);
+  box-shadow: 0 0 5px rgba(170, 200, 240, 0.65);
+}
+
+@keyframes snowFall {
+  0% {
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  85% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(calc(100% + 20px));
+    opacity: 0;
+  }
+}
+
+@keyframes snowSway {
+  0%,
+  100% {
+    margin-left: 0;
+  }
+  50% {
+    margin-left: 14px;
+  }
+}
+
+/* ── Lightning flash ── */
+.lightningFlash {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse at 72% 22%,
+    rgba(255, 250, 220, 0.85) 0%,
+    rgba(255, 240, 180, 0.4) 25%,
+    transparent 55%
+  );
+  opacity: 0;
+  animation: lightningFlash 8s infinite;
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+@keyframes lightningFlash {
+  0%,
+  91% {
+    opacity: 0;
+  }
+  91.5% {
+    opacity: 0.95;
+  }
+  92% {
+    opacity: 0.2;
+  }
+  92.5% {
+    opacity: 0.85;
+  }
+  93% {
+    opacity: 0;
+  }
+  96% {
+    opacity: 0;
+  }
+  96.4% {
+    opacity: 0.55;
+  }
+  96.8% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/* ── Sun glow ── */
+.sunGlow {
+  position: absolute;
+  top: -60px;
+  right: -60px;
+  width: 240px;
+  height: 240px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(255, 215, 110, 0.55) 0%,
+    rgba(255, 190, 80, 0.25) 35%,
+    transparent 70%
+  );
+  filter: blur(10px);
+  animation: sunPulse 5s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+.weatherCard[data-theme-mode='light'] .sunGlow {
+  background: radial-gradient(
+    circle,
+    rgba(255, 225, 140, 0.65) 0%,
+    rgba(255, 200, 100, 0.25) 35%,
+    transparent 70%
+  );
+}
+
+@keyframes sunPulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.85;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+}
+
+/* ── Cloud drift ── */
+.cloudShape {
+  position: absolute;
+  left: 0;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(255, 255, 255, 0.2) 0%,
+    rgba(255, 255, 255, 0.05) 50%,
+    transparent 75%
+  );
+  filter: blur(14px);
+  animation: cloudDrift linear infinite;
+  border-radius: 50%;
+  will-change: transform;
+}
+
+.weatherCard[data-theme-mode='light'] .cloudShape {
+  background: radial-gradient(
+    ellipse at center,
+    rgba(255, 255, 255, 0.55) 0%,
+    rgba(255, 255, 255, 0.18) 50%,
+    transparent 75%
+  );
+}
+
+@keyframes cloudDrift {
+  0% {
+    transform: translateX(-40%);
+  }
+  100% {
+    transform: translateX(180%);
+  }
+}
+
+/* ── Fog bands ── */
+.fogBand {
+  position: absolute;
+  left: -10%;
+  right: -10%;
+  height: 26px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.18), transparent);
+  filter: blur(8px);
+  animation: fogDrift ease-in-out infinite;
+  will-change: transform;
+}
+
+.weatherCard[data-theme-mode='light'] .fogBand {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.45), transparent);
+}
+
+@keyframes fogDrift {
+  0%,
+  100% {
+    transform: translateX(-25%);
+  }
+  50% {
+    transform: translateX(25%);
+  }
+}
+
+/* ── Wind streaks ── */
+.windStreak {
+  position: absolute;
+  left: -20%;
+  right: -20%;
+  height: 1.5px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.4) 50%,
+    transparent 100%
+  );
+  filter: blur(1px);
+  animation: windStreak linear infinite;
+  will-change: transform;
+}
+
+.weatherCard[data-theme-mode='light'] .windStreak {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.7) 50%,
+    transparent 100%
+  );
+}
+
+@keyframes windStreak {
+  0% {
+    transform: translateX(-60%);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(60%);
+    opacity: 0;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Responsive
+   ═══════════════════════════════════════════════════════════════════ */
+
+@media (max-width: 540px) {
+  .weatherCard {
+    padding: 18px 18px 14px;
+    border-radius: 20px;
+  }
+
+  .locationBar {
+    margin-bottom: 12px;
+  }
+
+  .hero {
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+
+  .heroIcon {
+    width: 56px;
+    height: 56px;
+  }
+
+  .heroIcon svg {
+    width: 56px;
+    height: 56px;
+  }
+
   .heroTemp {
-    font-size: 56px;
+    font-size: 54px;
   }
 
-  .detailGrid {
-    grid-template-columns: repeat(3, 1fr);
+  .heroAltTemp {
+    padding-top: 7px;
   }
 
-  .periods {
-    flex-wrap: wrap;
+  .heroRight {
+    padding-top: 2px;
+  }
+
+  .minMax {
+    font-size: 12.5px;
+    gap: 8px;
+  }
+
+  .feelsLikeHero {
+    font-size: 11.5px;
+  }
+
+  .periodSparkline {
+    height: 56px;
   }
 
   .periodChip {
-    min-width: 120px;
+    padding: 8px 4px;
+  }
+
+  .periodLabel {
+    font-size: 9.5px;
+  }
+
+  .periodTemp {
+    font-size: 13px;
+  }
+
+  .forecastDay {
+    padding: 6px 2px;
+    gap: 4px;
+  }
+
+  .forecastIcon svg {
+    width: 24px;
+    height: 24px;
+  }
+
+  .forecastDayName {
+    font-size: 10px;
+  }
+
+  .forecastHigh {
+    font-size: 12.5px;
+  }
+
+  .forecastLow {
+    font-size: 11px;
+  }
+
+  .detailPill {
+    font-size: 11.5px;
+    padding: 5px 9px 5px 8px;
+  }
+}
+
+@media (max-width: 380px) {
+  .hero {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .heroRight {
+    flex-direction: row;
+    width: 100%;
+    align-items: baseline;
+    justify-content: space-between;
+    padding-top: 0;
+  }
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   Reduced motion — strip all animations
+   ═══════════════════════════════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+  .weatherCard,
+  .heroIcon,
+  .sunGlow,
+  .cloudShape,
+  .fogBand,
+  .rainDrop,
+  .snowflake,
+  .lightningFlash,
+  .windStreak,
+  .detailPill,
+  .periodChip,
+  .forecastDay {
+    animation: none !important;
+    transition: none !important;
   }
 }


### PR DESCRIPTION
## Summary

Rebuilds the weather card from a dense opaque tile into a premium glassmorphic surface that respects both light and dark themes — and goes further than the Perplexity reference with subtle, condition-driven motion.

**What changed**
- Transparent base + `backdrop-filter: blur(28px) saturate(180%)` — the card now sits *on* the page rather than hiding it
- Theme-aware via `data-theme-mode` + CSS variables; light & dark both shipped with their own palettes
- Per-condition tint overlays (warm amber for sunny, deep navy for rain, moody purple for storm, icy pale blue for snow, neutral grey-blue for cloudy, warm tan for fog)
- Pure-CSS animated weather effects layered behind content:
  - **Rain / Heavy rain** — 16–26 falling drops, varied length/speed/opacity
  - **Snow** — 20 drifting flakes with horizontal sway
  - **Storm** — rain + periodic lightning flash with secondary strike (8s cycle, `mix-blend-mode: screen`)
  - **Sunny** — warm sun-glow corner with breathing pulse
  - **Cloudy / Partly cloudy** — two slow drifting cloud shapes
  - **Fog** — three horizontal mist bands
  - **Windy** — diagonal wind streaks
- Refined gradient SVG icons (sun, partly cloudy, rain, heavy rain, snow, storm, fog, windy, cloud) — gradient-rich, `currentColor` cloud bodies so they adapt to mode
- **Detail pills** replace the heavy detail grid — inline rounded chips (Wind, Humidity, Rain%, UV, Visibility, etc.) with hover lift
- **Period sparkline** — smooth Bézier curve through morning/afternoon/evening/overnight temps (our equivalent of Perplexity's hourly chart, using the period temps we already parse)
- Hero icon gets a 5s `breath` scale animation; pills/chips/forecast days stagger-fade in
- Hover micro-interactions on every interactive surface
- Responsive down to 380px width; honors `prefers-reduced-motion`

**No data-shape changes** — same `weatherData` contract, same parser, same MessageList wiring.

## Test plan

- [ ] Trigger a weather response in chat (e.g. "vancouver weather") in **light mode** — confirm glass effect, blue rain tint, falling drops animation
- [ ] Toggle to **dark mode** — confirm deep navy base, drops still visible, text legible
- [ ] Send a sunny query (e.g. "marrakech weather") — confirm warm amber tint + corner sun glow in both modes
- [ ] Send a thunderstorm query — confirm lightning flash fires periodically (every ~7s), with secondary strike
- [ ] Send a snow query — confirm drifting snowflakes with sway
- [ ] Send a fog query — confirm horizontal mist bands
- [ ] Resize browser narrow (≤540px) — hero scales, detail pills wrap, forecast row stays readable
- [ ] OS-level "reduce motion" — all weather animations stop, card stops breathing
- [ ] Confirm the period sparkline curve appears when periods have temps, and is hidden when they don't

https://claude.ai/code/session_0125LBngDm8nrnPMhyE1QwWw

---
_Generated by [Claude Code](https://claude.ai/code/session_0125LBngDm8nrnPMhyE1QwWw)_