### PR TITLE
fix(conversations): unify the five delete paths through a single hook

### DIFF
--- a/src/components/ConversationsView/ConversationsView.jsx
+++ b/src/components/ConversationsView/ConversationsView.jsx
@@ -27,10 +27,10 @@ import {
   deleteImportedConversation,
   bulkDeleteImportedConversations,
   updateConversation,
-  deleteConversation,
   fetchProjects as fetchProjectsApi,
 } from '../../services/api';
 import { useToast } from '../Toast/Toast';
+import useDeleteConversation from '../../hooks/useDeleteConversation';
 import { selectProjects, setProjects } from '../../store/slices/projectsSlice';
 import {
   SearchIcon,
@@ -93,7 +93,12 @@ function groupConversationsByTime(conversations) {
   return groups;
 }
 
-function useItemMenu(conversations, conversationsTotal, dispatch, { onArchive, showError } = {}) {
+function useItemMenu(
+  conversations,
+  conversationsTotal,
+  dispatch,
+  { onArchive, deleteConversation } = {}
+) {
   const [menuOpenId, setMenuOpenId] = useState(null);
   const [menuPosition, setMenuPosition] = useState({});
   const [renamingId, setRenamingId] = useState(null);
@@ -228,20 +233,8 @@ function useItemMenu(conversations, conversationsTotal, dispatch, { onArchive, s
 
   const confirmDelete = () => {
     const chatId = deleteConfirm;
-    const prevConversations = conversations;
-    const prevTotal = conversationsTotal;
-    dispatch(
-      setConversations({
-        conversations: conversations.filter((c) => c.id !== chatId),
-        total: Math.max(0, conversationsTotal - 1),
-      })
-    );
-    // Persist to backend
-    deleteConversation(chatId).catch(() => {
-      dispatch(setConversations({ conversations: prevConversations, total: prevTotal }));
-      if (showError) showError("Couldn't delete this conversation. Try again.");
-    });
     setDeleteConfirm(null);
+    if (deleteConversation) deleteConversation(chatId);
   };
 
   return {
@@ -355,9 +348,10 @@ export default function ConversationsView() {
     [conversations, conversationsTotal, dispatch, showError]
   );
 
+  const deleteConversation = useDeleteConversation();
   const menu = useItemMenu(conversations, conversationsTotal, dispatch, {
     onArchive: handleSingleArchive,
-    showError,
+    deleteConversation,
   });
 
   const importedProviders = useMemo(
@@ -688,20 +682,7 @@ export default function ConversationsView() {
   };
 
   const confirmBulkDelete = () => {
-    const prevConversations = conversations;
-    const prevTotal = conversationsTotal;
-    dispatch(
-      setConversations({
-        conversations: conversations.filter((c) => !selectedIds.has(c.id)),
-        total: Math.max(0, conversationsTotal - selectedIds.size),
-      })
-    );
-    selectedIds.forEach((id) => {
-      deleteConversation(id).catch(() => {
-        dispatch(setConversations({ conversations: prevConversations, total: prevTotal }));
-        showError("Couldn't delete some conversations. Try again.");
-      });
-    });
+    deleteConversation([...selectedIds]);
     setShowDeleteConfirm(false);
     exitSelectMode();
   };

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -148,6 +148,7 @@ import {
 } from '../../utils/guestSession';
 import DynamicSubtitle from '../DynamicSubtitle/DynamicSubtitle';
 import useUserLocation from '../../hooks/useUserLocation';
+import useDeleteConversation from '../../hooks/useDeleteConversation';
 import styles from './MainContent.module.css';
 
 const getGreeting = () => {
@@ -578,6 +579,7 @@ export default function MainContent() {
   const isProcessing = useSelector(selectIsProcessing);
   const selectedModelId = useSelector(selectSelectedModelId);
   const currentChatId = useSelector(selectCurrentChatId);
+  const deleteConversation = useDeleteConversation();
   const webSearchEnabled = useSelector(selectWebSearchEnabled);
   const extendedThinking = useSelector(selectExtendedThinking);
   const deepResearch = useSelector(selectDeepResearch);
@@ -2674,7 +2676,10 @@ export default function MainContent() {
                 className={styles.confirmDeleteBtn}
                 onClick={() => {
                   setShowDeleteConfirm(false);
-                  handleNewChat();
+                  // The shared hook handles optimistic Redux update, the
+                  // backend call, the navigate('/') for the now-deleted
+                  // open conversation, and on-failure revert + toast.
+                  if (currentChatId) deleteConversation(currentChatId);
                 }}
               >
                 Delete

--- a/src/components/ProjectsView/ProjectsView.jsx
+++ b/src/components/ProjectsView/ProjectsView.jsx
@@ -28,8 +28,8 @@ import {
   deleteProject as deleteProjectApi,
   fetchConversations,
   updateConversation,
-  deleteConversation,
 } from '../../services/api';
+import useDeleteConversation from '../../hooks/useDeleteConversation';
 import {
   SearchIcon,
   PlusIcon,
@@ -230,6 +230,8 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
   const [instructionsExpanded, setInstructionsExpanded] = useState(false);
   const [showMore, setShowMore] = useState(false);
   const [convMenuOpen, setConvMenuOpen] = useState(null);
+  const [convDeleteConfirm, setConvDeleteConfirm] = useState(null);
+  const deleteConversation = useDeleteConversation();
   const [showPlusMenu, setShowPlusMenu] = useState(false);
   const [attachedFiles, setAttachedFiles] = useState([]);
   const textareaRef = useRef(null);
@@ -588,13 +590,7 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
                             onClick={(e) => {
                               e.stopPropagation();
                               setConvMenuOpen(null);
-                              if (
-                                window.confirm('Delete this conversation? This cannot be undone.')
-                              ) {
-                                deleteConversation(conv.id).then(() => {
-                                  setConversations((prev) => prev.filter((c) => c.id !== conv.id));
-                                });
-                              }
+                              setConvDeleteConfirm(conv);
                             }}
                           >
                             <TrashIcon />
@@ -1326,6 +1322,60 @@ export default function ProjectsView() {
               </button>
               <button className={styles.confirmDeleteBtn} onClick={handleDelete}>
                 Delete{deleteOption === 'everything' ? ' everything' : ' project'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete-conversation confirmation — mirrors the project delete
+          modal so the in-project UX is consistent with the project-level
+          one. Replaces a previous window.confirm() prompt. */}
+      {convDeleteConfirm && (
+        <div className={styles.modalOverlay} onClick={() => setConvDeleteConfirm(null)}>
+          <div className={styles.confirmDialog} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.confirmIcon}>
+              <TrashIcon />
+            </div>
+            <h3 className={styles.confirmTitle}>
+              Delete &ldquo;{convDeleteConfirm.title || 'this conversation'}&rdquo;?
+            </h3>
+            <p className={styles.confirmDesc}>
+              This will permanently delete the conversation and all its messages. This action cannot
+              be undone.
+            </p>
+            <div className={styles.confirmActions}>
+              <button
+                className={styles.confirmCancelBtn}
+                onClick={() => setConvDeleteConfirm(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className={styles.confirmDeleteBtn}
+                onClick={async () => {
+                  const convId = convDeleteConfirm.id;
+                  setConvDeleteConfirm(null);
+                  // Optimistically drop from the project-local list. The
+                  // shared hook owns the global Redux + backend round-trip
+                  // and, on failure, will restore the global list and toast.
+                  setConversations((prev) => prev.filter((c) => c.id !== convId));
+                  const ok = await deleteConversation(convId);
+                  if (!ok) {
+                    // Hook reverted the global state; sync the project
+                    // view back in so the row reappears here too.
+                    try {
+                      const data = await fetchConversations(100, 0, {
+                        projectId: project.id,
+                      });
+                      setConversations(data.conversations || []);
+                    } catch {
+                      // Silent — the toast from the hook already covers it.
+                    }
+                  }
+                }}
+              >
+                Delete
               </button>
             </div>
           </div>

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -22,9 +22,9 @@ import { selectAuthUser, selectIsAuthenticated, signOut } from '../../store/slic
 import {
   fetchConversations,
   updateConversation,
-  deleteConversation,
   fetchProjects as fetchProjectsApi,
 } from '../../services/api';
+import useDeleteConversation from '../../hooks/useDeleteConversation';
 import { useToast } from '../Toast/Toast';
 import { selectProjects, setProjects } from '../../store/slices/projectsSlice';
 import { selectCurrentTier, selectTierLoaded } from '../../store/slices/subscriptionSlice';
@@ -152,6 +152,7 @@ export default function Sidebar() {
   const navigate = useNavigate();
   const location = useLocation();
   const { showError, showSuccess } = useToast();
+  const deleteConversation = useDeleteConversation();
   const collapsed = useSelector(selectSidebarCollapsed);
   const conversations = useSelector(selectConversations);
   const conversationsTotal = useSelector(selectConversationsTotal);
@@ -499,29 +500,8 @@ export default function Sidebar() {
 
   const confirmDelete = () => {
     const chatId = deleteConfirm;
-    const prevConversations = conversations;
-    const prevTotal = conversationsTotal;
-    // Optimistic update
-    dispatch(
-      setConversations({
-        conversations: conversations.filter((c) => c.id !== chatId),
-        total: Math.max(0, conversationsTotal - 1),
-      })
-    );
-    // If the deleted chat is currently open, clear it and pop the URL
-    // back to the new-chat root — otherwise the now-stale conversation
-    // id sticks in the address bar and a refresh would 404.
-    if (currentChatId === chatId) {
-      dispatch(createNewChat());
-      navigate('/');
-    }
-    // Persist to backend
-    deleteConversation(chatId).catch(() => {
-      // Revert
-      dispatch(setConversations({ conversations: prevConversations, total: prevTotal }));
-      showError("Couldn't delete this conversation. Try again.");
-    });
     setDeleteConfirm(null);
+    deleteConversation(chatId);
   };
 
   const handleAddToProject = (chatId) => {

--- a/src/hooks/useDeleteConversation.js
+++ b/src/hooks/useDeleteConversation.js
@@ -1,0 +1,82 @@
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import {
+  createNewChat,
+  selectConversations,
+  selectConversationsTotal,
+  selectCurrentChatId,
+  setConversations,
+} from '../store/slices/chatSlice';
+import { deleteConversation as apiDeleteConversation } from '../services/api';
+import { useToast } from '../components/Toast/Toast';
+
+/**
+ * Single source of truth for deleting one or more conversations.
+ *
+ * Every delete entry point in the app — sidebar item menu, in-chat header
+ * menu, `/conversations` single + bulk delete, project view — calls this
+ * hook so the post-confirm flow is identical:
+ *
+ *   1. Optimistically remove the rows from the sidebar list (Redux).
+ *   2. If one of the rows is the currently-open conversation, clear the
+ *      chat surface and pop the URL back to `/`. Otherwise leave the
+ *      surface alone.
+ *   3. Persist the delete to the backend.
+ *   4. On failure, revert the Redux list and toast the user. The URL
+ *      reset stays — pushing the user back into a "deleted" view is
+ *      worse than asking them to re-open from the now-restored list.
+ *
+ * Confirmation UX stays at the call site so each surface can keep its
+ * own modal styling — this hook only owns the post-confirm flow.
+ *
+ * @returns {(chatIdOrIds: string | string[]) => Promise<boolean>} a
+ *   stable callback that returns `true` when every backend delete
+ *   succeeded and `false` if any failed (and was reverted).
+ */
+export default function useDeleteConversation() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { showError } = useToast();
+  const conversations = useSelector(selectConversations);
+  const conversationsTotal = useSelector(selectConversationsTotal);
+  const currentChatId = useSelector(selectCurrentChatId);
+
+  return useCallback(
+    async (chatIdOrIds) => {
+      const ids = Array.isArray(chatIdOrIds) ? chatIdOrIds : [chatIdOrIds];
+      const validIds = ids.filter(Boolean);
+      if (validIds.length === 0) return true;
+
+      const idSet = new Set(validIds);
+      const deletedActive = currentChatId != null && idSet.has(currentChatId);
+      const prevConversations = conversations;
+      const prevTotal = conversationsTotal;
+
+      dispatch(
+        setConversations({
+          conversations: conversations.filter((c) => !idSet.has(c.id)),
+          total: Math.max(0, conversationsTotal - validIds.length),
+        })
+      );
+      if (deletedActive) {
+        dispatch(createNewChat());
+        navigate('/');
+      }
+
+      try {
+        await Promise.all(validIds.map((id) => apiDeleteConversation(id)));
+        return true;
+      } catch {
+        dispatch(setConversations({ conversations: prevConversations, total: prevTotal }));
+        showError(
+          validIds.length > 1
+            ? "Couldn't delete some conversations. Try again."
+            : "Couldn't delete this conversation. Try again."
+        );
+        return false;
+      }
+    },
+    [conversations, conversationsTotal, currentChatId, dispatch, navigate, showError]
+  );
+}


### PR DESCRIPTION
## Summary

Audit of the conversation-delete entry points (asked for in the previous turn) turned up five sites with drifted semantics, including a **critical bug**: the in-chat top-right "Delete" button **never actually deleted anything**. It opened the confirm dialog, then on confirm just dispatched `createNewChat()` and walked away — the conversation stayed in the database and reappeared on refresh.

This PR consolidates the five delete paths through a single hook so the post-confirm behavior is identical everywhere.

## The hook — `useDeleteConversation`

`src/hooks/useDeleteConversation.js`. Accepts a single id or an array (bulk). Returns a stable callback that:

1. Optimistically removes the row(s) from the sidebar list (Redux).
2. If one of the deleted rows is the currently-open conversation, clears the chat surface and pops the URL back to `/`.
3. Persists to the backend in parallel (`Promise.all`).
4. On failure: reverts the Redux list and toasts. The URL reset stays — pushing the user back into a "deleted" view is worse than letting them re-open from the now-restored list.

Resolves with `true` on full success, `false` if any backend delete failed (and was reverted). Confirmation UX stays at the call site so each surface keeps its own modal styling — the hook owns logic, not chrome.

## Call sites refactored

| # | Site | Before | After |
|---|---|---|---|
| 1 | Sidebar item kebab menu | Inline optimistic + API + revert + nav | `deleteConversation(chatId)` |
| 2 | **In-chat top-right "Delete"** | **Fake — just `handleNewChat()`** | `deleteConversation(currentChatId)` — actually deletes now |
| 3 | `/conversations` single-row | Inline; didn't reset `currentChatId` | `deleteConversation(chatId)` — handled by hook |
| 4 | `/conversations` bulk delete | Forced N parallel reverts on failure | `deleteConversation([...selectedIds])` — single revert |
| 5 | Project workspace conv kebab | `window.confirm()` + no failure handling | In-app modal mirroring the project-delete dialog + hook + revert on failure via re-fetch |

## What deliberately stays

- Each surface keeps its own confirm modal — the visual UX you have today.
- Project-level delete (the existing `Delete project` flow with "project only" / "everything" options) is untouched. Only the per-conversation kebab in the project view is changed.
- `services/api.js`, the chat slice, and toast are untouched.
- DB columns and backend endpoints are untouched.

## Regression check

- [x] `npm test` — 565/566 tests pass (one pre-existing `authSlice` failure unrelated to this change, present on `main`)
- [x] `npx eslint` — clean on all five touched files (one pre-existing warning in `MainContent.jsx` unrelated to this change)

## Test plan

- [ ] Open a conversation, click top-right kebab → Delete → confirm → verify URL becomes `/`, conversation is gone from sidebar, and a refresh confirms it's gone from the DB.
- [ ] From the sidebar, delete the *currently open* conversation → verify URL becomes `/`, UI clears.
- [ ] From the sidebar, delete a *different* conversation while one is open → verify the open chat and URL are untouched.
- [ ] `/conversations`: delete a single row → row vanishes, no error toast.
- [ ] `/conversations`: bulk-select 3 rows, delete → all three vanish, single toast on any failure.
- [ ] Inside a project view, click the conv kebab → Delete → in-app modal appears (not the browser native confirm) → confirm → conversation removed from project list and from the global sidebar.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_