### PR TITLE
Remove unused "New features & updates" toggle from Notifications settings

### DIFF
--- a/src/components/SettingsView/SettingsView.jsx
+++ b/src/components/SettingsView/SettingsView.jsx
@@ -1407,21 +1407,6 @@ export default function SettingsView() {
                   <div className={styles.fieldGroup}>
                     <div className={styles.toggleRow}>
                       <div className={styles.toggleInfo}>
-                        <span className={styles.toggleLabel}>New features & updates</span>
-                        <span className={styles.toggleDesc}>
-                          Get notified when new features or improvements are available.
-                        </span>
-                      </div>
-                      <ToggleSwitch
-                        value={settings.notifyNewFeatures}
-                        onChange={(v) => updateSetting('notifyNewFeatures', v)}
-                      />
-                    </div>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <div className={styles.toggleRow}>
-                      <div className={styles.toggleInfo}>
                         <span className={styles.toggleLabel}>Usage limit warnings</span>
                         <span className={styles.toggleDesc}>
                           Get alerted when you&apos;re approaching your credit or usage limits.


### PR DESCRIPTION
## Summary
- Removes the "New features & updates" toggle from the Notifications section of the Settings page since it isn't being used at the moment.

## Test plan
- [ ] Open Settings → Notifications and confirm "New features & updates" no longer appears.
- [ ] Confirm the remaining "Usage limit warnings" toggle still renders and works correctly.

https://claude.ai/code/session_011tha9N52XbfRV864LAfDNB

---
_Generated by [Claude Code](https://claude.ai/code/session_011tha9N52XbfRV864LAfDNB)_