### PR TITLE
fix(share): lift modal overlay above the composer so it doesn't bleed through

### DIFF
--- a/src/components/ShareModal/ShareModal.module.css
+++ b/src/components/ShareModal/ShareModal.module.css
@@ -6,7 +6,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  /* Must sit above MainContent's .container (z-index: 1050) and the mobile
+     menu button (z-index: 1001) so the modal isn't bled through by the
+     composer/greeting underneath. */
+  z-index: 2000;
   animation: overlayFadeIn 0.2s ease;
 }
 


### PR DESCRIPTION
## Summary

On the landing screen, the share modal opened from the sidebar / conversations list rendered with the greeting and "Ask anything…" composer bleeding through it.

`MainContent .container` (the greeting + composer wrapper) sits at `z-index: 1050` and its own comment explicitly states "Stays below modals (z-index ≥ 2000)". The share overlay was at `z-index: 1000`, breaking that contract. Lifted it to `2000`.

## Repro (before)

1. Sign in, land on the home screen with no conversation selected.
2. Open the sidebar `⋯` menu on any chat → click Share.
3. The modal opens but the greeting and composer render on top of it.

## Test plan

- [ ] After fix, the share modal fully covers the greeting and composer on the landing screen.
- [ ] Share modal opened from the conversation top-nav still behaves correctly (was already working — same overlay).

---
_Generated by [Claude Code](https://claude.ai/code/session_017KJnzQjPzJDTYCFioXpxMc)_