### PR TITLE
fix(weather): don't classify sunny days as Rain from "chance of rain" mentions

### DIFF
--- a/src/components/WeatherCard/weatherParser.js
+++ b/src/components/WeatherCard/weatherParser.js
@@ -191,25 +191,129 @@ function extractDate(text) {
   });
 }
 
-function inferCondition(text) {
+// Phrases like "chance of rain: 5%", "rain probability", "no rain", "rain: under 5%"
+// describe the *probability* of rain, not the current sky condition. We need
+// to strip these before scanning for condition keywords, otherwise a sunny day
+// with a low rain chance is misclassified as "Rain".
+function stripProbabilityContexts(text) {
+  return (
+    text
+      // "chance of rain / precipitation / showers / snow ... 5%"
+      .replace(
+        /\b(?:chance|probability|likelihood|odds|risk)\s+of\s+(?:rain|precipitation|showers?|snow|storms?|thunder(?:storms?)?)\b[^.\n]*/gi,
+        ' '
+      )
+      // "rain chance", "precipitation probability", "snow chance"
+      .replace(
+        /\b(?:rain|precipitation|snow|shower|thunderstorm)\s+(?:chance|probability)\b[^.\n]*/gi,
+        ' '
+      )
+      // "rain: under 5%", "snow: 10%", "showers: 0%"
+      .replace(
+        /\b(?:rain|snow|showers?|precipitation)\s*[:\-]\s*(?:under|less than|below|near|about|around|approximately|~)?\s*<?\s*\d+(?:\.\d+)?\s*%/gi,
+        ' '
+      )
+      // "X% rain", "5% chance of rain", "0% precipitation"
+      .replace(
+        /\b\d+(?:\.\d+)?\s*%\s*(?:chance of\s+)?(?:rain|precipitation|snow|showers?)\b/gi,
+        ' '
+      )
+      // "no rain", "no precipitation", "0 chance of rain"
+      .replace(/\bno\s+(?:rain|precipitation|showers?|snow|storms?)\b/gi, ' ')
+      // "dry — no rain"
+      .replace(
+        /\b(?:rain|precipitation|snow)\s+expected\s*[:\-]?\s*(?:no|none|0|low|minimal)\b/gi,
+        ' '
+      )
+  );
+}
+
+// Read explicit condition labels like "Sky: sunny intervals" / "Condition: Rain".
+// These take precedence over keyword scanning since they describe the sky directly.
+function extractExplicitCondition(text) {
+  const labels = [
+    'sky',
+    'skies',
+    'condition',
+    'conditions',
+    'current condition',
+    'current conditions',
+    'current weather',
+    'currently',
+    'now',
+    'present weather',
+    'present conditions',
+    'outlook',
+  ];
+  const lines = text.split('\n');
+  for (const raw of lines) {
+    const stripped = raw
+      .replace(/\*\*/g, '')
+      .replace(/^[\s\-*•]+/, '')
+      .trim();
+    if (!stripped) continue;
+    for (const label of labels) {
+      const re = new RegExp('^' + label + '\\s*[:\\-—–]\\s*(.+)', 'i');
+      const m = stripped.match(re);
+      if (m) {
+        const value = m[1].trim().replace(/[,.;]$/, '');
+        if (value.length > 0 && value.length < 120) return value;
+      }
+    }
+  }
+  return null;
+}
+
+function matchConditionKeywords(text) {
   const lower = text.toLowerCase();
+  // Order matters: more-specific phrases checked before generic ones, and
+  // partly-cloudy variants checked before bare "sunny" or "cloudy" so that
+  // "sunny intervals" maps to Partly Cloudy rather than Sunny.
   const conditions = [
     { keywords: ['thunderstorm', 'thunder', 'lightning'], label: 'Thunderstorm' },
     { keywords: ['heavy rain', 'downpour', 'torrential'], label: 'Heavy Rain' },
+    {
+      keywords: [
+        'sunny intervals',
+        'sunny spells',
+        'bright spells',
+        'bright intervals',
+        'partly cloudy',
+        'partly sunny',
+        'mostly sunny',
+        'some clouds',
+        'some sunshine',
+        'broken clouds',
+        'scattered clouds',
+        'intermittent clouds',
+        'intermittent sunshine',
+      ],
+      label: 'Partly Cloudy',
+    },
     { keywords: ['frequent showers'], label: 'Rain' },
     {
-      keywords: ['rain', 'rainy', 'raining', 'showers', 'drizzle', 'precipitation'],
+      keywords: ['raining', 'rainy', 'showers', 'drizzle', 'rain'],
       label: 'Rain',
     },
-    { keywords: ['snow', 'snowy', 'snowing', 'blizzard'], label: 'Snow' },
+    { keywords: ['snowing', 'snowy', 'snow', 'blizzard', 'flurries'], label: 'Snow' },
     { keywords: ['sleet', 'hail', 'freezing rain'], label: 'Sleet' },
     { keywords: ['fog', 'foggy', 'mist', 'misty', 'haze', 'hazy'], label: 'Fog' },
-    { keywords: ['partly cloudy', 'mostly sunny', 'some clouds'], label: 'Partly Cloudy' },
     {
-      keywords: ['cloudy', 'overcast', 'mostly cloudy', 'grey skies', 'gray skies'],
+      keywords: ['mostly cloudy', 'overcast', 'cloudy', 'grey skies', 'gray skies'],
       label: 'Cloudy',
     },
-    { keywords: ['sunny', 'clear', 'sunshine', 'bright', 'fine weather'], label: 'Sunny' },
+    {
+      keywords: [
+        'sunny',
+        'clear skies',
+        'clear',
+        'sunshine',
+        'bright',
+        'fine weather',
+        'fair weather',
+      ],
+      label: 'Sunny',
+    },
     { keywords: ['windy', 'gusty', 'breezy', 'strong winds'], label: 'Windy' },
   ];
   for (const { keywords, label } of conditions) {
@@ -218,6 +322,19 @@ function inferCondition(text) {
     }
   }
   return null;
+}
+
+function inferCondition(text) {
+  // 1. Prefer an explicit "Sky:" / "Condition:" / "Currently:" line if present.
+  const explicit = extractExplicitCondition(text);
+  if (explicit) {
+    const fromExplicit = matchConditionKeywords(explicit);
+    if (fromExplicit) return fromExplicit;
+  }
+
+  // 2. Fall back to scanning the whole text, but first strip out probability
+  //    contexts so "chance of rain: 5%" doesn't classify a sunny day as Rain.
+  return matchConditionKeywords(stripProbabilityContexts(text));
 }
 
 /**

--- a/src/components/WeatherCard/weatherParser.test.js
+++ b/src/components/WeatherCard/weatherParser.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { extractWeatherData } from './weatherParser';
+
+describe('extractWeatherData — condition inference', () => {
+  it('treats "Sky: sunny intervals" as Partly Cloudy even when rain chance is mentioned', () => {
+    const text = `Kent, UK
+- Sky: sunny intervals
+- Temperature: 22°C
+- Rain: under 5%
+- Wind: light, with gusts around 17 mph from the SSW
+- Gusts: 17 mph`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Partly Cloudy');
+  });
+
+  it('treats "Sky: sunny intervals" as Partly Cloudy with explicit chance phrasing', () => {
+    const text = `Today's weather in London
+- Sky: intermittent clouds
+- Temperature: 21°C
+- Chance of rain: 5%
+- Wind: 8 km/h SW`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Partly Cloudy');
+  });
+
+  it('does not classify a sunny day as Rain just because rain chance is mentioned', () => {
+    const text = `Marrakech, Morocco
+Condition: Sunny
+Temperature: 31°C
+Rain chance: 0%
+UV Index: 9`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Sunny');
+  });
+
+  it('does not classify a sunny day as Rain when "no rain" is mentioned', () => {
+    const text = `Currently: clear
+Temperature: 28°C
+No rain expected today.`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Sunny');
+  });
+
+  it('still detects actual rain when it is the current condition', () => {
+    const text = `Vancouver
+- Sky: light rain
+- Temperature: 13°C
+- Humidity: 77%`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Rain');
+  });
+
+  it('detects heavy rain over plain rain', () => {
+    const text = `Lagos
+Condition: Heavy rain
+Temperature: 27°C`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Heavy Rain');
+  });
+
+  it('detects thunderstorms', () => {
+    const text = `Currently: thunderstorm
+Temperature: 27°C
+Rain chance: 95%`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Thunderstorm');
+  });
+
+  it('detects snow', () => {
+    const text = `Reykjavík
+Sky: snow
+Temperature: -3°C`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Snow');
+  });
+
+  it('detects fog over rain mention in probability', () => {
+    const text = `London
+Conditions: foggy
+Temperature: 8°C
+Probability of rain: 10%`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Fog');
+  });
+
+  it('falls back to keyword detection when no explicit condition line is present', () => {
+    const text = `It is sunny today with a temperature of 28°C and humidity of 40%.`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Sunny');
+  });
+
+  it('handles "0% rain" without triggering Rain', () => {
+    const text = `Marrakech
+Sky: sunny
+Temperature: 31°C
+0% rain`;
+    const data = extractWeatherData(text);
+    expect(data.current.condition).toBe('Sunny');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a parser bug where the weather card classified a sunny day as **Rain** whenever the LLM response mentioned rain *probability* — e.g. `Sky: sunny intervals / Rain: under 5%` — which then triggered the new rain animation on every weather card in #392.

## Root cause

`inferCondition()` in `weatherParser.js` did naive substring matching on the entire response. If "rain" appeared anywhere — including in a chance-of-rain detail — it returned `Rain`, and the new card animation followed suit.

## Fix

1. **Read explicit condition labels first**: `Sky:`, `Condition:`, `Currently:`, `Conditions:`, `Now:`, `Outlook:`, `Present weather:` etc. take precedence. The condition is inferred from just that line's value.
2. **Strip probability contexts** before falling back to keyword scanning. Removes phrases like:
   - `chance of rain: 5%` / `probability of rain` / `rain probability` / `risk of rain`
   - `rain: under 5%` / `snow: 10%` / `showers: 0%`
   - `5% chance of rain` / `0% precipitation`
   - `no rain` / `rain expected: none`
3. **Recognises more UK/US phrasings as Partly Cloudy**: `sunny intervals`, `sunny spells`, `bright spells`, `intermittent clouds`, `intermittent sunshine`, `broken clouds`, `scattered clouds`, `partly sunny`, `some sunshine`.

## Tests

Added `weatherParser.test.js` with 11 cases — all pass:
- ✅ "Sky: sunny intervals" + "Rain: under 5%" → **Partly Cloudy** (was Rain — this is the user-reported bug)
- ✅ "Sky: intermittent clouds" + "Chance of rain: 5%" → **Partly Cloudy**
- ✅ "Condition: Sunny" + "Rain chance: 0%" → **Sunny**
- ✅ "Currently: clear" + "No rain expected today" → **Sunny**
- ✅ "Sky: light rain" → **Rain** (real rain still works)
- ✅ "Condition: Heavy rain" → **Heavy Rain**
- ✅ "Currently: thunderstorm" + "Rain chance: 95%" → **Thunderstorm**
- ✅ "Sky: snow" → **Snow**
- ✅ "Conditions: foggy" + "Probability of rain: 10%" → **Fog**

## Test plan

- [ ] Ask "what's the weather in Kent, UK now" — confirm card shows correct condition (Partly Cloudy / Sunny intervals), no rain animation when not actually raining
- [ ] Ask for a city that is actually raining — confirm rain icon + animation still work
- [ ] Ask for sunny / cloudy / thunderstorm / snow / fog locations — each maps to the right animation

https://claude.ai/code/session_0125LBngDm8nrnPMhyE1QwWw

---
_Generated by [Claude Code](https://claude.ai/code/session_0125LBngDm8nrnPMhyE1QwWw)_