### PR TITLE
fix(conversations): TDZ error when switching to Imported

### DIFF
--- a/src/components/ConversationsView/ConversationsView.jsx
+++ b/src/components/ConversationsView/ConversationsView.jsx
@@ -959,6 +959,22 @@ export default function ConversationsView() {
     [filteredConversations]
   );
 
+  const filteredImportedConversations = useMemo(() => {
+    return importedConversations.filter((chat) => {
+      if (activeImportProvider !== 'all' && chat.provider !== activeImportProvider) return false;
+      if (chat.isArchived) return false;
+      if (searchQuery.trim()) {
+        return chat.title?.toLowerCase().includes(searchQuery.toLowerCase());
+      }
+      return true;
+    });
+  }, [importedConversations, activeImportProvider, searchQuery]);
+
+  const groupedImportedConversations = useMemo(
+    () => groupConversationsByTime(filteredImportedConversations),
+    [filteredImportedConversations]
+  );
+
   const selectAll = () => {
     let source;
     if (activeSection === 'imported') {
@@ -1058,22 +1074,6 @@ export default function ConversationsView() {
   );
 
   // Imported conversations filtering
-  const filteredImportedConversations = useMemo(() => {
-    return importedConversations.filter((chat) => {
-      if (activeImportProvider !== 'all' && chat.provider !== activeImportProvider) return false;
-      if (chat.isArchived) return false;
-      if (searchQuery.trim()) {
-        return chat.title?.toLowerCase().includes(searchQuery.toLowerCase());
-      }
-      return true;
-    });
-  }, [importedConversations, activeImportProvider, searchQuery]);
-
-  const groupedImportedConversations = useMemo(
-    () => groupConversationsByTime(filteredImportedConversations),
-    [filteredImportedConversations]
-  );
-
   const handleImportedChatClick = async (chat) => {
     if (selectMode) {
       toggleSelect(chat.id);


### PR DESCRIPTION
## Summary

Clicking "Imported" on `/conversations` threw a ReferenceError and the feature error boundary swapped the page for "Something went wrong" (`Ref: mq6von62-mxut61` in the screenshot).

## Cause

`selectableCount` reads `filteredImportedConversations` to compute the "Select all" count:

```js
const selectableCount =
  activeTab === 'trash'
    ? (trashedConversations || []).length
    : activeSection === 'imported'
    ? filteredImportedConversations.length   // ← throws TDZ here
    : filteredConversations.length;
```

But the `useMemo` that defined `filteredImportedConversations` was declared ~80 lines lower in the component body, so reading it during render was a `const` TDZ access. `filteredConversations` was already above the read site, so the All section worked; only the Imported branch tripped it.

## Fix

Lift `filteredImportedConversations` and `groupedImportedConversations` above `selectAll` + `selectableCount`. No behavioural change — same memos, same deps, just declared before they're read.

## Regression check

- [x] `npm test` — 565 relevant tests pass (one pre-existing `authSlice` failure unrelated)
- [x] `npx eslint` — clean

## Test plan

- [ ] `/conversations` → click "Imported" → tab opens normally with the imported list, no error fallback.
- [ ] In "Imported", click Select → bar appears, click Select all → all visible imported rows tick.
- [ ] Switch back to "My chats" — All tab still works.
- [ ] Switch to Recently deleted — still works.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ri658VymJcJcEJ5VGeWNF)_