### PR TITLE
fix(sidebar): navigate to root when deleting the open conversation

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -508,9 +508,12 @@ export default function Sidebar() {
         total: Math.max(0, conversationsTotal - 1),
       })
     );
-    // If the deleted chat is currently open, clear it
+    // If the deleted chat is currently open, clear it and pop the URL
+    // back to the new-chat root — otherwise the now-stale conversation
+    // id sticks in the address bar and a refresh would 404.
     if (currentChatId === chatId) {
       dispatch(createNewChat());
+      navigate('/');
     }
     // Persist to backend
     deleteConversation(chatId).catch(() => {


### PR DESCRIPTION
## Summary

Deleting the currently-open conversation from the sidebar menu left the URL pointing at `/conversations/<deleted-id>`. The chat surface emptied — "Good evening" greeting and a fresh prompt input — but the address bar still showed the dead id. A refresh or share-link copy would 404, and the URL state no longer matched what the user was looking at.

Root cause: `Sidebar.jsx:512-514` cleared Redux via `dispatch(createNewChat())` when the deleted conversation was the active one, but `createNewChat` is a pure state reducer (it just nulls `currentChatId` and clears messages). Nothing called `navigate('/')`.

## Change

One file. After the `createNewChat` dispatch inside `confirmDelete`, add `navigate('/')` — gated on the same `currentChatId === chatId` check, so deleting a non-active conversation from the list still doesn't touch the URL.

## Related (not in this PR)

`ConversationsView.jsx` has two delete paths (single at L230 and bulk at L693) that don't check `currentChatId` at all. Because that view lives at `/conversations` (the list page, not a specific chat), there's no URL-stale bug — but if the user deletes the previously-active chat from the list, Redux's `currentChatId` is left pointing at a tombstoned id. Lower-impact than this PR's bug, separate concern, separate change.

## Test plan

- [x] `npm test` — 564 relevant tests pass (one pre-existing `authSlice` failure unrelated)
- [ ] Manual: open any conversation, delete it from its sidebar menu — verify URL pops to `/` and the new-chat greeting renders
- [ ] Manual: from inside an open conversation, delete a *different* one in the sidebar list — verify the URL is unchanged and the open conversation stays loaded

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_