### PR TITLE
fix(error-fallback): center the card in the route outlet

### DIFF
--- a/src/components/ErrorBoundary/ErrorFallback.module.css
+++ b/src/components/ErrorBoundary/ErrorFallback.module.css
@@ -1,4 +1,5 @@
 .page {
+  flex: 1;
   min-height: var(--app-height);
   display: flex;
   align-items: center;
@@ -10,6 +11,7 @@
 }
 
 .inline {
+  flex: 1;
   min-height: 360px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

The 404 page rendered last PR sits beside the persistent sidebar inside the app's flex shell (`App.css: .app { display: flex }`). Without `flex: 1` on the fallback root, the div was sized to the card's intrinsic width and the existing `align-items: center; justify-content: center` happened inside that narrow strip — visually the card landed flush-left next to the sidebar instead of centered in the remaining viewport.

## Change

Add `flex: 1` to both `.page` and `.inline` in `ErrorFallback.module.css`. Each variant now takes the remaining axis the outlet gives it, and the existing centering then produces a card that's visually centered in the content area.

Affects every consumer of `ErrorFallback`:

- `NotFound` (the case you reported) — now centered in the chat-area outlet
- `AppErrorBoundary` — already had the whole viewport, no visible change
- `RouteErrorBoundary` — now centers in the route outlet instead of hugging left
- `FeatureErrorBoundary` — inline variant now centers in its parent's main axis

## Regression check

- [x] `npm test` — 564/565 tests pass (one pre-existing `authSlice` failure unrelated to this change)
- [x] `npx eslint` — clean

## Test plan

- [ ] Visit `/conversations/00000000-0000-0000-0000-000000000000` — verify the NotFound card is horizontally and vertically centered in the area to the right of the sidebar, not pinned to the left.
- [ ] Resize the window narrow — verify the card stays centered, no overflow.
- [ ] Hit any other error surface (force a route error) — verify it also centers properly.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_