### PR TITLE
Remove Credit Usage section from Subscription page

### DIFF
--- a/src/components/SubscriptionView/SubscriptionSummary.jsx
+++ b/src/components/SubscriptionView/SubscriptionSummary.jsx
@@ -8,8 +8,6 @@ import {
   selectPeriodEnd,
   selectCancelAtPeriodEnd,
   selectSubscriptionStatus,
-  selectTextCredits,
-  selectImageCredits,
   selectPortalLoading,
   fetchSubscriptionThunk,
   createPortalThunk,
@@ -26,19 +24,6 @@ function getStatusLabel(tier, cancelAtPeriodEnd) {
   return { label: 'Active', className: styles.statusActive };
 }
 
-function getCreditColor(remaining, limit) {
-  if (limit === 0) return styles.creditHealthy;
-  const ratio = remaining / limit;
-  if (ratio > 0.5) return styles.creditHealthy;
-  if (ratio > 0.2) return styles.creditLow;
-  return styles.creditCritical;
-}
-
-function getCreditPct(remaining, limit) {
-  if (limit === 0) return 0;
-  return Math.min(100, Math.round((remaining / limit) * 100));
-}
-
 function formatDate(dateStr) {
   if (!dateStr) return null;
   return new Date(dateStr).toLocaleDateString(undefined, {
@@ -48,19 +33,14 @@ function formatDate(dateStr) {
   });
 }
 
-function formatTime(dateStr) {
-  if (!dateStr) return null;
-  return new Date(dateStr).toLocaleTimeString(undefined, {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
 /**
- * Plan overview + quick actions + credit usage — the shared body of the
- * standalone `/subscription` page and the `subscription` section inside
- * Settings. Keeps layout wrapping (headers, hero, page chrome) out of scope
- * so host components can place this in either a full-page or section context.
+ * Plan overview + quick actions — the shared body of the standalone
+ * `/subscription` page and the `subscription` section inside Settings.
+ * Keeps layout wrapping (headers, hero, page chrome) out of scope so host
+ * components can place this in either a full-page or section context.
+ *
+ * Detailed credit usage lives on the dedicated Usage & credits page,
+ * reachable via the "View detailed usage" quick action.
  *
  * Fetches subscription data on mount when the user is authenticated and no
  * load has happened yet. Subsequent mounts rely on the Redux cache.
@@ -85,8 +65,6 @@ export default function SubscriptionSummary({
   const periodEnd = useSelector(selectPeriodEnd);
   const cancelAtPeriodEnd = useSelector(selectCancelAtPeriodEnd);
   const subscriptionStatus = useSelector(selectSubscriptionStatus);
-  const textCredits = useSelector(selectTextCredits);
-  const imageCredits = useSelector(selectImageCredits);
   const portalLoading = useSelector(selectPortalLoading);
 
   useEffect(() => {
@@ -111,23 +89,6 @@ export default function SubscriptionSummary({
   const isPaid = !isFree;
   const status = getStatusLabel(currentTier, cancelAtPeriodEnd);
   const price = tierInfo ? getDisplayPrice(tierInfo, billingCycle) : 0;
-
-  // Text credits
-  const monthlyLimit = textCredits?.monthlyLimit || 0;
-  const monthlyUsed = textCredits?.monthlyUsed || 0;
-  const monthlyRemaining = Math.max(0, monthlyLimit - monthlyUsed);
-
-  // 3-hour session window
-  const windowLimit = textCredits?.windowLimit || 0;
-  const windowUsed = textCredits?.windowUsed || 0;
-  const windowRemaining = Math.max(0, windowLimit - windowUsed);
-  const windowResetAt = textCredits?.windowResetAt;
-
-  // Image credits
-  const imgRemaining = imageCredits?.remaining || 0;
-  const imgLimit = imageCredits?.limit || 0;
-  const packRemaining = imageCredits?.packRemaining || 0;
-  const cycleResetsAt = imageCredits?.cycleResetsAt;
 
   const tierBadgeClass =
     currentTier === 'pro'
@@ -215,76 +176,6 @@ export default function SubscriptionSummary({
             <button className={styles.secondaryBtn} onClick={() => navigate(usageLinkTo)}>
               View detailed usage
             </button>
-          )}
-        </div>
-      </div>
-
-      {/* ── Credit usage ── */}
-      <h2 className={styles.sectionTitle}>Credit Usage</h2>
-      <div className={styles.creditsCard}>
-        <div className={styles.creditSections}>
-          {/* Text credits (monthly) */}
-          <div className={styles.creditSection}>
-            <div className={styles.creditHeader}>
-              <span className={styles.creditLabel}>Text credits</span>
-              <span className={styles.creditCount}>
-                {monthlyRemaining} / {monthlyLimit} remaining
-              </span>
-            </div>
-            <div className={styles.creditBar}>
-              <div
-                className={`${styles.creditFill} ${getCreditColor(monthlyRemaining, monthlyLimit)}`}
-                style={{ width: `${getCreditPct(monthlyRemaining, monthlyLimit)}%` }}
-              />
-            </div>
-          </div>
-
-          {/* 3-hour session window */}
-          <div className={styles.creditSection}>
-            <div className={styles.creditHeader}>
-              <span className={styles.creditLabel}>Session window</span>
-              <span className={styles.creditCount}>
-                {windowRemaining} / {windowLimit} remaining
-              </span>
-            </div>
-            <div className={styles.creditBar}>
-              <div
-                className={`${styles.creditFill} ${getCreditColor(windowRemaining, windowLimit)}`}
-                style={{ width: `${getCreditPct(windowRemaining, windowLimit)}%` }}
-              />
-            </div>
-            {windowResetAt && (
-              <span className={styles.creditMeta}>Resets at {formatTime(windowResetAt)}</span>
-            )}
-          </div>
-
-          <div className={styles.creditDivider} />
-
-          {/* Image credits */}
-          <div className={styles.creditSection}>
-            <div className={styles.creditHeader}>
-              <span className={styles.creditLabel}>Image credits</span>
-              <span className={styles.creditCount}>
-                {imgRemaining} / {imgLimit} remaining
-              </span>
-            </div>
-            <div className={styles.creditBar}>
-              <div
-                className={`${styles.creditFill} ${getCreditColor(imgRemaining, imgLimit)}`}
-                style={{ width: `${getCreditPct(imgRemaining, imgLimit)}%` }}
-              />
-            </div>
-            {cycleResetsAt && (
-              <span className={styles.creditMeta}>Resets {formatDate(cycleResetsAt)}</span>
-            )}
-          </div>
-
-          {/* Pack credits */}
-          {packRemaining > 0 && (
-            <div className={styles.packCredits}>
-              <span>Credit pack balance</span>
-              <span className={styles.packCreditsValue}>{packRemaining} credits</span>
-            </div>
           )}
         </div>
       </div>

--- a/src/components/SubscriptionView/SubscriptionView.module.css
+++ b/src/components/SubscriptionView/SubscriptionView.module.css
@@ -241,16 +241,6 @@
   margin-top: 12px;
 }
 
-/* ── Section titles ── */
-
-.sectionTitle {
-  font-size: 15px;
-  font-weight: 700;
-  color: var(--text-primary);
-  letter-spacing: -0.01em;
-  margin-bottom: 14px;
-}
-
 /* ── Actions card ── */
 
 .actionsCard {
@@ -258,7 +248,6 @@
   border: 1px solid var(--border-color);
   border-radius: 14px;
   padding: 24px;
-  margin-bottom: 28px;
   animation: fadeIn 0.2s ease 0.05s both;
 }
 
@@ -304,98 +293,6 @@
 .secondaryBtn:hover {
   background: var(--bg-hover);
   border-color: var(--text-muted);
-}
-
-/* ── Credit usage card ── */
-
-.creditsCard {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 14px;
-  padding: 24px;
-  animation: fadeIn 0.2s ease 0.1s both;
-}
-
-.creditSections {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.creditSection {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.creditHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-}
-
-.creditLabel {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text-primary);
-}
-
-.creditCount {
-  font-size: 13px;
-  color: var(--text-muted);
-}
-
-.creditBar {
-  height: 6px;
-  border-radius: 3px;
-  background: var(--border-color);
-  overflow: hidden;
-}
-
-.creditFill {
-  height: 100%;
-  border-radius: 3px;
-  transition: width 0.4s ease;
-}
-
-.creditHealthy {
-  background: var(--text-muted);
-}
-
-.creditLow {
-  background: #c4956a;
-}
-
-.creditCritical {
-  background: #c75c3a;
-}
-
-.creditMeta {
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-.creditDivider {
-  height: 1px;
-  background: var(--border-color);
-}
-
-/* ── Pack credits ── */
-
-.packCredits {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px 14px;
-  background: var(--bg-hover);
-  border-radius: 8px;
-  font-size: 13px;
-  color: var(--text-secondary);
-}
-
-.packCreditsValue {
-  font-weight: 600;
-  color: var(--text-primary);
 }
 
 /* ── Responsive ── */


### PR DESCRIPTION
## Summary

- Removes the "Credit Usage" card from the Subscription page. The same data is already shown on the dedicated Usage & credits page, reachable via the existing "View detailed usage" quick action.
- Drops the credit selectors, helpers, and CSS classes that exclusively supported that section, so no dead code is left behind.
- Updates the `SubscriptionSummary` JSDoc to reflect its narrower scope and point readers to where credit usage now lives.

The Subscription page now focuses cleanly on plan + billing; credit details are not duplicated across two settings panes.

## Test plan

- [ ] `/settings/subscription` renders the Plan overview + Quick Actions cards only, no "Credit Usage" heading
- [ ] Standalone `/subscription` page renders the same way (shared `SubscriptionSummary`)
- [ ] "View detailed usage" still navigates to `/settings/usage`
- [ ] "Manage Subscription" and "Upgrade Plan" buttons behave as before
- [ ] No console errors / Redux warnings on load (build + lint pass locally)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkN8Fw6RUJhjrMn1XN3Bkk)_