### PR TITLE
fix(weather-card): let real forecast tables render the card

### DIFF
--- a/src/components/WeatherCard/weatherParser.js
+++ b/src/components/WeatherCard/weatherParser.js
@@ -102,11 +102,6 @@ const SUPPRESS_PHRASES = [
   'set this in your environment',
 ];
 
-// Markdown table separator — e.g. "|:---:|:---:|" — signals the model is
-// rendering structured data. Stealing pieces of it for the card always
-// produces broken output.
-const MARKDOWN_TABLE_SEPARATOR = /\n\s*\|\s*:?-+:?\s*\|\s*:?-+:?\s*\|/;
-
 // Template-literal syntax (Python f-strings, JS template literals, env vars)
 // means the model is showing code, not data.
 const TEMPLATE_LITERAL = /\{[^}\n]*\}|\$\{[^}]*\}|f"[^"]*\{[^}]*\}/;
@@ -118,10 +113,14 @@ export function detectWeatherResponse(text) {
 
   // Fail-closed gates: any of these and the card stays hidden, the response
   // renders as plain markdown. Better to show no card than a broken one.
+  //
+  // A markdown table is no longer a suppressor on its own — real multi-day
+  // forecasts often ship a `| DAY | HIGH | LOW | CONDITIONS |` table that
+  // the card's forecast extractor reads correctly. The phrase suppressors
+  // still catch the fabricated/illustrative cases we actually care about.
   for (const phrase of SUPPRESS_PHRASES) {
     if (lower.includes(phrase)) return false;
   }
-  if (MARKDOWN_TABLE_SEPARATOR.test(text)) return false;
   if (TEMPLATE_LITERAL.test(text)) return false;
 
   let score = 0;

--- a/src/components/WeatherCard/weatherParser.test.js
+++ b/src/components/WeatherCard/weatherParser.test.js
@@ -231,14 +231,23 @@ The current temperature, humidity, and wind information would normally appear he
     expect(detectWeatherResponse(text)).toBe(false);
   });
 
-  it('suppresses the card when the response contains a markdown table', () => {
-    const text = `Maidstone hourly forecast for today:
+  it('renders the card for a real multi-day forecast table with cited sources', () => {
+    const text = `London Weather Forecast: 8 -- 11 June 2026
+Source: Met Office & AccuWeather
 
-| Time | Temp | Conditions | Rain | Wind |
-|:---:|:---:|:---:|:---:|:---:|
-| 18:00 | 16°C | Partly cloudy | 10% | WSW 10 |
-| 19:00 | 15°C | Patchy cloud | 10% | WSW 9 |`;
-    expect(detectWeatherResponse(text)).toBe(false);
+Daily Breakdown
+
+| DAY | HIGH | LOW | CONDITIONS |
+|:---|:---|:---|:---|
+| **Mon 8 Jun** | 19°C | 10°C | Rain, cloudy with heavier pulses |
+| **Tue 9 Jun** | 19°C | 10°C | Sunshine and showers, risk of thunder |
+| **Wed 10 Jun** | 19°C | 11°C | Sunshine and showers, possible hail |
+| **Thu 11 Jun** | 18°C | 13°C | Fine start, rain arriving later |
+
+Summary
+Today starts cloudy with intermittent rain in places, with more persistent rain
+and heavier pulses spreading east during the day, followed by brighter conditions.`;
+    expect(detectWeatherResponse(text)).toBe(true);
   });
 
   it('suppresses the card when the response contains Python template literals', () => {


### PR DESCRIPTION
## Summary

The previous fail-closed pass suppressed the `WeatherCard` whenever the response contained a markdown table separator. That was the right call for fabricated/illustrative tables (the Maidstone "Hourly table for Maidstone — example only" case where the parser grabbed garbage from cells), but it also blocks the polished card from rendering for **clean live-data responses that ship a real forecast table** — exactly when we want the card most. Users get a generic Recharts line chart instead.

This PR drops the table-separator gate and keeps the other two suppressors. Real forecast tables flow into `extractForecast`, which reads `**Mon 8 Jun** | 19°C | 10°C | …` rows correctly and renders the multi-day forecast strip with the sparkline.

## Changes

- **`weatherParser.js`** — remove the `MARKDOWN_TABLE_SEPARATOR` constant and the gate that used it. The two remaining gates stay intact:
  - **Phrase suppressors** (illustrative, cannot access, here's how to get, …) — still catches the Maidstone "illustrative only" case end-to-end.
  - **Template literals** (`{...}`, `${...}`, Python f-strings) — still catches the london-weather "Python example" case.
- **`weatherParser.test.js`** — replace the "table suppresses card" test with a "real multi-day forecast table renders the card" test. Other 23 tests untouched.

## Regression check

- [x] `npm test` — 564/565 (only failure is a pre-existing `authSlice` test unrelated to this change)
- [x] All 24 `weatherParser` tests pass — phrase suppressors, template-literal suppressor, condition inference, and the new forecast-table render case all green.
- [x] The original Maidstone "illustrative only" suppress test still passes via the phrase gate.

Pairs with the matching API PR (samaig-araviel/araviel-api#151) that stops the model emitting chart blocks for weather data, so the combined result is: one polished WeatherCard per response, no generic chart underneath.

## Test plan

- [ ] Manual: ask "give me weather for the next 4 days in London" — verify the WeatherCard renders with location, current condition, and the 4-day forecast strip; no Recharts chart underneath
- [ ] Manual: send a message that would have hit the old Maidstone bug ("illustrative" + table) — verify the card stays hidden and the markdown renders as-is
- [ ] Manual: send a weather code example (Python f-strings) — verify the card stays hidden

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_