### PR TITLE
fix(conversations): 404 on stale id + trim self-explanatory comments

### DIFF
--- a/src/components/ConversationRoute.jsx
+++ b/src/components/ConversationRoute.jsx
@@ -4,15 +4,12 @@ import { useSelector } from 'react-redux';
 import { selectCurrentChatId } from '../store/slices/chatSlice';
 import useLoadConversation from '../hooks/useLoadConversation';
 import MainContent from './MainContent';
+import NotFound from './ErrorBoundary/NotFound';
 
-/**
- * Wrapper that loads a conversation by URL param and renders MainContent.
- * Used for /conversations/:id and /chat/:id routes.
- */
 export default function ConversationRoute() {
   const { id } = useParams();
   const currentChatId = useSelector(selectCurrentChatId);
-  const loadConversation = useLoadConversation();
+  const { loadConversation, notFound } = useLoadConversation();
 
   useEffect(() => {
     if (id && id !== currentChatId) {
@@ -20,5 +17,6 @@ export default function ConversationRoute() {
     }
   }, [id, currentChatId, loadConversation]);
 
+  if (notFound) return <NotFound />;
   return <MainContent />;
 }

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -2676,9 +2676,6 @@ export default function MainContent() {
                 className={styles.confirmDeleteBtn}
                 onClick={() => {
                   setShowDeleteConfirm(false);
-                  // The shared hook handles optimistic Redux update, the
-                  // backend call, the navigate('/') for the now-deleted
-                  // open conversation, and on-failure revert + toast.
                   if (currentChatId) deleteConversation(currentChatId);
                 }}
               >

--- a/src/components/ProjectsView/ProjectsView.jsx
+++ b/src/components/ProjectsView/ProjectsView.jsx
@@ -1328,9 +1328,6 @@ export default function ProjectsView() {
         </div>
       )}
 
-      {/* Delete-conversation confirmation — mirrors the project delete
-          modal so the in-project UX is consistent with the project-level
-          one. Replaces a previous window.confirm() prompt. */}
       {convDeleteConfirm && (
         <div className={styles.modalOverlay} onClick={() => setConvDeleteConfirm(null)}>
           <div className={styles.confirmDialog} onClick={(e) => e.stopPropagation()}>
@@ -1356,21 +1353,16 @@ export default function ProjectsView() {
                 onClick={async () => {
                   const convId = convDeleteConfirm.id;
                   setConvDeleteConfirm(null);
-                  // Optimistically drop from the project-local list. The
-                  // shared hook owns the global Redux + backend round-trip
-                  // and, on failure, will restore the global list and toast.
                   setConversations((prev) => prev.filter((c) => c.id !== convId));
                   const ok = await deleteConversation(convId);
                   if (!ok) {
-                    // Hook reverted the global state; sync the project
-                    // view back in so the row reappears here too.
                     try {
                       const data = await fetchConversations(100, 0, {
                         projectId: project.id,
                       });
                       setConversations(data.conversations || []);
                     } catch {
-                      // Silent — the toast from the hook already covers it.
+                      /* hook already toasted */
                     }
                   }
                 }}

--- a/src/hooks/useDeleteConversation.js
+++ b/src/hooks/useDeleteConversation.js
@@ -12,27 +12,12 @@ import { deleteConversation as apiDeleteConversation } from '../services/api';
 import { useToast } from '../components/Toast/Toast';
 
 /**
- * Single source of truth for deleting one or more conversations.
+ * Optimistically delete one or many conversations. On backend failure the
+ * Redux list is reverted and the user is toasted; the URL reset stays —
+ * sending them back into a "deleted" view is worse than re-opening from
+ * the restored list.
  *
- * Every delete entry point in the app — sidebar item menu, in-chat header
- * menu, `/conversations` single + bulk delete, project view — calls this
- * hook so the post-confirm flow is identical:
- *
- *   1. Optimistically remove the rows from the sidebar list (Redux).
- *   2. If one of the rows is the currently-open conversation, clear the
- *      chat surface and pop the URL back to `/`. Otherwise leave the
- *      surface alone.
- *   3. Persist the delete to the backend.
- *   4. On failure, revert the Redux list and toast the user. The URL
- *      reset stays — pushing the user back into a "deleted" view is
- *      worse than asking them to re-open from the now-restored list.
- *
- * Confirmation UX stays at the call site so each surface can keep its
- * own modal styling — this hook only owns the post-confirm flow.
- *
- * @returns {(chatIdOrIds: string | string[]) => Promise<boolean>} a
- *   stable callback that returns `true` when every backend delete
- *   succeeded and `false` if any failed (and was reverted).
+ * @returns {(chatIdOrIds: string | string[]) => Promise<boolean>}
  */
 export default function useDeleteConversation() {
   const dispatch = useDispatch();
@@ -44,11 +29,10 @@ export default function useDeleteConversation() {
 
   return useCallback(
     async (chatIdOrIds) => {
-      const ids = Array.isArray(chatIdOrIds) ? chatIdOrIds : [chatIdOrIds];
-      const validIds = ids.filter(Boolean);
-      if (validIds.length === 0) return true;
+      const ids = (Array.isArray(chatIdOrIds) ? chatIdOrIds : [chatIdOrIds]).filter(Boolean);
+      if (ids.length === 0) return true;
 
-      const idSet = new Set(validIds);
+      const idSet = new Set(ids);
       const deletedActive = currentChatId != null && idSet.has(currentChatId);
       const prevConversations = conversations;
       const prevTotal = conversationsTotal;
@@ -56,7 +40,7 @@ export default function useDeleteConversation() {
       dispatch(
         setConversations({
           conversations: conversations.filter((c) => !idSet.has(c.id)),
-          total: Math.max(0, conversationsTotal - validIds.length),
+          total: Math.max(0, conversationsTotal - ids.length),
         })
       );
       if (deletedActive) {
@@ -65,12 +49,12 @@ export default function useDeleteConversation() {
       }
 
       try {
-        await Promise.all(validIds.map((id) => apiDeleteConversation(id)));
+        await Promise.all(ids.map((id) => apiDeleteConversation(id)));
         return true;
       } catch {
         dispatch(setConversations({ conversations: prevConversations, total: prevTotal }));
         showError(
-          validIds.length > 1
+          ids.length > 1
             ? "Couldn't delete some conversations. Try again."
             : "Couldn't delete this conversation. Try again."
         );

--- a/src/hooks/useLoadConversation.js
+++ b/src/hooks/useLoadConversation.js
@@ -1,13 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { setCurrentChat, setMessages } from '../store/slices/chatSlice';
 import { fetchConversationMessages } from '../services/api';
 import { getGeneratedImages } from '../services/imageGeneration';
 
-/**
- * Maps raw backend messages to the shape the frontend expects,
- * including restoring generatedImages from backend data, localStorage, or content markdown.
- */
 function mapMessages(rawMessages, storedImages) {
   return (rawMessages || []).map((msg) => {
     const base = {
@@ -21,16 +17,10 @@ function mapMessages(rawMessages, storedImages) {
       let generatedImages = msg.generatedImages || [];
 
       if (generatedImages.length === 0) {
-        // Primary: match by messageId (deterministic)
-        let matched = storedImages.filter(
-          (img) => img.messageId && img.messageId === msg.id
-        );
-        // Fallback: timestamp proximity
+        let matched = storedImages.filter((img) => img.messageId && img.messageId === msg.id);
         if (matched.length === 0) {
           const msgTime = new Date(msg.createdAt).getTime();
-          matched = storedImages.filter(
-            (img) => Math.abs(img.createdAt - msgTime) < 30000
-          );
+          matched = storedImages.filter((img) => Math.abs(img.createdAt - msgTime) < 30000);
         }
         if (matched.length > 0) {
           generatedImages = matched.map((img) => ({
@@ -43,7 +33,6 @@ function mapMessages(rawMessages, storedImages) {
         }
       }
 
-      // Last resort: extract images from message content markdown
       if (generatedImages.length === 0 && msg.content) {
         const imgRe = /!\[Generated image[^\]]*\]\(([^)]+)\)/g;
         let m;
@@ -92,28 +81,25 @@ function mapMessages(rawMessages, storedImages) {
   });
 }
 
-/**
- * Hook that provides a function to load a conversation by ID.
- * Sets currentChatId in Redux and fetches + maps messages from the API.
- */
 export default function useLoadConversation() {
   const dispatch = useDispatch();
+  const [notFound, setNotFound] = useState(false);
 
   const loadConversation = useCallback(
     async (chatId) => {
+      setNotFound(false);
       dispatch(setCurrentChat(chatId));
       dispatch(setMessages([]));
       try {
         const data = await fetchConversationMessages(chatId);
         const storedImages = getGeneratedImages();
-        const mapped = mapMessages(data.messages, storedImages);
-        dispatch(setMessages(mapped));
-      } catch {
-        // Fail silently — conversation will appear empty
+        dispatch(setMessages(mapMessages(data.messages, storedImages)));
+      } catch (err) {
+        if (err?.status === 404) setNotFound(true);
       }
     },
     [dispatch]
   );
 
-  return loadConversation;
+  return { loadConversation, notFound };
 }


### PR DESCRIPTION
## Summary

Two issues from the previous PR's review:

### 1. Stale conversation URLs silently rendered "Good morning"

Pasting or revisiting `/conversations/<deleted-id>` — e.g. a shared link, an old bookmark, or a refresh just after a delete from another tab — mounted `ConversationRoute`, fired the load, the backend returned 404, the hook swallowed it, and the empty MainContent rendered as if it were a brand-new chat. The address bar showed a dead id while the page showed a "Good morning" greeting. Confusing.

Fix: `useLoadConversation` now surfaces a `notFound` flag when the backend returns 404, and `ConversationRoute` renders the existing `NotFound` page in that case. Other errors still fall through silently (unchanged), so transient failures don't bounce the user out of an open chat.

### 2. Too many comments narrating what the code says

The previous delete refactor had comments like "Optimistically remove from the list", "The shared hook handles…", "Mirrors the project delete modal — replaces a previous window.confirm". Code already says that. Trimmed down to one clear JSDoc on the delete hook (covering the genuine why-it-matters: the revert/URL trade-off on failure) and let names + structure carry the rest.

## Changes

- **`useLoadConversation.js`** — adds a `notFound` boolean, set when `fetchConversationMessages` throws a 404. Resets at the start of every load so re-navigation works.
- **`ConversationRoute.jsx`** — returns `<NotFound />` when `notFound` is true.
- **`useDeleteConversation.js`** — JSDoc trimmed to a 4-line summary of the trade-off; inline comments removed.
- **`MainContent.jsx`** — drops the now-redundant comment on the Delete button.
- **`ProjectsView.jsx`** — drops the modal/handler comments.

## Regression check

- [x] `npm test` — 565/566 tests pass (one pre-existing `authSlice` failure, unrelated)
- [x] `npx eslint` — clean on all five touched files
- [x] Backend `/api/conversations/:id/messages` already returns 404 for missing or deleted conversations — verified at `araviel-api/src/app/api/conversations/[id]/messages/route.ts:121-122`. No API change needed.

## Test plan

- [ ] Visit `/conversations/00000000-0000-0000-0000-000000000000` (any nonexistent id) — verify the NotFound page renders with the "Go home" button, not the new-chat greeting.
- [ ] Open a conversation, delete it from the sidebar — verify URL pops to `/` (existing behavior, untouched).
- [ ] In another tab, paste the URL of a conversation just deleted from the first tab — verify NotFound renders.
- [ ] Open a working conversation while offline (simulated) — verify the page stays mounted (not a false NotFound).

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_