### PR TITLE
fix(weather-card): hide low temps on mobile, cap forecast at 7 days

### DIFF
--- a/src/components/WeatherCard/WeatherCard.jsx
+++ b/src/components/WeatherCard/WeatherCard.jsx
@@ -785,7 +785,7 @@ export default function WeatherCard({ weatherData, isDark, renderMarkdown }) {
 
           {hasForecast && (
             <div className={styles.forecast}>
-              {forecast.map((f, i) => (
+              {forecast.slice(0, 7).map((f, i) => (
                 <ForecastDay key={`${f.day}-${i}`} item={f} index={i} />
               ))}
             </div>

--- a/src/components/WeatherCard/WeatherCard.module.css
+++ b/src/components/WeatherCard/WeatherCard.module.css
@@ -939,8 +939,11 @@
     font-size: 12.5px;
   }
 
+  /* On narrow phones, 7 cells × (high + low) crowds and the temperatures
+     collide. Drop the low so the high reads cleanly, matching the
+     iOS / Google Weather hourly-strip pattern. */
   .forecastLow {
-    font-size: 11px;
+    display: none;
   }
 
   .detailPill {


### PR DESCRIPTION
## Summary

On phones the forecast strip squeezes 7 day-cells side-by-side, and each cell's high+low temperature pair overruns its column — `60°F` and `49°F` visibly collide on the [user's screenshot](https://github.com/samaig-araviel/araviel-web/pull/403). This PR matches the iOS Weather / Google Weather hourly-strip pattern: on narrow viewports show just the high. The low stays on tablet and desktop where the column is wide enough to hold both cleanly.

## Changes

- **`WeatherCard.module.css`** — in the existing `@media (max-width: 540px)` block, swap `.forecastLow { font-size: 11px }` for `display: none`. Nothing else in that breakpoint changes.
- **`WeatherCard.jsx`** — `forecast.slice(0, 7).map(...)` so a model that returns 10–14 days doesn't overflow the strip. Seven is the natural week window the rest of the layout is sized for.

## What deliberately stays

- High temp typography, day-name labels, icons, and animations are all unchanged.
- Desktop/tablet view still shows both H and L exactly as before.
- The parser is untouched — this is a pure rendering tweak.

## Test plan

- [x] `npm test` — 564 relevant tests pass (one pre-existing `authSlice` failure unrelated)
- [ ] Manual: open the existing London 7-day forecast on a phone-width viewport — verify each day shows only the high temp and the row no longer overlaps
- [ ] Manual: same chat on desktop — verify both H and L still render

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_