### PR TITLE
fix(weather-card): keep multi-week forecasts intact (12-day, 14-day…)

### DIFF
--- a/src/components/WeatherCard/WeatherCard.jsx
+++ b/src/components/WeatherCard/WeatherCard.jsx
@@ -637,12 +637,15 @@ function DetailPill({ iconKey, label, value }) {
   );
 }
 
-function ForecastDay({ item, index }) {
+function ForecastDay({ item, index, showDate }) {
   const theme = mapConditionToTheme(item.condition);
   const IconComp = ICON_MAP[theme.icon] || CloudIcon;
+  // For multi-week forecasts, append the date number so "MON" doesn't appear
+  // twice without context. Single-week strips keep the cleaner 3-letter label.
+  const label = showDate && item.date ? `${item.day} ${item.date}` : item.day;
   return (
     <div className={styles.forecastDay} style={{ animationDelay: `${0.08 * index + 0.15}s` }}>
-      <span className={styles.forecastDayName}>{item.day}</span>
+      <span className={styles.forecastDayName}>{label}</span>
       <span className={styles.forecastIcon}>
         <IconComp size={28} />
       </span>
@@ -789,7 +792,12 @@ export default function WeatherCard({ weatherData, isDark, renderMarkdown }) {
               style={{ '--forecast-cols': Math.min(7, forecast.length) }}
             >
               {forecast.map((f, i) => (
-                <ForecastDay key={`${f.day}-${i}`} item={f} index={i} />
+                <ForecastDay
+                  key={`${f.day}-${f.date ?? i}`}
+                  item={f}
+                  index={i}
+                  showDate={forecast.length > 7}
+                />
               ))}
             </div>
           )}

--- a/src/components/WeatherCard/weatherParser.js
+++ b/src/components/WeatherCard/weatherParser.js
@@ -639,12 +639,19 @@ function extractForecast(text) {
     }
 
     const dayLabel = matchedDay.charAt(0).toUpperCase() + matchedDay.slice(1, 3);
+    // Capture the date number immediately after the day name (e.g. "Mon 8 Jun").
+    // Without this, a multi-week forecast (12-day, 14-day) collapses to seven
+    // entries because the second week's Mon dedupes against the first week's.
+    const dateMatch = stripped.match(new RegExp('^' + matchedDay + '\\s+(\\d+)', 'i'));
+    const date = dateMatch ? dateMatch[1] : null;
 
     if (high) {
-      // De-dupe: same day name shouldn't appear twice
-      if (!forecast.find((f) => f.day === dayLabel)) {
+      // De-dupe: same (day, date) shouldn't appear twice. Two different
+      // "Mon" entries are valid when their dates differ.
+      if (!forecast.find((f) => f.day === dayLabel && f.date === date)) {
         forecast.push({
           day: dayLabel,
+          date,
           high,
           low: low || null,
           condition: condition || null,

--- a/src/components/WeatherCard/weatherParser.test.js
+++ b/src/components/WeatherCard/weatherParser.test.js
@@ -214,6 +214,26 @@ Currently: 11°C, Sunny.
     const data = extractWeatherData(text);
     expect(data.forecast[0].condition).toBe('Partly Cloudy');
   });
+
+  it('keeps both weeks of a multi-week forecast — does not dedupe Mon 8 against Mon 15', () => {
+    const text = `London 12-day forecast:
+- Monday 8 Jun: High 61°F, Low 49°F, cloudy
+- Tuesday 9 Jun: High 64°F, Low 49°F, sunny
+- Wednesday 10 Jun: High 61°F, Low 49°F, showers
+- Thursday 11 Jun: High 61°F, Low 56°F, showers
+- Friday 12 Jun: High 71°F, Low 55°F, cloudy
+- Saturday 13 Jun: High 74°F, Low 61°F, sunny
+- Sunday 14 Jun: High 79°F, Low 63°F, sunny
+- Monday 15 Jun: High 75°F, Low 60°F, sunny
+- Tuesday 16 Jun: High 72°F, Low 58°F, partly cloudy
+- Wednesday 17 Jun: High 70°F, Low 56°F, showers
+- Thursday 18 Jun: High 68°F, Low 55°F, showers
+- Friday 19 Jun: High 72°F, Low 58°F, sunny`;
+    const data = extractWeatherData(text);
+    expect(data.forecast).toHaveLength(12);
+    expect(data.forecast[0]).toMatchObject({ day: 'Mon', date: '8' });
+    expect(data.forecast[7]).toMatchObject({ day: 'Mon', date: '15' });
+  });
 });
 
 describe('detectWeatherResponse — fail-closed gates', () => {


### PR DESCRIPTION
## Summary

The user asked for a "12-day forecast for London", got back 7 cells. Root cause: `extractForecast` deduped by day-of-week name only, so the second week's Mon/Tue/Wed/… collided with the first week's and got silently dropped. The grid-wrap from #405 was working — there was just no data for it to wrap.

## Changes

- **`weatherParser.js`** — capture the date number that follows the day name (`Mon 8 Jun` → `8`), store it on each forecast item, and dedupe on `(day, date)` instead of `day` alone. Two different "Mon" entries are valid when their dates differ. For dateless mentions (a passing "Monday" in narrative text) the behavior is unchanged.
- **`WeatherCard.jsx`** — `ForecastDay` now optionally appends the date to the label (`MON 8`, `MON 15`) when the strip carries more than 7 cells, so two Mondays in the same view are distinguishable at a glance. Single-week strips keep the cleaner 3-letter `MON` label.
- **`weatherParser.test.js`** — adds a 12-day fixture covering the exact regression: same day name in week 1 and week 2 must both be kept and labelled with their dates.

## Regression check

- [x] `npm test` — 565/566 tests pass (one pre-existing `authSlice` failure unrelated)
- [x] All 25 `weatherParser` tests pass — including the 4-day London test from PR #403, the suppression tests, and the new 12-day test.
- [x] Single-week strip rendering unchanged — `showDate` only kicks in above 7 items.
- [x] The grid wrap and mobile low-temp hiding from #404/#405 still apply.

## Test plan

- [ ] Manual: ask "12-day forecast summary for London" — verify all 12 cells render, two rows of 7+5, day labels show dates (`MON 8`, `MON 15`)
- [ ] Manual: ask "5-day London forecast" — verify single row of 5 cells, labels stay as `MON`/`TUE`/… without dates
- [ ] Manual: same on mobile — verify wrapping is clean, lows stay hidden

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_