### PR TITLE
feat(suggestions): send follow-up chips on click instead of populating

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -4791,7 +4791,20 @@ function QuestionCard({ questions, onComplete, onDismiss }) {
 }
 
 function SuggestionsList({ suggestions, onSelect }) {
+  // Suggestions are sent immediately on click (the chips are full, complete
+  // prompts — populate-then-send would just add friction). Lock the list as
+  // soon as one fires so a fast double-tap can't queue the same chip twice.
+  // The list unmounts when the next response starts streaming, so this state
+  // is short-lived.
+  const [sent, setSent] = useState(false);
+
   if (!suggestions || suggestions.length === 0) return null;
+
+  const handleClick = (suggestion) => {
+    if (sent) return;
+    setSent(true);
+    onSelect(suggestion);
+  };
 
   return (
     <div className={styles.suggestionsList}>
@@ -4800,7 +4813,12 @@ function SuggestionsList({ suggestions, onSelect }) {
       </div>
       <div className={styles.suggestionsItems}>
         {suggestions.map((suggestion, idx) => (
-          <button key={idx} className={styles.suggestionItem} onClick={() => onSelect(suggestion)}>
+          <button
+            key={idx}
+            className={styles.suggestionItem}
+            onClick={() => handleClick(suggestion)}
+            disabled={sent}
+          >
             <span className={styles.suggestionText}>{suggestion}</span>
             <ArrowRightIcon />
           </button>
@@ -6232,10 +6250,11 @@ export default function MessageList({
 
   const handleFollowUpSelect = useCallback(
     (text) => {
-      dispatch(setInputValue(text));
-      if (focusInput) focusInput();
+      if (onSendMessage && text) {
+        onSendMessage(text, { addUserMessage: true });
+      }
     },
-    [dispatch, focusInput]
+    [onSendMessage]
   );
 
   const handleQuestionsSend = useCallback(

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -2479,6 +2479,11 @@
   opacity: 1;
 }
 
+.suggestionItem:disabled {
+  cursor: default;
+  pointer-events: none;
+}
+
 .suggestionItem svg {
   width: 13px;
   height: 13px;


### PR DESCRIPTION
## Summary

Follow-up suggestion chips below an assistant response are full, complete prompts ("Hourly table for Maidstone"), not templates that need editing. Today, clicking one populates the input — the user then has to click send. Every other major chat product (ChatGPT, Claude.ai, Perplexity, Gemini) sends immediately on chip click. This PR matches that pattern.

## Changes

- **`handleFollowUpSelect`** now calls `onSendMessage(text, { addUserMessage: true })` directly, mirroring the existing `handleQuestionsSend` path. `setInputValue` / `focusInput` are no longer involved in this flow — user drafts in the input are preserved.
- **`SuggestionsList`** tracks a one-shot `sent` flag that disables every chip on first click, so a fast double-tap can't queue the same prompt twice. The list unmounts when the next response begins streaming, so the disabled state is only ever visible for a frame or two.
- **CSS** adds a minimal `:disabled` rule (`cursor: default; pointer-events: none`) on `.suggestionItem` so the brief disabled flash before the section unmounts looks intentional, not glitchy.

No other behavior changed. The settings toggle (`Follow-up suggestions`) and AI-generated `questions` flow are untouched.

## Test plan

- [x] `npx eslint` — clean (one unrelated pre-existing warning at line 6127)
- [x] `npm test` — 559 unrelated tests pass (one pre-existing `authSlice` failure unrelated to this change)
- [ ] Manual: click a suggestion chip → message sends immediately, input stays unchanged
- [ ] Manual: type a draft, click a chip → suggestion sends, draft preserved
- [ ] Manual: rapidly double-click the same chip → only one message sent
- [ ] Manual: open Settings > Personalization > Follow-up suggestions OFF → chips don't render

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_