### PR TITLE
fix(subscription): no Free flash on sign-in; no silent downgrade on stale refetch

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -26,7 +26,7 @@ import {
 } from '../../services/api';
 import { useToast } from '../Toast/Toast';
 import { selectProjects, setProjects } from '../../store/slices/projectsSlice';
-import { selectCurrentTier } from '../../store/slices/subscriptionSlice';
+import { selectCurrentTier, selectTierLoaded } from '../../store/slices/subscriptionSlice';
 import {
   PlusIcon,
   ChevronLeftIcon,
@@ -170,6 +170,7 @@ export default function Sidebar() {
   const [linkCopied, setLinkCopied] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const userTier = useSelector(selectCurrentTier);
+  const tierLoaded = useSelector(selectTierLoaded);
   const [searchOpen, setSearchOpen] = useState(false);
   const userMenuRef = useRef(null);
   const renameInputRef = useRef(null);
@@ -962,7 +963,9 @@ export default function Sidebar() {
                     </span>
                     <span className={styles.userPlan}>
                       {isAuthenticated
-                        ? `${userTier.charAt(0).toUpperCase() + userTier.slice(1)} plan`
+                        ? tierLoaded
+                          ? `${userTier.charAt(0).toUpperCase() + userTier.slice(1)} plan`
+                          : 'Loading plan…'
                         : 'Sign in to save'}
                     </span>
                   </div>

--- a/src/hooks/useAuthListener.js
+++ b/src/hooks/useAuthListener.js
@@ -1,12 +1,20 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { supabase } from '../lib/supabase';
-import { initializeAuth, setAuth, clearAuth, signOut, updateBirthDate } from '../store/slices/authSlice';
+import {
+  initializeAuth,
+  setAuth,
+  clearAuth,
+  signOut,
+  updateBirthDate,
+} from '../store/slices/authSlice';
 import { resetChatState, setCreditBalance } from '../store/slices/chatSlice';
 import { resetProjectsState } from '../store/slices/projectsSlice';
 import {
   resetSubscriptionState,
   setSubscriptionData,
+  setSubscriptionLoading,
+  setSubscriptionFailed,
   setImageCredits,
 } from '../store/slices/subscriptionSlice';
 import { resetGuestPromptCount } from '../utils/guestSession';
@@ -21,23 +29,42 @@ import { isAgeAllowed, MIN_AGE } from '../utils/age';
 // TOKEN_REFRESHED arriving close together don't fan out into duplicate
 // API calls.
 let hydrationInFlight = null;
+// Wall-clock of the last successful subscription fetch. Used by the
+// visibility listener to decide whether to re-validate when the tab
+// regains focus.
+let lastHydratedAt = 0;
+
+// Up to 5 attempts with exponential backoff capped at 4s
+// (500, 1000, 2000, 4000, 4000) — total ~11s worth of retries.
+// Hydration is infrequent and important: a stale tier locks the user out
+// of paid features they've actually paid for, so we'd rather try a few
+// more times than give up after 1.5s.
+const SUBSCRIPTION_FETCH_MAX_ATTEMPTS = 5;
+const SUBSCRIPTION_FETCH_BACKOFF_CAP_MS = 4000;
 
 function hydrateUserState(dispatch) {
   if (hydrationInFlight) return hydrationInFlight;
 
-  // Retry the subscription fetch a couple of times before giving up so a
-  // single transient 401/network blip can't pin the user at the default
-  // 'free' tier until they reload.
+  dispatch(setSubscriptionLoading());
+
+  // Retry the subscription fetch several times before giving up. We never
+  // dispatch a fallback "free" tier on failure — the slice keeps the last
+  // known value so a transient API blip can't silently downgrade a paying
+  // user. The server-side endpoint is now strict (returns 5xx on real DB
+  // errors instead of returning tier="free"), so a 200 response really is
+  // authoritative and is safe to apply.
   const fetchWithRetry = async (attempt = 0) => {
     try {
       const data = await fetchSubscription();
       dispatch(setSubscriptionData(data));
+      lastHydratedAt = Date.now();
     } catch (err) {
-      if (attempt < 2) {
-        const delay = 500 * 2 ** attempt;
+      if (attempt < SUBSCRIPTION_FETCH_MAX_ATTEMPTS - 1) {
+        const delay = Math.min(500 * 2 ** attempt, SUBSCRIPTION_FETCH_BACKOFF_CAP_MS);
         await new Promise((r) => setTimeout(r, delay));
         return fetchWithRetry(attempt + 1);
       }
+      dispatch(setSubscriptionFailed());
       logger.warn('subscription hydration failed', {
         route: 'auth.hydrate',
         reason: err?.message,
@@ -71,6 +98,18 @@ function hydrateUserState(dispatch) {
     hydrationInFlight = null;
   });
   return hydrationInFlight;
+}
+
+/**
+ * Re-fetch the subscription if it hasn't been refreshed recently. Called
+ * when the tab regains visibility so a session left idle for a while
+ * picks up any tier changes (Stripe events, manual upgrades) without
+ * requiring a page reload.
+ */
+const STALE_AFTER_MS = 2 * 60 * 1000; // 2 minutes
+function refreshIfStale(dispatch) {
+  if (Date.now() - lastHydratedAt < STALE_AFTER_MS) return;
+  hydrateUserState(dispatch);
 }
 
 // ---------------------------------------------------------------------------
@@ -163,7 +202,12 @@ export default function useAuthListener() {
             // /signup/verify-age for manual entry.
             const provider = session?.user?.app_metadata?.provider;
             const providerToken = session?.provider_token;
-            if (event === 'SIGNED_IN' && provider === 'google' && providerToken && !user.birthDate) {
+            if (
+              event === 'SIGNED_IN' &&
+              provider === 'google' &&
+              providerToken &&
+              !user.birthDate
+            ) {
               fetchGoogleBirthday(providerToken)
                 .then((birthDate) => {
                   if (!birthDate) return; // Falls through to manual entry.
@@ -209,6 +253,7 @@ export default function useAuthListener() {
           setLoggerUser(null);
           resetGuestPromptCount();
           clearImageCache();
+          lastHydratedAt = 0;
 
           // 2. Clear user-specific localStorage
           USER_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
@@ -228,9 +273,33 @@ export default function useAuthListener() {
       }
     });
 
-    // 3. Cleanup on unmount
+    // 3. Refresh subscription when the tab regains visibility after being
+    //    hidden long enough to be considered stale. Catches the case
+    //    where the user upgraded in another tab / Stripe portal and came
+    //    back without a Supabase auth event firing.
+    const handleVisibilityChange = () => {
+      if (typeof document === 'undefined') return;
+      if (document.visibilityState !== 'visible') return;
+      // Read current auth state via the supabase client rather than the
+      // redux selector so we don't have to wire up a subscription —
+      // this is a one-shot check, not a derived view.
+      supabase.auth.getSession().then(({ data }) => {
+        const sUser = data?.session?.user;
+        if (sUser && !sUser.is_anonymous) {
+          refreshIfStale(dispatch);
+        }
+      });
+    };
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+
+    // 4. Cleanup on unmount
     return () => {
       subscription.unsubscribe();
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+      }
     };
   }, [dispatch]);
 }

--- a/src/store/slices/subscriptionSlice.js
+++ b/src/store/slices/subscriptionSlice.js
@@ -54,6 +54,12 @@ const initialState = {
   periodEnd: null,
   cancelAtPeriodEnd: false,
   subscriptionStatus: 'idle', // 'idle' | 'loading' | 'succeeded' | 'failed'
+  // Sticky flag: true once we've successfully loaded the subscription
+  // from the server at least once this session. Stays true across later
+  // re-fetches (succeeded or failed) so the UI never falls back to the
+  // default "Free" label after we know the real tier. Reset only on
+  // sign-out via `resetSubscriptionState`.
+  tierLoaded: false,
   // Text credits (monthly + 3-hour window)
   textCredits: {
     monthlyUsed: 0,
@@ -97,6 +103,14 @@ const subscriptionSlice = createSlice({
     setImageCredits: (state, action) => {
       state.imageCredits = { ...state.imageCredits, ...action.payload };
     },
+    /** Mark a subscription fetch as in flight. */
+    setSubscriptionLoading: (state) => {
+      state.subscriptionStatus = 'loading';
+    },
+    /** Mark a subscription fetch as failed. */
+    setSubscriptionFailed: (state) => {
+      state.subscriptionStatus = 'failed';
+    },
     /** Bulk setter from API response — avoids multiple dispatches */
     setSubscriptionData: (state, action) => {
       const data = action.payload;
@@ -124,6 +138,7 @@ const subscriptionSlice = createSlice({
         };
       }
       state.subscriptionStatus = 'succeeded';
+      state.tierLoaded = true;
     },
     showUpgradeModal: (state, action) => {
       state.showUpgradeModal = true;
@@ -172,6 +187,7 @@ const subscriptionSlice = createSlice({
         state.cancelAtPeriodEnd = data.cancelAtPeriodEnd ?? false;
         state.isFirstMonth = data.firstMonth ?? false;
         state.subscriptionStatus = 'succeeded';
+        state.tierLoaded = true;
       })
       .addCase(fetchSubscriptionThunk.rejected, (state) => {
         state.subscriptionStatus = 'failed';
@@ -208,6 +224,8 @@ export const {
   setTextCredits,
   setImageCredits,
   setSubscriptionData,
+  setSubscriptionLoading,
+  setSubscriptionFailed,
   showUpgradeModal,
   hideUpgradeModal,
   initiateUpgrade,
@@ -221,6 +239,13 @@ export const selectIsFirstMonth = (state) => state.subscription.isFirstMonth;
 export const selectPeriodEnd = (state) => state.subscription.periodEnd;
 export const selectCancelAtPeriodEnd = (state) => state.subscription.cancelAtPeriodEnd;
 export const selectSubscriptionStatus = (state) => state.subscription.subscriptionStatus;
+/**
+ * True once we've successfully loaded the subscription from the server at
+ * least once this session. Components that render the tier as text should
+ * gate on this so they don't flash the default "Free" before the real tier
+ * arrives.
+ */
+export const selectTierLoaded = (state) => state.subscription.tierLoaded;
 export const selectTextCredits = (state) => state.subscription.textCredits;
 export const selectImageCredits = (state) => state.subscription.imageCredits;
 export const selectShowUpgradeModal = (state) => state.subscription.showUpgradeModal;

--- a/src/store/slices/subscriptionSlice.test.js
+++ b/src/store/slices/subscriptionSlice.test.js
@@ -6,6 +6,8 @@ import subscriptionReducer, {
   setTextCredits,
   setImageCredits,
   setSubscriptionData,
+  setSubscriptionLoading,
+  setSubscriptionFailed,
   showUpgradeModal,
   hideUpgradeModal,
   initiateUpgrade,
@@ -25,6 +27,7 @@ import subscriptionReducer, {
   selectCheckoutLoading,
   selectPortalLoading,
   selectSubscriptionError,
+  selectTierLoaded,
 } from './subscriptionSlice';
 
 describe('subscriptionSlice', () => {
@@ -45,6 +48,10 @@ describe('subscriptionSlice', () => {
 
     it('defaults to idle subscription status', () => {
       expect(defaultState.subscriptionStatus).toBe('idle');
+    });
+
+    it('defaults to tierLoaded false', () => {
+      expect(defaultState.tierLoaded).toBe(false);
     });
 
     it('has default text credits', () => {
@@ -143,12 +150,42 @@ describe('subscriptionSlice', () => {
     });
 
     it('handles partial data gracefully', () => {
-      const state = subscriptionReducer(
-        defaultState,
-        setSubscriptionData({ tier: 'pro' })
-      );
+      const state = subscriptionReducer(defaultState, setSubscriptionData({ tier: 'pro' }));
       expect(state.currentTier).toBe('pro');
       expect(state.billingCycle).toBe('monthly'); // unchanged
+    });
+
+    it('marks tierLoaded true after a successful fetch', () => {
+      const state = subscriptionReducer(defaultState, setSubscriptionData({ tier: 'pro' }));
+      expect(state.tierLoaded).toBe(true);
+    });
+
+    it('keeps tierLoaded true across a later failed fetch', () => {
+      let state = subscriptionReducer(defaultState, setSubscriptionData({ tier: 'pro' }));
+      state = subscriptionReducer(state, setSubscriptionFailed());
+      expect(state.tierLoaded).toBe(true);
+      expect(state.subscriptionStatus).toBe('failed');
+      expect(state.currentTier).toBe('pro');
+    });
+
+    it('keeps tierLoaded true while a re-fetch is loading', () => {
+      let state = subscriptionReducer(defaultState, setSubscriptionData({ tier: 'pro' }));
+      state = subscriptionReducer(state, setSubscriptionLoading());
+      expect(state.tierLoaded).toBe(true);
+      expect(state.subscriptionStatus).toBe('loading');
+      expect(state.currentTier).toBe('pro');
+    });
+  });
+
+  describe('setSubscriptionLoading / setSubscriptionFailed', () => {
+    it('setSubscriptionLoading flips status to loading', () => {
+      const state = subscriptionReducer(defaultState, setSubscriptionLoading());
+      expect(state.subscriptionStatus).toBe('loading');
+    });
+
+    it('setSubscriptionFailed flips status to failed', () => {
+      const state = subscriptionReducer(defaultState, setSubscriptionFailed());
+      expect(state.subscriptionStatus).toBe('failed');
     });
   });
 
@@ -193,6 +230,13 @@ describe('subscriptionSlice', () => {
       state = subscriptionReducer(state, resetSubscriptionState());
       expect(state.currentTier).toBe('free');
       expect(state.billingCycle).toBe('monthly');
+    });
+
+    it('clears tierLoaded on sign-out', () => {
+      let state = subscriptionReducer(defaultState, setSubscriptionData({ tier: 'pro' }));
+      expect(state.tierLoaded).toBe(true);
+      state = subscriptionReducer(state, resetSubscriptionState());
+      expect(state.tierLoaded).toBe(false);
     });
   });
 
@@ -276,6 +320,7 @@ describe('subscriptionSlice', () => {
         periodEnd: '2024-12-31',
         cancelAtPeriodEnd: false,
         subscriptionStatus: 'succeeded',
+        tierLoaded: true,
         textCredits: { monthlyUsed: 100, monthlyLimit: 4000 },
         imageCredits: { used: 10, limit: 150, remaining: 140 },
         showUpgradeModal: false,
@@ -294,12 +339,10 @@ describe('subscriptionSlice', () => {
     it('selectCancelAtPeriodEnd', () => expect(selectCancelAtPeriodEnd(rootState)).toBe(false));
     it('selectSubscriptionStatus', () =>
       expect(selectSubscriptionStatus(rootState)).toBe('succeeded'));
-    it('selectTextCredits', () =>
-      expect(selectTextCredits(rootState).monthlyLimit).toBe(4000));
-    it('selectImageCredits', () =>
-      expect(selectImageCredits(rootState).remaining).toBe(140));
-    it('selectShowUpgradeModal', () =>
-      expect(selectShowUpgradeModal(rootState)).toBe(false));
+    it('selectTierLoaded', () => expect(selectTierLoaded(rootState)).toBe(true));
+    it('selectTextCredits', () => expect(selectTextCredits(rootState).monthlyLimit).toBe(4000));
+    it('selectImageCredits', () => expect(selectImageCredits(rootState).remaining).toBe(140));
+    it('selectShowUpgradeModal', () => expect(selectShowUpgradeModal(rootState)).toBe(false));
     it('selectUpgradeContext', () => expect(selectUpgradeContext(rootState)).toBeNull());
     it('selectUpgradeLoading', () => expect(selectUpgradeLoading(rootState)).toBeNull());
     it('selectCheckoutLoading', () => expect(selectCheckoutLoading(rootState)).toBe(false));


### PR DESCRIPTION
## Summary

Two related user-visible problems with the subscription / tier state:

1. **"Free" flashes on sign-in.** The Redux slice initialized `currentTier` to `'free'`, and components like the sidebar rendered `${tier} plan` immediately on auth — so for a few hundred ms after login a paying user saw "Free plan" before the real tier arrived from `/api/subscription`.

2. **Tier silently switches to "free" mid-session.** Any later refetch (Supabase `TOKEN_REFRESHED`, returning from Stripe portal, settings page load) that received a worse tier overwrote the known-good one in Redux. The user then lost access to paid features until they reloaded.

This PR paired with the araviel-api PR (same branch name) addresses both:

- Add a sticky `tierLoaded` flag to the subscription slice. Flips to `true` on the first successful fetch, stays `true` through later failed/loading refetches; only resets on sign-out via `resetSubscriptionState`.
- Expose `setSubscriptionLoading` / `setSubscriptionFailed` reducers so the non-thunk hydration path in `useAuthListener` can signal loading and failure states without dispatching tier data.
- In `useAuthListener.hydrateUserState`: mark the slice as loading at the start; widen the retry budget to 5 attempts with backoff capped at 4s (was 2 attempts, ~1.5s); on final failure, mark the slice failed but **leave the tier untouched** so we keep showing the last-known value.
- Add a `visibilitychange` listener that re-validates the subscription when the tab regains focus and the last successful fetch is older than two minutes. Catches the "left for a while, came back" case without a periodic poll.
- In the sidebar's plan label, show `"Loading plan…"` until `tierLoaded` so authenticated users never see a stale "Free plan" placeholder.

The companion araviel-api change is what makes "never overwrite with worse" safe: the server now returns a 5xx on real DB errors instead of silently returning `tier="free"` with a 200, so a 200 response really is authoritative.

## Test plan
- [x] `npx vitest run src/store/slices/subscriptionSlice.test.js` — 48/48 pass, includes new tests for `tierLoaded` sticky semantics + loading/failed reducers
- [x] Full `npx vitest run` — 551/552 (1 pre-existing failure in `authSlice.test.js` unrelated to this change)
- [x] `npx vite build` — succeeds
- [x] `npx eslint` on touched files — clean
- [ ] Manually verify: fresh sign-in shows "Loading plan…" briefly, then the real tier — never "Free plan" for a paid user
- [ ] Manually verify: forcing `/api/subscription` to return 5xx leaves the previously-loaded tier visible (no flip to Free)
- [ ] Manually verify: tab background → foreground after 2 min triggers a re-fetch


---
_Generated by [Claude Code](https://claude.ai/code/session_01NeoiAZFfqaWL2NfKQRRSLj)_