### PR TITLE
feat(weather): extract multi-line day-forecast blocks into the card display

### DIFF
--- a/src/components/WeatherCard/weatherParser.js
+++ b/src/components/WeatherCard/weatherParser.js
@@ -287,6 +287,12 @@ function matchConditionKeywords(text) {
         'scattered clouds',
         'intermittent clouds',
         'intermittent sunshine',
+        'intervals of clouds',
+        'intervals of sunshine',
+        'clouds and sunshine',
+        'clouds and sun',
+        'sun and clouds',
+        'sunshine and clouds',
       ],
       label: 'Partly Cloudy',
     },
@@ -450,60 +456,184 @@ function extractPeriods(text) {
   return periods;
 }
 
+const DAY_NAMES = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday',
+  'mon',
+  'tue',
+  'tues',
+  'wed',
+  'thu',
+  'thur',
+  'thurs',
+  'fri',
+  'sat',
+  'sun',
+];
+
+function stripListPrefix(s) {
+  return s
+    .replace(/\*\*/g, '')
+    .replace(/^\s+/, '')
+    .replace(/^(?:\d+\s*[.)\]]\s+|[\-*•◦▪–—]\s+)/, '')
+    .trim();
+}
+
+function matchesDayHeader(stripped) {
+  const lower = stripped.toLowerCase();
+  for (const day of DAY_NAMES) {
+    // day name followed by word boundary (space, comma, dash, colon, end)
+    if (new RegExp('^' + day + '\\b').test(lower)) {
+      return day;
+    }
+  }
+  return null;
+}
+
+function normalizeTempString(raw) {
+  if (!raw) return null;
+  const m = raw.match(/(-?\d+(?:\.\d+)?)\s*°?\s*([CF])/i);
+  if (!m) return null;
+  return `${m[1]}°${m[2].toUpperCase()}`;
+}
+
+/**
+ * Extract a multi-day forecast in any of these shapes:
+ *   - "Mon: 21°C / 11°C, Cloudy"                         (single-line compact)
+ *   - "**Friday**\n   - High: 80°F (26°C)\n   - Low: 64°F" (multi-line, bullet/numbered)
+ *   - "1. Friday — May 22, 2026\n   - Conditions: ...\n   - High: 80°F · Low: 64°F"
+ *
+ * Returns `{ forecast, consumed }` where `consumed` is the set of line
+ * indices that fed the extraction so the body-text renderer can skip them.
+ */
 function extractForecast(text) {
   const forecast = [];
+  const consumed = new Set();
   const lines = text.split('\n');
-  const dayNames = [
-    'monday',
-    'tuesday',
-    'wednesday',
-    'thursday',
-    'friday',
-    'saturday',
-    'sunday',
-    'mon',
-    'tue',
-    'wed',
-    'thu',
-    'fri',
-    'sat',
-    'sun',
-  ];
 
-  for (const line of lines) {
-    const stripped = line
-      .replace(/\*\*/g, '')
-      .replace(/^[\s\-*•]+/, '')
-      .trim();
-    const lower = stripped.toLowerCase();
-    if (!lower) continue;
+  let i = 0;
+  while (i < lines.length) {
+    const stripped = stripListPrefix(lines[i]);
+    if (!stripped) {
+      i++;
+      continue;
+    }
 
-    for (const day of dayNames) {
-      if (lower.startsWith(day) || lower.startsWith(`${day}:`)) {
-        const temps = extractAllTemperatures(stripped);
-        const condition = inferCondition(stripped);
-        const dayLabel = day.charAt(0).toUpperCase() + day.slice(1, 3);
+    const matchedDay = matchesDayHeader(stripped);
+    if (!matchedDay) {
+      i++;
+      continue;
+    }
 
-        if (temps.length >= 2) {
-          forecast.push({
-            day: dayLabel,
-            high: `${temps[0].value}°${temps[0].unit}`,
-            low: `${temps[1].value}°${temps[1].unit}`,
-            condition: condition || null,
-          });
-        } else if (temps.length === 1) {
-          forecast.push({
-            day: dayLabel,
-            high: `${temps[0].value}°${temps[0].unit}`,
-            low: null,
-            condition: condition || null,
-          });
-        }
+    // Collect this line + any continuation lines until next day header /
+    // blank-then-day / clearly-new section.
+    const blockLines = [stripped];
+    const blockIndices = [i];
+    let j = i + 1;
+    let blanksSeen = 0;
+    while (j < lines.length && j - i <= 8) {
+      const nextStripped = stripListPrefix(lines[j]);
+      if (!nextStripped) {
+        // Allow one blank line within a block; stop on second blank
+        blanksSeen++;
+        if (blanksSeen >= 2) break;
+        j++;
+        continue;
+      }
+      blanksSeen = 0;
+      if (matchesDayHeader(nextStripped)) break;
+      // Stop at clearly non-forecast continuation
+      if (
+        /^(summary|note|tip|recommendation|advisory|alert|warning|disclaimer|if you|i can|let me)/i.test(
+          nextStripped
+        )
+      ) {
         break;
+      }
+      blockLines.push(nextStripped);
+      blockIndices.push(j);
+      j++;
+    }
+
+    const blockText = blockLines.join(' ');
+
+    // Prefer explicit "High:" / "Low:" labels
+    let high = null;
+    let low = null;
+    const highMatch = blockText.match(
+      /\b(?:high|hi|max(?:imum)?)\s*[:\-—–]?\s*(-?\d+(?:\.\d+)?\s*°?\s*[CF])/i
+    );
+    const lowMatch = blockText.match(
+      /\b(?:low|lo|min(?:imum)?)\s*[:\-—–]?\s*(-?\d+(?:\.\d+)?\s*°?\s*[CF])/i
+    );
+    if (highMatch) high = normalizeTempString(highMatch[1]);
+    if (lowMatch) low = normalizeTempString(lowMatch[1]);
+
+    // Fallback: first two temps in the block — first is high, second is low.
+    // Skip parenthetical temps (e.g. the "(26°C)" alt unit beside "80°F").
+    if (!high || !low) {
+      const noParen = blockText.replace(/\([^)]*\)/g, ' ');
+      const temps = extractAllTemperatures(noParen);
+      if (!high && temps.length >= 1) high = `${temps[0].value}°${temps[0].unit}`;
+      if (!low && temps.length >= 2) low = `${temps[1].value}°${temps[1].unit}`;
+    }
+
+    // Condition: prefer a "Conditions:" line in the block, fall back to inference
+    let condition = null;
+    const conditionsLineMatch = blockText.match(/\bconditions?\s*[:\-—–]\s*([^\n.;|·]+)/i);
+    if (conditionsLineMatch) {
+      condition = inferCondition(conditionsLineMatch[1]);
+    }
+    if (!condition) {
+      // Don't use the day name itself as condition input (avoid matching "sun" → Sunny for "Sunday")
+      const blockMinusDay = blockText.replace(new RegExp('^' + matchedDay + '\\b', 'i'), '');
+      condition = inferCondition(blockMinusDay);
+    }
+
+    const dayLabel = matchedDay.charAt(0).toUpperCase() + matchedDay.slice(1, 3);
+
+    if (high) {
+      // De-dupe: same day name shouldn't appear twice
+      if (!forecast.find((f) => f.day === dayLabel)) {
+        forecast.push({
+          day: dayLabel,
+          high,
+          low: low || null,
+          condition: condition || null,
+        });
+        // Mark the lines we used so they're stripped from the body text
+        for (const idx of blockIndices) consumed.add(idx);
+      }
+    }
+
+    i = j;
+  }
+
+  // If we extracted a forecast, also consume the header line that introduces
+  // it (e.g. "4-day forecast", "Forecast:", "Weekly outlook") and a bare
+  // "Summary" header that immediately precedes it.
+  if (forecast.length > 0) {
+    const minConsumed = Math.min(...consumed);
+    for (let k = Math.max(0, minConsumed - 4); k < minConsumed; k++) {
+      const stripped = stripListPrefix(lines[k]).toLowerCase();
+      if (!stripped) continue;
+      const isForecastHeader =
+        /^(?:\d+[\-\s]?day\s+)?(?:weekly\s+|extended\s+|multi[\-\s]?day\s+|short[\-\s]?term\s+|long[\-\s]?term\s+)?(?:forecast|outlook)\b/i.test(
+          stripped
+        );
+      const isBareSummary = /^summary\s*[:\-]?\s*$/i.test(stripped);
+      if (isForecastHeader || isBareSummary) {
+        consumed.add(k);
       }
     }
   }
-  return forecast;
+
+  return { forecast, consumed };
 }
 
 function extractSource(text) {
@@ -525,9 +655,9 @@ function extractSource(text) {
  * Identify which lines are "consumed" by the weather card extraction
  * and return everything else as remaining text for markdown rendering.
  */
-function extractRemainingText(text, weatherData) {
+function extractRemainingText(text, weatherData, preConsumed) {
   const lines = text.split('\n');
-  const consumed = new Set();
+  const consumed = new Set(preConsumed || []);
   const lower = text.toLowerCase();
 
   // Mark header/intro line (first 1-2 lines with location/weather context)
@@ -644,6 +774,40 @@ function extractRemainingText(text, weatherData) {
       consumed.add(i);
       continue;
     }
+
+    // Short "label: value" lines whose value is already shown in the card hero.
+    // Matches things like "Sky: Sunny", "Temperature: 80°F", "High: 80°F · Low: 64°F",
+    // "Condition: Rain", "Currently: Clear".
+    const heroLabels = [
+      'sky',
+      'skies',
+      'condition',
+      'conditions',
+      'current condition',
+      'current conditions',
+      'temperature',
+      'temp',
+      'high',
+      'hi',
+      'low',
+      'lo',
+      'max',
+      'maximum',
+      'min',
+      'minimum',
+      'currently',
+      'now',
+      'present weather',
+      'outlook',
+    ];
+    if (stripped.length < 100) {
+      for (const label of heroLabels) {
+        if (new RegExp('^' + label + '\\s*[:\\-—–]').test(stripped)) {
+          consumed.add(i);
+          break;
+        }
+      }
+    }
   }
 
   // Collect remaining lines
@@ -667,7 +831,7 @@ export function extractWeatherData(text) {
   const temps = extractAllTemperatures(text);
   const mainCondition = inferCondition(text);
   const periods = extractPeriods(text);
-  const forecast = extractForecast(text);
+  const { forecast, consumed: forecastConsumed } = extractForecast(text);
   const source = extractSource(text);
 
   // Current temperature — first temperature in the text
@@ -739,8 +903,9 @@ export function extractWeatherData(text) {
     source,
   };
 
-  // Extract text not consumed by the card
-  weatherData.remainingText = extractRemainingText(text, weatherData);
+  // Extract text not consumed by the card (start with forecast-block indices
+  // so multi-line forecast entries don't leak into the body text below).
+  weatherData.remainingText = extractRemainingText(text, weatherData, forecastConsumed);
 
   return weatherData;
 }

--- a/src/components/WeatherCard/weatherParser.test.js
+++ b/src/components/WeatherCard/weatherParser.test.js
@@ -98,3 +98,120 @@ Temperature: 31°C
     expect(data.current.condition).toBe('Sunny');
   });
 });
+
+describe('extractWeatherData — forecast extraction', () => {
+  it('extracts a multi-line numbered 4-day forecast (the user-reported case)', () => {
+    const text = `London — 80°F (26°C), Sunny.
+
+4-day forecast (dates shown)
+1. Friday — May 22, 2026
+   - Conditions: Intervals of clouds and sunshine, very warm
+   - High: 80°F (26°C) · Low: 64°F (18°C).
+2. Saturday — May 23, 2026
+   - Conditions: Mostly sunny and very warm
+   - High: 83°F (28°C) · Low: 60°F (16°C).
+3. Sunday — May 24, 2026
+   - Conditions: Very warm with sunshine
+   - High: 85°F (30°C) · Low: 62°F (17°C).
+4. Monday — May 25, 2026
+   - Conditions: Very warm with sunshine
+   - High: 89°F (32°C) · Low: 64°F (18°C).
+
+Note: Monday looks the hottest of the period.`;
+    const data = extractWeatherData(text);
+    expect(data.forecast).not.toBeNull();
+    expect(data.forecast).toHaveLength(4);
+    expect(data.forecast[0]).toMatchObject({ day: 'Fri', high: '80°F', low: '64°F' });
+    expect(data.forecast[1]).toMatchObject({ day: 'Sat', high: '83°F', low: '60°F' });
+    expect(data.forecast[2]).toMatchObject({ day: 'Sun', high: '85°F', low: '62°F' });
+    expect(data.forecast[3]).toMatchObject({ day: 'Mon', high: '89°F', low: '64°F' });
+  });
+
+  it('removes the consumed forecast block from remainingText (Note still kept)', () => {
+    const text = `London — 80°F, Sunny.
+
+4-day forecast
+1. Friday — May 22, 2026
+   - High: 80°F · Low: 64°F.
+2. Saturday — May 23, 2026
+   - High: 83°F · Low: 60°F.
+
+Note: Monday looks the hottest of the period.`;
+    const data = extractWeatherData(text);
+    expect(data.forecast).toHaveLength(2);
+    // The note should still be present in remainingText
+    expect(data.remainingText || '').toContain('Monday looks the hottest');
+    // But the forecast day lines should NOT be in remainingText
+    expect(data.remainingText || '').not.toContain('Friday — May 22');
+    expect(data.remainingText || '').not.toContain('Saturday — May 23');
+    expect(data.remainingText || '').not.toContain('High: 80°F');
+    // And the forecast header itself should be gone
+    expect(data.remainingText || '').not.toContain('4-day forecast');
+  });
+
+  it('extracts compact single-line forecast format', () => {
+    const text = `Toronto
+Currently: 11°C, Sunny.
+
+- Mon: 21°C / 11°C, Sunny
+- Tue: 19°C / 10°C, Partly Cloudy
+- Wed: 16°C / 8°C, Rain`;
+    const data = extractWeatherData(text);
+    expect(data.forecast).toHaveLength(3);
+    expect(data.forecast[0]).toMatchObject({ day: 'Mon', high: '21°C', low: '11°C' });
+    expect(data.forecast[1]).toMatchObject({ day: 'Tue', high: '19°C', low: '10°C' });
+    expect(data.forecast[2]).toMatchObject({ day: 'Wed', high: '16°C', low: '8°C' });
+  });
+
+  it('handles bold day headers with details on the next lines', () => {
+    const text = `Weather report
+
+**Friday**
+- High: 22°C
+- Low: 14°C
+- Cloudy
+
+**Saturday**
+- High: 25°C
+- Low: 16°C
+- Sunny`;
+    const data = extractWeatherData(text);
+    expect(data.forecast).toHaveLength(2);
+    expect(data.forecast[0]).toMatchObject({ day: 'Fri', high: '22°C', low: '14°C' });
+    expect(data.forecast[1]).toMatchObject({ day: 'Sat', high: '25°C', low: '16°C' });
+  });
+
+  it('does not treat "Sunday" as the Sunny condition', () => {
+    const text = `Forecast
+
+1. Sunday — May 24
+   - High: 18°C · Low: 9°C
+   - Conditions: Heavy rain`;
+    const data = extractWeatherData(text);
+    expect(data.forecast).toHaveLength(1);
+    expect(data.forecast[0].condition).toBe('Heavy Rain');
+  });
+
+  it('returns null forecast for text with no day headers', () => {
+    const text = `It's currently 22°C and sunny in Paris with low humidity.`;
+    const data = extractWeatherData(text);
+    expect(data.forecast).toBeNull();
+  });
+
+  it('maps "Intervals of clouds and sunshine" to Partly Cloudy', () => {
+    const text = `Friday
+- Conditions: Intervals of clouds and sunshine, very warm
+- High: 80°F · Low: 64°F`;
+    const data = extractWeatherData(text);
+    expect(data.forecast).toHaveLength(1);
+    expect(data.forecast[0].condition).toBe('Partly Cloudy');
+  });
+
+  it('maps "Mostly sunny" to Partly Cloudy in a forecast block', () => {
+    const text = `Saturday
+- Conditions: Mostly sunny and very warm
+- High: 83°F · Low: 60°F`;
+    const data = extractWeatherData(text);
+    expect(data.forecast[0].condition).toBe('Partly Cloudy');
+  });
+});


### PR DESCRIPTION
## Summary

Multi-day forecasts now render *in* the weather card (day · icon · high/low strip) instead of leaking out as plain markdown below it. The parser was only catching single-line forecast entries — multi-line numbered formats like the user's "1. Friday — May 22, 2026 / Conditions: … / High: 80°F · Low: 64°F" were unrecognised and fell through to body text.

## What's new in `extractForecast`

- **Handles every common shape** the LLM produces:
  - `Mon: 21°C / 11°C, Sunny` (compact one-liner)
  - `**Friday**\n  - High: 22°C\n  - Low: 14°C\n  - Cloudy` (bold + bullets)
  - `1. Friday — May 22, 2026\n  - Conditions: …\n  - High: 80°F · Low: 64°F` (numbered + multi-line)
- Walks each day-header line plus its continuation lines, stopping at the next day header / blank gap / "Summary"/"Note" section
- Prefers explicit `High:` / `Low:` labels; falls back to the first two temps in the block. Strips `(…)` so the alt-unit `(26°C)` next to `80°F` isn't picked up as the low.
- Reads `Conditions: …` lines for the per-day icon; uses our improved condition matcher (now recognises "intervals of clouds and sunshine", "clouds and sun", "sunshine and clouds", etc. as Partly Cloudy)
- Avoids the classic "Sunday → Sunny" confusion by stripping the day-name from the condition input
- De-dupes if the same day appears twice

## Body-text cleanup

`extractForecast` now records the exact line indices it consumed, which the body-text extractor uses as a starting set. The "N-day forecast" / "Forecast:" / bare "Summary" header preceding the block is also consumed.

Short `Sky: …`, `Temperature: …`, `High: … · Low: …`, `Currently: …` lines (whose values already live in the card hero) are now stripped from the body too — so what's left below the card is just the prose: notes, recommendations, follow-up offers.

## Verified against the user-reported case

Input (London 4-day forecast) now extracts as:
```json
[
  { "day": "Fri", "high": "80°F", "low": "64°F", "condition": "Partly Cloudy" },
  { "day": "Sat", "high": "83°F", "low": "60°F", "condition": "Partly Cloudy" },
  { "day": "Sun", "high": "85°F", "low": "62°F", "condition": "Sunny" },
  { "day": "Mon", "high": "89°F", "low": "64°F", "condition": "Sunny" }
]
```

Remaining body text below the card:
```
**Note:** Monday looks the hottest of the period. Take heat precautions…
If you want hourly breakdowns, precipitation probability, wind and humidity…
```

## Tests

8 new tests added (19 total, all pass):
- Multi-line numbered 4-day forecast extracts correctly
- Forecast block stripped from `remainingText`, Note still kept
- Compact single-line format still works
- Bold day headers with details on next lines
- "Sunday" not classified as the "Sunny" condition
- Returns `null` forecast when no day headers present
- "Intervals of clouds and sunshine" → Partly Cloudy
- "Mostly sunny" → Partly Cloudy

## Scope

Only `weatherParser.js` and its tests are touched. No changes to the card component, animations, current-weather rendering, or any other file.

## Test plan

- [ ] Ask "give me weather for the next 4 days in London" — confirm the 4 days render *in the card* as day · icon · high/low, with the body below containing only the Note and follow-up
- [ ] Try other forecast phrasings (Toronto next 5 days, etc.) — confirm extraction still works
- [ ] Ask a current-conditions-only query (no forecast) — confirm body text is unaffected

https://claude.ai/code/session_0125LBngDm8nrnPMhyE1QwWw

---
_Generated by [Claude Code](https://claude.ai/code/session_0125LBngDm8nrnPMhyE1QwWw)_