### PR TITLE
fix(weather-card): never render a broken card when the data is fake

### DIFF
--- a/src/components/WeatherCard/weatherParser.js
+++ b/src/components/WeatherCard/weatherParser.js
@@ -76,10 +76,54 @@ const WEATHER_CONTEXT_PHRASES = [
   'degrees fahrenheit',
 ];
 
+// Hard suppressors — when any of these are present the card MUST NOT render
+// regardless of how many weather words appear in the response. The model is
+// either being honest that it doesn't have real data, or already presenting
+// structured data the card extractor would only mangle.
+const SUPPRESS_PHRASES = [
+  'illustrative',
+  'example only',
+  'not real-time',
+  'not real time',
+  'cannot access',
+  'cannot fetch',
+  "can't access",
+  "can't fetch",
+  "i can't access",
+  "i can't fetch",
+  "i don't have access",
+  'i do not have access',
+  'no real-time',
+  'no real time',
+  "here's how to get",
+  'here is how to get',
+  'you can run',
+  'you can use the',
+  'set this in your environment',
+];
+
+// Markdown table separator — e.g. "|:---:|:---:|" — signals the model is
+// rendering structured data. Stealing pieces of it for the card always
+// produces broken output.
+const MARKDOWN_TABLE_SEPARATOR = /\n\s*\|\s*:?-+:?\s*\|\s*:?-+:?\s*\|/;
+
+// Template-literal syntax (Python f-strings, JS template literals, env vars)
+// means the model is showing code, not data.
+const TEMPLATE_LITERAL = /\{[^}\n]*\}|\$\{[^}]*\}|f"[^"]*\{[^}]*\}/;
+
 export function detectWeatherResponse(text) {
   if (!text || text.length < 30) return false;
 
   const lower = text.toLowerCase();
+
+  // Fail-closed gates: any of these and the card stays hidden, the response
+  // renders as plain markdown. Better to show no card than a broken one.
+  for (const phrase of SUPPRESS_PHRASES) {
+    if (lower.includes(phrase)) return false;
+  }
+  if (MARKDOWN_TABLE_SEPARATOR.test(text)) return false;
+  if (TEMPLATE_LITERAL.test(text)) return false;
+
   let score = 0;
 
   // Temperature patterns — strong signal

--- a/src/components/WeatherCard/weatherParser.test.js
+++ b/src/components/WeatherCard/weatherParser.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractWeatherData } from './weatherParser';
+import { detectWeatherResponse, extractWeatherData } from './weatherParser';
 
 describe('extractWeatherData — condition inference', () => {
   it('treats "Sky: sunny intervals" as Partly Cloudy even when rain chance is mentioned', () => {
@@ -213,5 +213,48 @@ Currently: 11°C, Sunny.
 - High: 83°F · Low: 60°F`;
     const data = extractWeatherData(text);
     expect(data.forecast[0].condition).toBe('Partly Cloudy');
+  });
+});
+
+describe('detectWeatherResponse — fail-closed gates', () => {
+  it('suppresses the card when the model labels its data as illustrative', () => {
+    const text = `Maidstone, Partly cloudy, 16°C, light wind.
+The example below is illustrative only and not real-time data.
+| 18:00 | 16 | Partly cloudy |`;
+    expect(detectWeatherResponse(text)).toBe(false);
+  });
+
+  it('suppresses the card when the model says it cannot fetch live weather', () => {
+    const text = `London current weather cannot be fetched from here in real time.
+Here is how to get current London weather using wttr.in or the Met Office API.
+The current temperature, humidity, and wind information would normally appear here.`;
+    expect(detectWeatherResponse(text)).toBe(false);
+  });
+
+  it('suppresses the card when the response contains a markdown table', () => {
+    const text = `Maidstone hourly forecast for today:
+
+| Time | Temp | Conditions | Rain | Wind |
+|:---:|:---:|:---:|:---:|:---:|
+| 18:00 | 16°C | Partly cloudy | 10% | WSW 10 |
+| 19:00 | 15°C | Patchy cloud | 10% | WSW 9 |`;
+    expect(detectWeatherResponse(text)).toBe(false);
+  });
+
+  it('suppresses the card when the response contains Python template literals', () => {
+    const text = `Here's how to fetch London weather:
+print(f"Feels like: {data['main']['feels_like']} °C")
+print(f"Wind: {data['wind']['speed']} m/s, temp 16°C, sunny")`;
+    expect(detectWeatherResponse(text)).toBe(false);
+  });
+
+  it('still renders the card for a clean live weather response', () => {
+    const text = `Current weather in London
+Temperature: 16°C
+Sky: light rain
+Feels like: 14°C
+Humidity: 78%
+Wind: 12 km/h NW`;
+    expect(detectWeatherResponse(text)).toBe(true);
   });
 });


### PR DESCRIPTION
The frontend WeatherCard parser was happily building a widget out of any response that mentioned a few weather words and a temperature — including the model's honest "I cannot fetch this, here's the wttr.in example" replies and the "illustrative only" hourly tables. It would then grep template literals, warning text, and markdown table cells into card fields, producing displays like a "Low: *illustrative only*" pill or a card with `{data['main']['feels_like']} °C` as the feels-like value.

Add hard fail-closed gates at the top of `detectWeatherResponse`:

- Phrase suppressors — illustrative, example only, cannot access, no real-time, "here's how to get", "you can run", and similar refusal/instruction language.
- Markdown table separator — `|:---:|:---:|` means the model is presenting structured data; stealing pieces of it always mangles the result. Let the markdown renderer do its job.
- Template literals — `{...}`, `${...}`, Python f-strings — the model is showing code, not data.

When any gate fires the card stays hidden and the response renders as plain markdown. Clean live-weather responses are unaffected and still get the card.