### PR TITLE
fix(weather-card): wrap forecast to 7 cells per row instead of capping

### DIFF
--- a/src/components/WeatherCard/WeatherCard.jsx
+++ b/src/components/WeatherCard/WeatherCard.jsx
@@ -784,8 +784,11 @@ export default function WeatherCard({ weatherData, isDark, renderMarkdown }) {
           )}
 
           {hasForecast && (
-            <div className={styles.forecast}>
-              {forecast.slice(0, 7).map((f, i) => (
+            <div
+              className={styles.forecast}
+              style={{ '--forecast-cols': Math.min(7, forecast.length) }}
+            >
+              {forecast.map((f, i) => (
                 <ForecastDay key={`${f.day}-${i}`} item={f} index={i} />
               ))}
             </div>

--- a/src/components/WeatherCard/WeatherCard.module.css
+++ b/src/components/WeatherCard/WeatherCard.module.css
@@ -481,9 +481,11 @@
 
 .forecast {
   display: grid;
-  grid-auto-columns: minmax(0, 1fr);
-  grid-auto-flow: column;
-  gap: 2px;
+  /* Column count comes from --forecast-cols, set per-instance by JSX as
+     min(7, days). 4 days → 4 even columns spanning the row; 10 days →
+     row of 7 then a row of 3; 14 → two rows of 7. Fallback is 7. */
+  grid-template-columns: repeat(var(--forecast-cols, 7), minmax(0, 1fr));
+  gap: 8px 2px;
   padding-top: 14px;
   border-top: 1px solid var(--w-divider);
 }


### PR DESCRIPTION
## Summary

Follow-up to #404. That PR capped the forecast at 7 days, which silently dropped data when the user asked for a 10- or 14-day outlook. The intent was layout, not truncation: show every day the model returned, just keep each row at most 7 wide so the cells stay readable.

## Change

Switch the forecast grid from a single-row column-flow layout to `grid-template-columns: repeat(N, minmax(0, 1fr))`, where N is set per-instance via the `--forecast-cols` custom property to `Math.min(7, forecast.length)`. Row-gap added so wrapped rows breathe.

That gives:

- **4 days** → one row of 4 cells, full width
- **7 days** → one row of 7, full width
- **10 days** → row of 7, then a row of 3
- **14 days** → two rows of 7

Column count is data-driven and unbounded — the parser still controls what gets shown, the UI just never crams more than 7 per row.

## What stays from #404

- Low temps still hidden on mobile (≤540px) so the highs don't collide.
- All other forecast styling, animations, hover states, and the desktop H+L layout are unchanged.

## Test plan

- [x] `npm test` — 564 relevant tests pass (one pre-existing `authSlice` failure unrelated)
- [ ] Manual: ask "5-day London forecast" — verify 5 cells span the full row
- [ ] Manual: ask "14-day London forecast" — verify two rows of 7 with vertical breathing room
- [ ] Manual: same on mobile width — verify wrapping is clean and lows stay hidden

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_