### PR TITLE
feat(conversations/trash): select + bulk + Load More pagination (15/page)

### DIFF
--- a/src/components/ConversationsView/ConversationsView.jsx
+++ b/src/components/ConversationsView/ConversationsView.jsx
@@ -30,6 +30,7 @@ import {
   fetchProjects as fetchProjectsApi,
   fetchTrashedConversations,
   restoreConversation,
+  purgeConversation,
 } from '../../services/api';
 import { useToast } from '../Toast/Toast';
 import useDeleteConversation from '../../hooks/useDeleteConversation';
@@ -48,6 +49,7 @@ import {
   LinkIcon,
   ImportIcon,
   ProjectsIcon,
+  RefreshIcon,
 } from '../Icons';
 import { getProviderLogo } from '../getProviderLogo';
 import ImportConversationsModal from '../ImportConversationsModal';
@@ -279,7 +281,27 @@ function formatRelativeDeleted(iso) {
   return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
-function TrashList({ conversations, loading, error, restoringId, onRestore, onRetry }) {
+function TrashList({
+  conversations,
+  loading,
+  error,
+  restoringId,
+  onRestore,
+  onPurgeRequest,
+  onRetry,
+  selectMode,
+  selectedIds,
+  onToggleSelect,
+}) {
+  const [openMenuId, setOpenMenuId] = useState(null);
+
+  useEffect(() => {
+    if (!openMenuId) return;
+    const close = () => setOpenMenuId(null);
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [openMenuId]);
+
   if (loading && conversations === null) {
     return (
       <div className={styles.skeleton}>
@@ -329,9 +351,39 @@ function TrashList({ conversations, loading, error, restoringId, onRestore, onRe
     <ul className={styles.trashList}>
       {conversations.map((conv) => {
         const isRestoring = restoringId === conv.id;
+        const isSelected = selectMode && selectedIds?.has(conv.id);
         const daysLeft = conv.daysRemaining ?? 0;
+        const handleRowClick = () => {
+          if (selectMode) onToggleSelect(conv.id);
+        };
         return (
-          <li key={conv.id} className={styles.trashRow}>
+          <li
+            key={conv.id}
+            className={`${styles.trashRow} ${isSelected ? styles.trashRowSelected : ''} ${
+              selectMode ? styles.trashRowSelectMode : ''
+            }`}
+            onClick={handleRowClick}
+          >
+            {selectMode && (
+              <div className={styles.checkboxArea}>
+                <div className={`${styles.checkbox} ${isSelected ? styles.checkboxChecked : ''}`}>
+                  {isSelected && (
+                    <svg
+                      width="10"
+                      height="10"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  )}
+                </div>
+              </div>
+            )}
             <div className={styles.trashMeta}>
               <span className={styles.trashTitle}>{conv.title || 'Untitled conversation'}</span>
               <span className={styles.trashSub}>
@@ -341,14 +393,50 @@ function TrashList({ conversations, loading, error, restoringId, onRestore, onRe
                 </span>
               </span>
             </div>
-            <button
-              type="button"
-              className={styles.trashRestoreBtn}
-              onClick={() => onRestore(conv.id)}
-              disabled={isRestoring}
-            >
-              {isRestoring ? 'Restoring…' : 'Restore'}
-            </button>
+            {!selectMode && (
+              <div className={styles.trashRowActions}>
+                <button
+                  type="button"
+                  className={styles.trashRestoreBtn}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRestore(conv.id);
+                  }}
+                  disabled={isRestoring}
+                >
+                  {isRestoring ? 'Restoring…' : 'Restore'}
+                </button>
+                <div className={styles.trashMenuWrapper}>
+                  <button
+                    type="button"
+                    className={styles.trashMenuBtn}
+                    aria-label="More actions"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setOpenMenuId((prev) => (prev === conv.id ? null : conv.id));
+                    }}
+                  >
+                    <MoreVerticalIcon />
+                  </button>
+                  {openMenuId === conv.id && (
+                    <div className={styles.trashMenu} onMouseDown={(e) => e.stopPropagation()}>
+                      <button
+                        type="button"
+                        className={`${styles.trashMenuItem} ${styles.trashMenuItemDanger}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setOpenMenuId(null);
+                          onPurgeRequest([conv.id]);
+                        }}
+                      >
+                        <TrashIcon />
+                        <span>Delete permanently</span>
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
           </li>
         );
       })}
@@ -391,6 +479,9 @@ export default function ConversationsView() {
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState(new Set());
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [purgeTargetIds, setPurgeTargetIds] = useState(null);
+  const [purging, setPurging] = useState(false);
+  const [bulkRestoring, setBulkRestoring] = useState(false);
   const [showImportModal, setShowImportModal] = useState(false);
   const [importedConversations, setImportedConversations] = useState([]);
   const [importedLoading, setImportedLoading] = useState(false);
@@ -836,10 +927,100 @@ export default function ConversationsView() {
   );
 
   const selectAll = () => {
-    const source =
-      activeSection === 'imported' ? filteredImportedConversations : filteredConversations;
+    let source;
+    if (activeSection === 'imported') {
+      source = filteredImportedConversations;
+    } else if (activeTab === 'trash') {
+      source = trashedConversations || [];
+    } else {
+      source = filteredConversations;
+    }
     setSelectedIds(new Set(source.map((c) => c.id)));
   };
+
+  const selectableCount =
+    activeTab === 'trash'
+      ? (trashedConversations || []).length
+      : activeSection === 'imported'
+      ? filteredImportedConversations.length
+      : filteredConversations.length;
+
+  const handleBulkRestore = useCallback(async () => {
+    if (bulkRestoring) return;
+    const ids = [...selectedIds];
+    if (ids.length === 0) return;
+    setBulkRestoring(true);
+    const failures = [];
+    await Promise.all(
+      ids.map((id) =>
+        restoreConversation(id).catch(() => {
+          failures.push(id);
+        })
+      )
+    );
+    setBulkRestoring(false);
+    setTrashedConversations((prev) =>
+      (prev || []).filter((c) => failures.includes(c.id) || !ids.includes(c.id))
+    );
+    setSelectedIds(new Set(failures));
+    if (failures.length === 0) setSelectMode(false);
+    window.dispatchEvent(new CustomEvent('araviel-conversation-updated'));
+    const restoredCount = ids.length - failures.length;
+    if (restoredCount > 0) {
+      showSuccess(`${restoredCount} conversation${restoredCount === 1 ? '' : 's'} restored.`);
+    }
+    if (failures.length > 0) {
+      showError(
+        failures.length === ids.length
+          ? "Couldn't restore the selected conversations."
+          : `Couldn't restore ${failures.length} of ${ids.length}.`
+      );
+    }
+  }, [bulkRestoring, selectedIds, showError, showSuccess]);
+
+  const runPurge = useCallback(
+    async (ids) => {
+      if (purging || ids.length === 0) return;
+      setPurging(true);
+      const failures = [];
+      await Promise.all(
+        ids.map((id) =>
+          purgeConversation(id).catch(() => {
+            failures.push(id);
+          })
+        )
+      );
+      setPurging(false);
+      setTrashedConversations((prev) =>
+        (prev || []).filter((c) => failures.includes(c.id) || !ids.includes(c.id))
+      );
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        ids.forEach((id) => {
+          if (!failures.includes(id)) next.delete(id);
+        });
+        return next;
+      });
+      setPurgeTargetIds(null);
+      const purgedCount = ids.length - failures.length;
+      if (purgedCount > 0 && failures.length === 0) {
+        setSelectMode(false);
+      }
+      if (purgedCount > 0) {
+        showSuccess(
+          `${purgedCount} conversation${purgedCount === 1 ? '' : 's'} permanently deleted.`
+        );
+      }
+      if (failures.length > 0) {
+        showError(
+          failures.length === ids.length
+            ? "Couldn't permanently delete the selected conversations."
+            : `Couldn't delete ${failures.length} of ${ids.length}.`
+        );
+      }
+    },
+    [purging, showError, showSuccess]
+  );
 
   // Imported conversations filtering
   const filteredImportedConversations = useMemo(() => {
@@ -1288,76 +1469,94 @@ export default function ConversationsView() {
                   </button>
                 ))}
               </div>
-              {activeTab !== 'trash' && (
-                <button
-                  className={`${styles.selectToggle} ${
-                    selectMode ? styles.selectToggleActive : ''
-                  }`}
-                  onClick={() => {
-                    if (selectMode) {
-                      exitSelectMode();
-                    } else {
-                      setSelectMode(true);
-                    }
-                  }}
-                >
-                  {selectMode ? 'Cancel' : 'Select'}
-                </button>
-              )}
+              <button
+                className={`${styles.selectToggle} ${selectMode ? styles.selectToggleActive : ''}`}
+                onClick={() => {
+                  if (selectMode) {
+                    exitSelectMode();
+                  } else {
+                    setSelectMode(true);
+                  }
+                }}
+              >
+                {selectMode ? 'Cancel' : 'Select'}
+              </button>
             </div>
 
-            {/* Selection action bar */}
             {selectMode && (
               <div className={styles.selectionBar}>
                 <div className={styles.selectionLeft}>
                   <span className={styles.selectionCount}>{selectedIds.size} selected</span>
-                  {selectedIds.size < filteredConversations.length && (
+                  {selectedIds.size < selectableCount && (
                     <button className={styles.selectAllBtn} onClick={selectAll}>
                       Select all
                     </button>
                   )}
                 </div>
                 <div className={styles.selectionActions}>
-                  <button
-                    className={styles.selectionAction}
-                    onClick={() => hasSelection && handleBulkAddToProject()}
-                    disabled={!hasSelection}
-                    title="Add to project"
-                  >
-                    <ProjectsIcon />
-                  </button>
-                  <button
-                    className={styles.selectionAction}
-                    onClick={() => hasSelection && handleBulkRemoveFromProject()}
-                    disabled={!hasSelection}
-                    title="Remove from project"
-                  >
-                    <LinkIcon />
-                  </button>
-                  <button
-                    className={styles.selectionAction}
-                    onClick={() => hasSelection && toggleStar(selectedIds)}
-                    disabled={!hasSelection}
-                    title="Star"
-                  >
-                    <StarIcon />
-                  </button>
-                  <button
-                    className={styles.selectionAction}
-                    onClick={() => hasSelection && toggleArchive(selectedIds)}
-                    disabled={!hasSelection}
-                    title={activeTab === 'archived' ? 'Move to Chats' : 'Archive'}
-                  >
-                    <ArchiveIcon />
-                  </button>
-                  <button
-                    className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
-                    onClick={() => hasSelection && handleBulkDelete()}
-                    disabled={!hasSelection}
-                    title="Delete"
-                  >
-                    <TrashIcon />
-                  </button>
+                  {activeTab === 'trash' ? (
+                    <>
+                      <button
+                        className={styles.selectionAction}
+                        onClick={() => hasSelection && handleBulkRestore()}
+                        disabled={!hasSelection || bulkRestoring}
+                        title="Restore"
+                      >
+                        <RefreshIcon />
+                      </button>
+                      <button
+                        className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
+                        onClick={() => hasSelection && setPurgeTargetIds([...selectedIds])}
+                        disabled={!hasSelection || purging}
+                        title="Delete permanently"
+                      >
+                        <TrashIcon />
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <button
+                        className={styles.selectionAction}
+                        onClick={() => hasSelection && handleBulkAddToProject()}
+                        disabled={!hasSelection}
+                        title="Add to project"
+                      >
+                        <ProjectsIcon />
+                      </button>
+                      <button
+                        className={styles.selectionAction}
+                        onClick={() => hasSelection && handleBulkRemoveFromProject()}
+                        disabled={!hasSelection}
+                        title="Remove from project"
+                      >
+                        <LinkIcon />
+                      </button>
+                      <button
+                        className={styles.selectionAction}
+                        onClick={() => hasSelection && toggleStar(selectedIds)}
+                        disabled={!hasSelection}
+                        title="Star"
+                      >
+                        <StarIcon />
+                      </button>
+                      <button
+                        className={styles.selectionAction}
+                        onClick={() => hasSelection && toggleArchive(selectedIds)}
+                        disabled={!hasSelection}
+                        title={activeTab === 'archived' ? 'Move to Chats' : 'Archive'}
+                      >
+                        <ArchiveIcon />
+                      </button>
+                      <button
+                        className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
+                        onClick={() => hasSelection && handleBulkDelete()}
+                        disabled={!hasSelection}
+                        title="Delete"
+                      >
+                        <TrashIcon />
+                      </button>
+                    </>
+                  )}
                 </div>
                 <button
                   className={styles.selectionClose}
@@ -1377,7 +1576,11 @@ export default function ConversationsView() {
                   error={trashError}
                   restoringId={restoringId}
                   onRestore={handleRestoreConversation}
+                  onPurgeRequest={setPurgeTargetIds}
                   onRetry={loadTrash}
+                  selectMode={selectMode}
+                  selectedIds={selectedIds}
+                  onToggleSelect={toggleSelect}
                 />
               ) : conversationsLoading && conversations.length === 0 ? (
                 <div className={styles.skeleton}>
@@ -1683,6 +1886,44 @@ export default function ConversationsView() {
               <TrashIcon />
               <span>Delete</span>
             </button>
+          </div>
+        </div>
+      )}
+
+      {purgeTargetIds && purgeTargetIds.length > 0 && (
+        <div
+          className={styles.confirmOverlay}
+          onClick={() => (purging ? null : setPurgeTargetIds(null))}
+        >
+          <div className={styles.confirmDialog} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.confirmIcon}>
+              <TrashIcon />
+            </div>
+            <h3 className={styles.confirmTitle}>
+              Permanently delete {purgeTargetIds.length} chat
+              {purgeTargetIds.length === 1 ? '' : 's'}?
+            </h3>
+            <p className={styles.confirmDesc}>
+              This skips the 15-day recovery window. The chat
+              {purgeTargetIds.length === 1 ? '' : 's'} and all messages will be removed immediately
+              and cannot be restored.
+            </p>
+            <div className={styles.confirmActions}>
+              <button
+                className={styles.confirmCancelBtn}
+                onClick={() => setPurgeTargetIds(null)}
+                disabled={purging}
+              >
+                Cancel
+              </button>
+              <button
+                className={styles.confirmDeleteBtn}
+                onClick={() => runPurge(purgeTargetIds)}
+                disabled={purging}
+              >
+                {purging ? 'Deleting…' : 'Delete permanently'}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/ConversationsView/ConversationsView.jsx
+++ b/src/components/ConversationsView/ConversationsView.jsx
@@ -57,6 +57,8 @@ import ProjectPickerModal from '../ProjectPickerModal';
 import ShareModal from '../ShareModal/ShareModal';
 import styles from './ConversationsView.module.css';
 
+const CONVERSATIONS_PAGE_SIZE = 15;
+
 const TABS = [
   { id: 'all', label: 'All' },
   { id: 'starred', label: 'Starred' },
@@ -283,12 +285,14 @@ function formatRelativeDeleted(iso) {
 
 function TrashList({
   conversations,
+  total = 0,
   loading,
   error,
   restoringId,
   onRestore,
   onPurgeRequest,
   onRetry,
+  onLoadMore,
   selectMode,
   selectedIds,
   onToggleSelect,
@@ -440,6 +444,23 @@ function TrashList({
           </li>
         );
       })}
+      {conversations.length < total && (
+        <li className={styles.trashLoadMoreWrapper}>
+          {loading ? (
+            <div className={styles.loadingMore}>
+              <div className={styles.loadingDots}>
+                <span />
+                <span />
+                <span />
+              </div>
+            </div>
+          ) : (
+            <button type="button" className={styles.loadMoreBtn} onClick={onLoadMore}>
+              Load more conversations
+            </button>
+          )}
+        </li>
+      )}
     </ul>
   );
 }
@@ -473,6 +494,7 @@ export default function ConversationsView() {
   const [activeTab, setActiveTab] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [trashedConversations, setTrashedConversations] = useState(null);
+  const [trashedTotal, setTrashedTotal] = useState(0);
   const [trashLoading, setTrashLoading] = useState(false);
   const [trashError, setTrashError] = useState(null);
   const [restoringId, setRestoringId] = useState(null);
@@ -619,21 +641,33 @@ export default function ConversationsView() {
     }
   }, [projects.length, dispatch, showError, isAuthenticated]);
 
-  const loadTrash = useCallback(() => {
-    if (!isAuthenticated) return;
-    setTrashLoading(true);
-    setTrashError(null);
-    fetchTrashedConversations()
-      .then((data) => setTrashedConversations(data.conversations || []))
-      .catch((err) =>
-        setTrashError(err?.userMessage || "Couldn't load recently deleted conversations.")
-      )
-      .finally(() => setTrashLoading(false));
-  }, [isAuthenticated]);
+  const loadTrash = useCallback(
+    (offset = 0) => {
+      if (!isAuthenticated) return;
+      setTrashLoading(true);
+      setTrashError(null);
+      fetchTrashedConversations(CONVERSATIONS_PAGE_SIZE, offset)
+        .then((data) => {
+          const rows = data.conversations || [];
+          setTrashedTotal(data.total ?? rows.length);
+          setTrashedConversations((prev) => (offset === 0 ? rows : [...(prev || []), ...rows]));
+        })
+        .catch((err) =>
+          setTrashError(err?.userMessage || "Couldn't load recently deleted conversations.")
+        )
+        .finally(() => setTrashLoading(false));
+    },
+    [isAuthenticated]
+  );
+
+  const handleLoadMoreTrash = useCallback(() => {
+    if (trashLoading) return;
+    loadTrash((trashedConversations || []).length);
+  }, [trashLoading, loadTrash, trashedConversations]);
 
   useEffect(() => {
     if (activeTab === 'trash' && trashedConversations === null) {
-      loadTrash();
+      loadTrash(0);
     }
   }, [activeTab, trashedConversations, loadTrash]);
 
@@ -644,6 +678,7 @@ export default function ConversationsView() {
       try {
         await restoreConversation(chatId);
         setTrashedConversations((prev) => (prev || []).filter((c) => c.id !== chatId));
+        setTrashedTotal((prev) => Math.max(0, prev - 1));
         window.dispatchEvent(new CustomEvent('araviel-conversation-updated'));
         showSuccess('Conversation restored');
       } catch (err) {
@@ -801,8 +836,6 @@ export default function ConversationsView() {
       showSuccess('Conversations removed from project.');
     }
   };
-
-  const CONVERSATIONS_PAGE_SIZE = 15;
 
   const loadConversations = useCallback(
     async (offset = 0) => {
@@ -962,10 +995,11 @@ export default function ConversationsView() {
     setTrashedConversations((prev) =>
       (prev || []).filter((c) => failures.includes(c.id) || !ids.includes(c.id))
     );
+    const restoredCount = ids.length - failures.length;
+    setTrashedTotal((prev) => Math.max(0, prev - restoredCount));
     setSelectedIds(new Set(failures));
     if (failures.length === 0) setSelectMode(false);
     window.dispatchEvent(new CustomEvent('araviel-conversation-updated'));
-    const restoredCount = ids.length - failures.length;
     if (restoredCount > 0) {
       showSuccess(`${restoredCount} conversation${restoredCount === 1 ? '' : 's'} restored.`);
     }
@@ -994,6 +1028,8 @@ export default function ConversationsView() {
       setTrashedConversations((prev) =>
         (prev || []).filter((c) => failures.includes(c.id) || !ids.includes(c.id))
       );
+      const purgedCount = ids.length - failures.length;
+      setTrashedTotal((prev) => Math.max(0, prev - purgedCount));
       setSelectedIds((prev) => {
         const next = new Set(prev);
         ids.forEach((id) => {
@@ -1002,7 +1038,6 @@ export default function ConversationsView() {
         return next;
       });
       setPurgeTargetIds(null);
-      const purgedCount = ids.length - failures.length;
       if (purgedCount > 0 && failures.length === 0) {
         setSelectMode(false);
       }
@@ -1572,12 +1607,14 @@ export default function ConversationsView() {
               {activeTab === 'trash' ? (
                 <TrashList
                   conversations={trashedConversations}
+                  total={trashedTotal}
                   loading={trashLoading}
                   error={trashError}
                   restoringId={restoringId}
                   onRestore={handleRestoreConversation}
                   onPurgeRequest={setPurgeTargetIds}
-                  onRetry={loadTrash}
+                  onRetry={() => loadTrash(0)}
+                  onLoadMore={handleLoadMoreTrash}
                   selectMode={selectMode}
                   selectedIds={selectedIds}
                   onToggleSelect={toggleSelect}

--- a/src/components/ConversationsView/ConversationsView.module.css
+++ b/src/components/ConversationsView/ConversationsView.module.css
@@ -1656,3 +1656,10 @@
 .trashMenuItemDanger:hover {
   background-color: rgba(239, 68, 68, 0.08);
 }
+
+.trashLoadMoreWrapper {
+  list-style: none;
+  padding: 12px 0 0;
+  display: flex;
+  justify-content: center;
+}

--- a/src/components/ConversationsView/ConversationsView.module.css
+++ b/src/components/ConversationsView/ConversationsView.module.css
@@ -1565,3 +1565,94 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.trashRowSelectMode {
+  cursor: pointer;
+}
+
+.trashRowSelected {
+  background-color: var(--bg-selected, var(--bg-hover));
+}
+
+.trashRowActions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.trashMenuWrapper {
+  position: relative;
+}
+
+.trashMenuBtn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.trashMenuBtn:hover {
+  background-color: var(--bg-button-hover, var(--bg-hover));
+  color: var(--text-primary);
+}
+
+.trashMenu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 200px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 6px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  z-index: 50;
+  animation: trashMenuIn 0.12s ease;
+}
+
+@keyframes trashMenuIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.trashMenuItem {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.1s ease;
+}
+
+.trashMenuItem:hover {
+  background-color: var(--bg-hover);
+}
+
+.trashMenuItemDanger {
+  color: #ef4444;
+}
+
+.trashMenuItemDanger:hover {
+  background-color: rgba(239, 68, 68, 0.08);
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -229,6 +229,13 @@ export function restoreConversation(conversationId) {
   });
 }
 
+export function purgeConversation(conversationId) {
+  return apiFetch(`/api/conversations/${conversationId}/purge`, {
+    method: 'DELETE',
+    errorContext: 'conversations.purge',
+  });
+}
+
 export function fetchConversation(conversationId) {
   return apiFetch(`/api/conversations/${conversationId}`, {
     errorContext: 'conversations.get',

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -216,8 +216,8 @@ export function deleteAllConversations() {
   });
 }
 
-export function fetchTrashedConversations() {
-  return apiFetch(`/api/conversations/trash`, {
+export function fetchTrashedConversations(limit = 15, offset = 0) {
+  return apiFetch(`/api/conversations/trash?limit=${limit}&offset=${offset}`, {
     errorContext: 'conversations.trash.list',
   });
 }


### PR DESCRIPTION
Two pieces in this PR. The first ships the Select + bulk UX in Recently Deleted; the second hooks Recently Deleted into the same Load More pagination as the other tabs. Both pair with API changes already merged (samaig-araviel/araviel-api#154 — purge endpoint) or in flight (samaig-araviel/araviel-api#155 — paginated trash list).

## 1. Select + bulk Restore / Delete permanently

Recently Deleted now mirrors the All / Starred / Archived selection UX:

- Select toggle works on the trash tab.
- Selection action bar swaps in **Restore** + **Delete permanently** (replacing the project/star/archive/delete set used on the other tabs). "Select all" uses the trash list size.
- Trash rows participate in select mode — checkbox on the left, full-row click toggles selection.
- In normal mode every row keeps its primary Restore button and gains a `MoreVerticalIcon` kebab → "Delete permanently" for the rarer per-row purge action.
- Bulk Restore fires the restore endpoint per id in parallel, drops restored rows from the list, decrements the cached total, toasts. Partial failures keep failed rows visible.
- Bulk Delete permanently goes through a confirm modal that explains the 15-day window is being skipped, then calls `DELETE /api/conversations/[id]/purge` per id in parallel. Same partial-failure handling.

## 2. Load More pagination — 15 at a time

- `fetchTrashedConversations(limit, offset)` matches the active-tab API shape.
- First open of the trash tab fetches `CONVERSATIONS_PAGE_SIZE` (15) rows; the response `total` drives whether the "Load more conversations" button appears under the list. Same component, same look as the active tabs.
- `CONVERSATIONS_PAGE_SIZE` is lifted to module scope so the trash hooks share the constant with the active-tab pagination — single source of truth.
- Restore and Delete permanently (single + bulk) decrement the cached total so the button hides cleanly once everything in the grace window is loaded.

## Files

- `services/api.js` — adds `purgeConversation(id)` and extends `fetchTrashedConversations` with `limit` / `offset` params.
- `ConversationsView.jsx` + `.module.css` — bulk handlers, row checkbox / kebab in `TrashList`, swapped selection action bar, purge confirm modal, Load More wrapper under the trash list.

## Regression check

- [x] `npm test` — 565 relevant tests pass (one pre-existing `authSlice` failure unrelated to this change)
- [x] `npx eslint` — clean

## Test plan

- [ ] Recently deleted → click Select → bar shows Restore + Delete permanently (no project / star / archive icons).
- [ ] Select rows → Restore: rows vanish, total decrements, sidebar refreshes.
- [ ] Select rows → Delete permanently → confirm modal explains irreversibility → confirm: rows hard-delete, total decrements.
- [ ] In normal mode, hover a row → kebab visible → Delete permanently → confirm modal works for one row.
- [ ] Restore button on a row still works one-click.
- [ ] All tab → action bar still shows project / star / archive / delete (unchanged).
- [ ] Visit Recently deleted with 30+ trashed conversations — only 15 render initially, "Load more conversations" button shown; click loads the next 15.
- [ ] Click "Load more" while a load is in flight — no duplicate fetch.