### PR TITLE
Add dedicated Shared chats page as source of truth

### DIFF
--- a/src/components/ConversationsView/ConversationsView.jsx
+++ b/src/components/ConversationsView/ConversationsView.jsx
@@ -34,6 +34,7 @@ import {
 } from '../../services/api';
 import { useToast } from '../Toast/Toast';
 import useDeleteConversation from '../../hooks/useDeleteConversation';
+import useSharedChats from '../../hooks/useSharedChats';
 import { selectProjects, setProjects } from '../../store/slices/projectsSlice';
 import {
   SearchIcon,
@@ -50,6 +51,9 @@ import {
   ImportIcon,
   ProjectsIcon,
   RefreshIcon,
+  ExternalLinkIcon,
+  EyeIcon,
+  ChevronRightIcon,
 } from '../Icons';
 import { getProviderLogo } from '../getProviderLogo';
 import ImportConversationsModal from '../ImportConversationsModal';
@@ -62,6 +66,7 @@ const CONVERSATIONS_PAGE_SIZE = 15;
 const TABS = [
   { id: 'all', label: 'All' },
   { id: 'starred', label: 'Starred' },
+  { id: 'shared', label: 'Shared' },
   { id: 'archived', label: 'Archived' },
   { id: 'trash', label: 'Recently deleted' },
 ];
@@ -475,6 +480,243 @@ function getImportedProviders(conversations) {
   return [...providerMap.entries()].map(([id, name]) => ({ id, name }));
 }
 
+function formatSharedDate(iso) {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
+function formatSharedViews(count) {
+  const n = typeof count === 'number' ? count : 0;
+  if (n < 1000) return `${n} view${n === 1 ? '' : 's'}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k views`;
+  return `${(n / 1_000_000).toFixed(1)}M views`;
+}
+
+function SharedChatRowMenu({ shareUrl, onOpenPublic, onCopy, onUnshare }) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const [position, setPosition] = useState({});
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleClick = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) setOpen(false);
+    };
+    const handleEsc = (e) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [open]);
+
+  const handleToggle = (e) => {
+    e.stopPropagation();
+    if (!open) {
+      const rect = e.currentTarget.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - rect.bottom;
+      setPosition(
+        spaceBelow < 170 ? { bottom: '100%', marginBottom: 6 } : { top: '100%', marginTop: 6 }
+      );
+    }
+    setOpen((v) => !v);
+  };
+
+  return (
+    <div className={styles.sharedRowMenuWrapper} ref={wrapperRef}>
+      <button
+        type="button"
+        className={styles.sharedRowMenuBtn}
+        onClick={handleToggle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Share actions"
+      >
+        <MoreVerticalIcon />
+      </button>
+      {open && (
+        <div className={styles.sharedRowMenu} style={position} role="menu">
+          <a
+            className={styles.sharedRowMenuItem}
+            href={shareUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            role="menuitem"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onOpenPublic?.();
+            }}
+          >
+            <ExternalLinkIcon />
+            <span>Open public link</span>
+          </a>
+          <button
+            type="button"
+            className={styles.sharedRowMenuItem}
+            role="menuitem"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onCopy();
+            }}
+          >
+            <LinkIcon />
+            <span>Copy link</span>
+          </button>
+          <div className={styles.sharedRowMenuDivider} />
+          <button
+            type="button"
+            className={`${styles.sharedRowMenuItem} ${styles.sharedRowMenuItemDanger}`}
+            role="menuitem"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onUnshare();
+            }}
+          >
+            <TrashIcon />
+            <span>Unshare</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SharedChatsTabPanel({
+  shares,
+  loading,
+  error,
+  searchQuery,
+  busyConversationId,
+  onRetry,
+  onRowClick,
+  onCopy,
+  onUnshare,
+  onManageAll,
+}) {
+  if (shares === null && loading) {
+    return (
+      <div className={styles.skeleton}>
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className={styles.skeletonItem}>
+            <div className={styles.skeletonContent}>
+              <div className={styles.skeletonTitle} style={{ width: `${45 + ((i * 11) % 30)}%` }} />
+              <div className={styles.skeletonSub} style={{ width: `${25 + ((i * 7) % 20)}%` }} />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.empty}>
+        <div className={styles.emptyIcon}>
+          <ShareIcon />
+        </div>
+        <h3 className={styles.emptyTitle}>Couldn&rsquo;t load shared chats</h3>
+        <p className={styles.emptyDesc}>{error}</p>
+        <button type="button" className={styles.emptyAction} onClick={onRetry}>
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  const list = shares || [];
+  if (list.length === 0) {
+    return (
+      <div className={styles.empty}>
+        <div className={styles.emptyIcon}>
+          <ShareIcon />
+        </div>
+        <h3 className={styles.emptyTitle}>No shared chats yet</h3>
+        <p className={styles.emptyDesc}>
+          When you share a conversation publicly, it&rsquo;ll appear here so you can manage every
+          active link.
+        </p>
+      </div>
+    );
+  }
+
+  const q = searchQuery.trim().toLowerCase();
+  const filtered = q
+    ? list.filter((s) => (s.title || 'Untitled conversation').toLowerCase().includes(q))
+    : list;
+
+  if (filtered.length === 0) {
+    return (
+      <div className={styles.empty}>
+        <div className={styles.emptyIcon}>
+          <SearchIcon />
+        </div>
+        <h3 className={styles.emptyTitle}>No matches</h3>
+        <p className={styles.emptyDesc}>Try a different search term.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <ul className={styles.sharedList}>
+        {filtered.map((share) => {
+          const url = `${window.location.origin}/share/${share.shareToken}`;
+          const isBusy = busyConversationId === share.conversationId;
+          return (
+            <li
+              key={share.shareToken}
+              className={`${styles.sharedRow} ${isBusy ? styles.sharedRowBusy : ''}`}
+              onClick={() => onRowClick(share.conversationId)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onRowClick(share.conversationId);
+                }
+              }}
+            >
+              <div className={styles.sharedRowMeta}>
+                <span className={styles.sharedRowTitle}>
+                  {share.title || 'Untitled conversation'}
+                </span>
+                <span className={styles.sharedRowSub}>
+                  <span>Shared {formatSharedDate(share.createdAt)}</span>
+                  <span className={styles.sharedRowDot}>•</span>
+                  <span className={styles.sharedRowViews}>
+                    <EyeIcon />
+                    {formatSharedViews(share.viewCount)}
+                  </span>
+                </span>
+              </div>
+              <SharedChatRowMenu
+                shareUrl={url}
+                onCopy={() => onCopy(share.shareToken)}
+                onUnshare={() => onUnshare(share)}
+              />
+            </li>
+          );
+        })}
+      </ul>
+      <button type="button" className={styles.sharedManageAllBtn} onClick={onManageAll}>
+        <span>Manage on Shared chats page</span>
+        <ChevronRightIcon />
+      </button>
+    </>
+  );
+}
+
 export default function ConversationsView() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -516,6 +758,18 @@ export default function ConversationsView() {
       return {};
     }
   });
+
+  // Shared chats are only fetched once the user opens the "Shared" tab — keep
+  // hydrated afterwards so the tab badge can stay live while they move around.
+  const [sharedFetchEnabled, setSharedFetchEnabled] = useState(false);
+  useEffect(() => {
+    if (activeTab === 'shared' && !sharedFetchEnabled) setSharedFetchEnabled(true);
+  }, [activeTab, sharedFetchEnabled]);
+  const sharedChats = useSharedChats({
+    enabled: isAuthenticated && sharedFetchEnabled,
+  });
+  const [sharedUnshareTarget, setSharedUnshareTarget] = useState(null);
+  const [sharedBusyConversationId, setSharedBusyConversationId] = useState(null);
 
   const listRef = useRef(null);
 
@@ -689,6 +943,39 @@ export default function ConversationsView() {
     },
     [restoringId, showError, showSuccess]
   );
+
+  const handleSharedCopy = useCallback(
+    async (shareToken) => {
+      try {
+        await navigator.clipboard.writeText(`${window.location.origin}/share/${shareToken}`);
+        showSuccess('Link copied to clipboard');
+      } catch {
+        showError('Could not copy link');
+      }
+    },
+    [showError, showSuccess]
+  );
+
+  const handleSharedRowClick = useCallback(
+    (conversationId) => {
+      dispatch(setImportedContext(null));
+      navigate(`/conversations/${conversationId}`);
+    },
+    [dispatch, navigate]
+  );
+
+  const confirmSharedUnshare = useCallback(async () => {
+    if (!sharedUnshareTarget) return;
+    setSharedBusyConversationId(sharedUnshareTarget.conversationId);
+    const result = await sharedChats.unshare(sharedUnshareTarget.conversationId);
+    setSharedBusyConversationId(null);
+    setSharedUnshareTarget(null);
+    if (result.ok) {
+      showSuccess('Conversation unshared');
+    } else {
+      showError(result.error || 'Could not unshare conversation');
+    }
+  }, [sharedChats, sharedUnshareTarget, showError, showSuccess]);
 
   const handleAddToProject = (chatId) => {
     menu.closeMenu();
@@ -1501,21 +1788,28 @@ export default function ConversationsView() {
                     {tab.id === 'archived' && archivedIds.size > 0 && (
                       <span className={styles.tabBadge}>{archivedIds.size}</span>
                     )}
+                    {tab.id === 'shared' && sharedChats.shares && sharedChats.shares.length > 0 && (
+                      <span className={styles.tabBadge}>{sharedChats.shares.length}</span>
+                    )}
                   </button>
                 ))}
               </div>
-              <button
-                className={`${styles.selectToggle} ${selectMode ? styles.selectToggleActive : ''}`}
-                onClick={() => {
-                  if (selectMode) {
-                    exitSelectMode();
-                  } else {
-                    setSelectMode(true);
-                  }
-                }}
-              >
-                {selectMode ? 'Cancel' : 'Select'}
-              </button>
+              {activeTab !== 'shared' && (
+                <button
+                  className={`${styles.selectToggle} ${
+                    selectMode ? styles.selectToggleActive : ''
+                  }`}
+                  onClick={() => {
+                    if (selectMode) {
+                      exitSelectMode();
+                    } else {
+                      setSelectMode(true);
+                    }
+                  }}
+                >
+                  {selectMode ? 'Cancel' : 'Select'}
+                </button>
+              )}
             </div>
 
             {selectMode && (
@@ -1618,6 +1912,19 @@ export default function ConversationsView() {
                   selectMode={selectMode}
                   selectedIds={selectedIds}
                   onToggleSelect={toggleSelect}
+                />
+              ) : activeTab === 'shared' ? (
+                <SharedChatsTabPanel
+                  shares={sharedChats.shares}
+                  loading={sharedChats.loading}
+                  error={sharedChats.error}
+                  searchQuery={searchQuery}
+                  busyConversationId={sharedBusyConversationId}
+                  onRetry={sharedChats.refetch}
+                  onRowClick={handleSharedRowClick}
+                  onCopy={handleSharedCopy}
+                  onUnshare={setSharedUnshareTarget}
+                  onManageAll={() => navigate('/shared')}
                 />
               ) : conversationsLoading && conversations.length === 0 ? (
                 <div className={styles.skeleton}>
@@ -1923,6 +2230,40 @@ export default function ConversationsView() {
               <TrashIcon />
               <span>Delete</span>
             </button>
+          </div>
+        </div>
+      )}
+
+      {sharedUnshareTarget && (
+        <div
+          className={styles.confirmOverlay}
+          onClick={() => (sharedBusyConversationId ? null : setSharedUnshareTarget(null))}
+        >
+          <div className={styles.confirmDialog} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.confirmIcon}>
+              <TrashIcon />
+            </div>
+            <h3 className={styles.confirmTitle}>Unshare this conversation?</h3>
+            <p className={styles.confirmDesc}>
+              The public link will stop working immediately. The conversation itself stays in your
+              history.
+            </p>
+            <div className={styles.confirmActions}>
+              <button
+                className={styles.confirmCancelBtn}
+                onClick={() => setSharedUnshareTarget(null)}
+                disabled={!!sharedBusyConversationId}
+              >
+                Cancel
+              </button>
+              <button
+                className={styles.confirmDeleteBtn}
+                onClick={confirmSharedUnshare}
+                disabled={!!sharedBusyConversationId}
+              >
+                {sharedBusyConversationId ? 'Unsharing…' : 'Unshare'}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/ConversationsView/ConversationsView.module.css
+++ b/src/components/ConversationsView/ConversationsView.module.css
@@ -1663,3 +1663,224 @@
   display: flex;
   justify-content: center;
 }
+
+/* ── Shared chats tab ── */
+.sharedList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sharedRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-primary);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.05s ease,
+    opacity 0.2s ease;
+  position: relative;
+}
+
+.sharedRow:hover {
+  background-color: var(--bg-hover);
+  border-color: var(--text-muted);
+}
+
+.sharedRow:focus-visible {
+  outline: 2px solid var(--text-muted);
+  outline-offset: 2px;
+}
+
+.sharedRow:active {
+  transform: scale(0.997);
+}
+
+.sharedRowBusy {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.sharedRowMeta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.sharedRowTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sharedRowSub {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.sharedRowDot {
+  font-size: 8px;
+  line-height: 1;
+  opacity: 0.6;
+}
+
+.sharedRowViews {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sharedRowViews svg {
+  width: 12px;
+  height: 12px;
+}
+
+.sharedRowMenuWrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.sharedRowMenuBtn {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.sharedRowMenuBtn svg {
+  width: 16px;
+  height: 16px;
+}
+
+.sharedRowMenuBtn:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.sharedRowMenu {
+  position: absolute;
+  right: 0;
+  z-index: 20;
+  min-width: 190px;
+  padding: 6px;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  animation: sharedMenuFadeIn 0.15s ease;
+}
+
+@keyframes sharedMenuFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.sharedRowMenuItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.sharedRowMenuItem svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.sharedRowMenuItem:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.sharedRowMenuDivider {
+  height: 1px;
+  margin: 4px 2px;
+  background-color: var(--border-color);
+}
+
+.sharedRowMenuItemDanger {
+  color: #ef4444;
+}
+
+.sharedRowMenuItemDanger:hover {
+  background-color: rgba(239, 68, 68, 0.08);
+  color: #ef4444;
+}
+
+.sharedManageAllBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 16px auto 0;
+  padding: 9px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background-color: transparent;
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease,
+    transform 0.1s ease;
+}
+
+.sharedManageAllBtn svg {
+  width: 14px;
+  height: 14px;
+  color: var(--text-muted);
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+
+.sharedManageAllBtn:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+  transform: translateY(-1px);
+}
+
+.sharedManageAllBtn:hover svg {
+  color: var(--text-primary);
+  transform: translateX(2px);
+}

--- a/src/components/SettingsView/SettingsView.jsx
+++ b/src/components/SettingsView/SettingsView.jsx
@@ -33,8 +33,9 @@ import {
   DEFAULT_SETTINGS,
 } from '../../services/settings';
 import { createPackCheckoutSession } from '../../services/subscription';
-import { listMyShares, revokeConversationShare, deleteAllConversations } from '../../services/api';
+import { deleteAllConversations } from '../../services/api';
 import { setConversations as setConversationsAction } from '../../store/slices/chatSlice';
+import useSharedChats from '../../hooks/useSharedChats';
 import { useToast } from '../Toast/Toast';
 import { logger } from '../../lib/logger';
 import ConfirmPackModal from '../ConfirmPackModal/ConfirmPackModal';
@@ -42,6 +43,7 @@ import { GuestGate } from '../GuestGate';
 import SubscriptionSummary from '../SubscriptionView/SubscriptionSummary';
 import {
   ChevronLeftIcon,
+  ChevronRightIcon,
   SunIcon,
   MoonIcon,
   TrashIcon,
@@ -50,6 +52,7 @@ import {
   SettingsIcon,
   EditIcon,
   GlobeIcon,
+  ShareIcon,
   ZapIcon,
 } from '../Icons';
 import styles from './SettingsView.module.css';
@@ -113,129 +116,66 @@ const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.userAgent
 const modKey = isMac ? '⌘' : 'Ctrl';
 
 /**
- * Manage the signed-in user's active share links. Mirrors Claude's
- * Settings > Privacy > Manage: a simple list of shared conversations with a
- * per-row "View" link (opens the public page) and "Unshare" button.
- *
- * Loading / empty / error states are rendered inline. The list is refetched
- * when the section mounts and after each successful unshare — no global state
- * needed.
+ * Compact entry point that summarises the user's active share links and
+ * routes them to `/shared` for the full management experience. The dedicated
+ * page is the source of truth — this stub only surfaces the count so the
+ * Data & privacy panel doesn't grow unbounded with every share.
  */
-function SharedChatsManager() {
-  const { showError, showSuccess } = useToast();
-  const [shares, setShares] = useState(null); // null = loading
-  const [loadError, setLoadError] = useState('');
-  const [revokingToken, setRevokingToken] = useState(null);
+function SharedChatsStub({ active }) {
+  const navigate = useNavigate();
+  const { shares, loading, error, refetch } = useSharedChats({ enabled: active });
+  const count = shares?.length ?? 0;
 
-  const loadShares = useCallback(async (signal) => {
-    try {
-      const data = await listMyShares();
-      if (signal?.aborted) return;
-      setShares(Array.isArray(data?.shares) ? data.shares : []);
-      setLoadError('');
-    } catch (err) {
-      if (signal?.aborted) return;
-      setShares([]);
-      setLoadError(err?.message || 'Failed to load shared chats');
-    }
-  }, []);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    loadShares(controller.signal);
-    return () => controller.abort();
-  }, [loadShares]);
-
-  const handleUnshare = useCallback(
-    async (share) => {
-      if (revokingToken) return;
-      setRevokingToken(share.shareToken);
-      try {
-        await revokeConversationShare(share.conversationId);
-        setShares((prev) => (prev || []).filter((s) => s.shareToken !== share.shareToken));
-        showSuccess('Conversation unshared');
-      } catch (err) {
-        showError(err?.message || 'Failed to unshare conversation');
-      } finally {
-        setRevokingToken(null);
-      }
-    },
-    [revokingToken, showError, showSuccess]
-  );
-
-  const formatDate = (iso) => {
-    try {
-      const d = new Date(iso);
-      if (isNaN(d.getTime())) return '';
-      return d.toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-      });
-    } catch {
-      return '';
-    }
-  };
-
-  if (shares === null) {
-    return (
-      <div className={styles.sharedChatsLoading}>
-        <div className={styles.sharedChatsSpinner} />
-        <span>Loading shared chats…</span>
-      </div>
-    );
-  }
-
-  if (loadError) {
-    return <div className={styles.sharedChatsError}>{loadError}</div>;
-  }
-
-  if (shares.length === 0) {
-    return (
-      <div className={styles.sharedChatsEmpty}>You haven&rsquo;t shared any conversations yet.</div>
-    );
-  }
+  const handleManage = () => navigate('/shared');
 
   return (
-    <ul className={styles.sharedChatsList}>
-      {shares.map((share) => {
-        const url = `${window.location.origin}/share/${share.shareToken}`;
-        const isRevoking = revokingToken === share.shareToken;
-        return (
-          <li key={share.shareToken} className={styles.sharedChatsRow}>
-            <div className={styles.sharedChatsMeta}>
-              <span className={styles.sharedChatsTitle}>
-                {share.title || 'Untitled conversation'}
-              </span>
-              <span className={styles.sharedChatsSub}>
-                Shared {formatDate(share.createdAt)}
-                {typeof share.viewCount === 'number'
-                  ? ` · ${share.viewCount} view${share.viewCount === 1 ? '' : 's'}`
-                  : ''}
-              </span>
-            </div>
-            <div className={styles.sharedChatsActions}>
-              <a
-                href={url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.sharedChatsViewLink}
-              >
-                View
-              </a>
-              <button
-                type="button"
-                className={styles.sharedChatsUnshareBtn}
-                onClick={() => handleUnshare(share)}
-                disabled={isRevoking}
-              >
-                {isRevoking ? 'Unsharing…' : 'Unshare'}
-              </button>
-            </div>
-          </li>
-        );
-      })}
-    </ul>
+    <div className={styles.sharedChatsStub}>
+      <div className={styles.sharedChatsStubIcon}>
+        <ShareIcon />
+      </div>
+      <div className={styles.sharedChatsStubBody}>
+        {shares === null && loading ? (
+          <>
+            <span className={styles.sharedChatsStubTitle}>Loading shared chats…</span>
+            <span className={styles.sharedChatsStubSub}>
+              Fetching the conversations you&rsquo;ve shared publicly.
+            </span>
+          </>
+        ) : error ? (
+          <>
+            <span className={styles.sharedChatsStubTitle}>Couldn&rsquo;t load shared chats</span>
+            <button type="button" className={styles.sharedChatsStubRetry} onClick={refetch}>
+              Try again
+            </button>
+          </>
+        ) : count === 0 ? (
+          <>
+            <span className={styles.sharedChatsStubTitle}>No shared chats yet</span>
+            <span className={styles.sharedChatsStubSub}>
+              When you share a conversation publicly, it&rsquo;ll appear here.
+            </span>
+          </>
+        ) : (
+          <>
+            <span className={styles.sharedChatsStubTitle}>
+              {count} conversation{count === 1 ? '' : 's'} shared publicly
+            </span>
+            <span className={styles.sharedChatsStubSub}>
+              View, copy, or revoke any active link from one place.
+            </span>
+          </>
+        )}
+      </div>
+      <button
+        type="button"
+        className={styles.sharedChatsStubAction}
+        onClick={handleManage}
+        disabled={!!error}
+      >
+        <span>Manage</span>
+        <ChevronRightIcon />
+      </button>
+    </div>
   );
 }
 
@@ -1484,10 +1424,10 @@ export default function SettingsView() {
                   <div className={styles.fieldGroup}>
                     <label className={styles.fieldLabel}>Shared chats</label>
                     <p className={styles.fieldLabelDesc}>
-                      Links to conversations you&rsquo;ve shared publicly. Unsharing revokes the
-                      link immediately.
+                      Links to conversations you&rsquo;ve shared publicly. Manage every active link
+                      from the Shared chats page.
                     </p>
-                    <SharedChatsManager />
+                    <SharedChatsStub active={activeSection === 'data'} />
                   </div>
 
                   <div className={styles.dangerZone}>

--- a/src/components/SettingsView/SettingsView.module.css
+++ b/src/components/SettingsView/SettingsView.module.css
@@ -1322,140 +1322,133 @@
   opacity: 0.85;
 }
 
-/* ── Shared chats manager (Data & privacy section) ── */
+/* ── Shared chats stub (Data & privacy section) ── */
 
-.sharedChatsLoading {
+.sharedChatsStub {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 14px 0 4px;
-  color: var(--text-secondary);
-  font-size: 13px;
-}
-
-.sharedChatsSpinner {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  border: 2px solid var(--border-color);
-  border-top-color: var(--text-primary);
-  animation: sharedChatsSpin 0.8s linear infinite;
-}
-
-@keyframes sharedChatsSpin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.sharedChatsError {
-  margin-top: 10px;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background-color: var(--bg-secondary);
-  color: var(--text-secondary);
-  border: 1px solid var(--border-color);
-  font-size: 13px;
-}
-
-.sharedChatsEmpty {
-  margin-top: 8px;
-  padding: 14px 16px;
-  border-radius: 10px;
-  border: 1px dashed var(--border-color);
-  color: var(--text-muted);
-  font-size: 13px;
-  text-align: center;
-}
-
-.sharedChatsList {
-  list-style: none;
-  margin: 10px 0 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.sharedChatsRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   gap: 14px;
-  padding: 12px 14px;
+  padding: 14px 16px;
+  margin-top: 4px;
+  background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  border-radius: 10px;
-  background-color: var(--bg-primary);
+  border-radius: 14px;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
-.sharedChatsMeta {
+.sharedChatsStub:hover {
+  background-color: var(--bg-hover);
+  border-color: var(--text-muted);
+}
+
+.sharedChatsStubIcon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.sharedChatsStubIcon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.sharedChatsStubBody {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  flex: 1;
   min-width: 0;
 }
 
-.sharedChatsTitle {
-  font-size: 13px;
+.sharedChatsStubTitle {
+  font-size: 13.5px;
   font-weight: 600;
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 360px;
 }
 
-.sharedChatsSub {
-  font-size: 12px;
+.sharedChatsStubSub {
+  font-size: 12.5px;
   color: var(--text-muted);
+  line-height: 1.4;
 }
 
-.sharedChatsActions {
+.sharedChatsStubAction {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-}
-
-.sharedChatsViewLink {
-  padding: 6px 12px;
-  border-radius: 8px;
-  border: 1px solid var(--border-color);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
+  gap: 4px;
+  padding: 8px 12px 8px 16px;
+  border-radius: 9px;
+  font-size: 12.5px;
   font-weight: 600;
-  text-decoration: none;
-  transition: all 0.15s ease;
-}
-
-.sharedChatsViewLink:hover {
-  background-color: var(--bg-hover);
   color: var(--text-primary);
-  border-color: var(--text-muted);
-}
-
-.sharedChatsUnshareBtn {
-  padding: 6px 12px;
-  border-radius: 8px;
+  background-color: var(--bg-primary);
   border: 1px solid var(--border-color);
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 600;
   cursor: pointer;
-  transition: all 0.15s ease;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
 }
 
-.sharedChatsUnshareBtn:hover:not(:disabled) {
-  background-color: var(--bg-hover);
+.sharedChatsStubAction svg {
+  width: 14px;
+  height: 14px;
+  color: var(--text-muted);
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+
+.sharedChatsStubAction:hover:not(:disabled) {
+  border-color: var(--text-muted);
+  transform: translateY(-1px);
+}
+
+.sharedChatsStubAction:hover:not(:disabled) svg {
   color: var(--text-primary);
+  transform: translateX(2px);
+}
+
+.sharedChatsStubAction:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sharedChatsStubRetry {
+  margin-top: 4px;
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.sharedChatsStubRetry:hover {
+  background-color: var(--bg-hover);
   border-color: var(--text-muted);
 }
 
-.sharedChatsUnshareBtn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+@media (max-width: 640px) {
+  .sharedChatsStub {
+    flex-wrap: wrap;
+  }
+
+  .sharedChatsStubAction {
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 /* ── Usage limit threshold chips ── */

--- a/src/components/SharedView/SharedView.jsx
+++ b/src/components/SharedView/SharedView.jsx
@@ -1,0 +1,703 @@
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import useSharedChats from '../../hooks/useSharedChats';
+import { selectIsAuthenticated } from '../../store/slices/authSlice';
+import { GuestGate } from '../GuestGate';
+import { useToast } from '../Toast/Toast';
+import {
+  ShareIcon,
+  SearchIcon,
+  CloseIcon,
+  ChevronDownIcon,
+  MoreVerticalIcon,
+  LinkIcon,
+  ExternalLinkIcon,
+  TrashIcon,
+  EyeIcon,
+} from '../Icons';
+import styles from './SharedView.module.css';
+
+const SORT_OPTIONS = [
+  { id: 'recent', label: 'Newest first' },
+  { id: 'oldest', label: 'Oldest first' },
+  { id: 'views', label: 'Most viewed' },
+];
+
+const sortShares = (shares, sortId) => {
+  const copy = [...shares];
+  if (sortId === 'oldest') {
+    copy.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+  } else if (sortId === 'views') {
+    copy.sort((a, b) => (b.viewCount || 0) - (a.viewCount || 0));
+  } else {
+    copy.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  }
+  return copy;
+};
+
+const groupSharesByDate = (shares) => {
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfYesterday = new Date(startOfToday);
+  startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+  const startOf7Days = new Date(startOfToday);
+  startOf7Days.setDate(startOf7Days.getDate() - 7);
+  const startOf30Days = new Date(startOfToday);
+  startOf30Days.setDate(startOf30Days.getDate() - 30);
+
+  const buckets = {
+    Today: [],
+    Yesterday: [],
+    'Previous 7 days': [],
+    'Previous 30 days': [],
+    Older: [],
+  };
+  for (const share of shares) {
+    const d = new Date(share.createdAt);
+    if (d >= startOfToday) buckets.Today.push(share);
+    else if (d >= startOfYesterday) buckets.Yesterday.push(share);
+    else if (d >= startOf7Days) buckets['Previous 7 days'].push(share);
+    else if (d >= startOf30Days) buckets['Previous 30 days'].push(share);
+    else buckets.Older.push(share);
+  }
+  return Object.entries(buckets)
+    .filter(([, items]) => items.length > 0)
+    .map(([label, items]) => ({ label, items }));
+};
+
+const formatViewCount = (count) => {
+  const n = typeof count === 'number' ? count : 0;
+  if (n < 1000) return `${n} view${n === 1 ? '' : 's'}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k views`;
+  return `${(n / 1_000_000).toFixed(1)}M views`;
+};
+
+const formatShareDate = (iso) => {
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return '';
+  }
+};
+
+const buildPublicUrl = (token) => `${window.location.origin}/share/${token}`;
+
+function SortMenu({ value, onChange }) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleClick = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) setOpen(false);
+    };
+    const handleEsc = (e) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [open]);
+
+  const current = SORT_OPTIONS.find((o) => o.id === value) || SORT_OPTIONS[0];
+
+  return (
+    <div className={styles.sortWrapper} ref={wrapperRef}>
+      <button
+        type="button"
+        className={styles.sortBtn}
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className={styles.sortLabel}>Sort: {current.label}</span>
+        <ChevronDownIcon />
+      </button>
+      {open && (
+        <ul className={styles.sortMenu} role="listbox">
+          {SORT_OPTIONS.map((option) => (
+            <li key={option.id}>
+              <button
+                type="button"
+                className={`${styles.sortMenuItem} ${
+                  option.id === value ? styles.sortMenuItemActive : ''
+                }`}
+                role="option"
+                aria-selected={option.id === value}
+                onClick={() => {
+                  onChange(option.id);
+                  setOpen(false);
+                }}
+              >
+                {option.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ShareRowMenu({ shareUrl, onOpen, onCopy, onUnshare, disabled }) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const [position, setPosition] = useState({});
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleClick = (e) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) setOpen(false);
+    };
+    const handleEsc = (e) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [open]);
+
+  const handleToggle = (e) => {
+    e.stopPropagation();
+    if (!open) {
+      const rect = e.currentTarget.getBoundingClientRect();
+      const spaceBelow = window.innerHeight - rect.bottom;
+      setPosition(
+        spaceBelow < 160 ? { bottom: '100%', marginBottom: 6 } : { top: '100%', marginTop: 6 }
+      );
+    }
+    setOpen((v) => !v);
+  };
+
+  return (
+    <div className={styles.rowMenuWrapper} ref={wrapperRef}>
+      <button
+        type="button"
+        className={styles.rowMenuBtn}
+        onClick={handleToggle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Share actions"
+        disabled={disabled}
+      >
+        <MoreVerticalIcon />
+      </button>
+      {open && (
+        <div className={styles.rowMenu} style={position} role="menu">
+          <a
+            className={styles.rowMenuItem}
+            href={shareUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            role="menuitem"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onOpen?.();
+            }}
+          >
+            <ExternalLinkIcon />
+            <span>Open public link</span>
+          </a>
+          <button
+            type="button"
+            className={styles.rowMenuItem}
+            role="menuitem"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onCopy();
+            }}
+          >
+            <LinkIcon />
+            <span>Copy link</span>
+          </button>
+          <div className={styles.rowMenuDivider} />
+          <button
+            type="button"
+            className={`${styles.rowMenuItem} ${styles.rowMenuItemDanger}`}
+            role="menuitem"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onUnshare();
+            }}
+          >
+            <TrashIcon />
+            <span>Unshare</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SharedView() {
+  const navigate = useNavigate();
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const { showError, showSuccess } = useToast();
+  const { shares, loading, error, refetch, unshare, unshareMany } = useSharedChats({
+    enabled: isAuthenticated,
+  });
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortId, setSortId] = useState('recent');
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedTokens, setSelectedTokens] = useState(() => new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [unshareTarget, setUnshareTarget] = useState(null);
+  const [bulkConfirm, setBulkConfirm] = useState(false);
+  const [busyConversationId, setBusyConversationId] = useState(null);
+
+  const sharesList = useMemo(() => shares || [], [shares]);
+
+  const filteredShares = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    const base = q
+      ? sharesList.filter((s) => (s.title || 'Untitled conversation').toLowerCase().includes(q))
+      : sharesList;
+    return sortShares(base, sortId);
+  }, [sharesList, searchQuery, sortId]);
+
+  const groupedShares = useMemo(
+    () => (sortId === 'recent' || sortId === 'oldest' ? groupSharesByDate(filteredShares) : null),
+    [filteredShares, sortId]
+  );
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelectedTokens(new Set());
+  }, []);
+
+  const toggleSelect = useCallback((token) => {
+    setSelectedTokens((prev) => {
+      const next = new Set(prev);
+      if (next.has(token)) next.delete(token);
+      else next.add(token);
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback(() => {
+    setSelectedTokens(new Set(filteredShares.map((s) => s.shareToken)));
+  }, [filteredShares]);
+
+  const handleCopy = useCallback(
+    async (token) => {
+      try {
+        await navigator.clipboard.writeText(buildPublicUrl(token));
+        showSuccess('Link copied to clipboard');
+      } catch {
+        showError('Could not copy link');
+      }
+    },
+    [showError, showSuccess]
+  );
+
+  const handleUnshareConfirmed = useCallback(async () => {
+    if (!unshareTarget) return;
+    setBusyConversationId(unshareTarget.conversationId);
+    const result = await unshare(unshareTarget.conversationId);
+    setBusyConversationId(null);
+    setUnshareTarget(null);
+    if (result.ok) {
+      showSuccess('Conversation unshared');
+    } else {
+      showError(result.error || 'Could not unshare conversation');
+    }
+  }, [unshare, unshareTarget, showError, showSuccess]);
+
+  const handleBulkUnshareConfirmed = useCallback(async () => {
+    const tokenSet = new Set(selectedTokens);
+    const ids = sharesList.filter((s) => tokenSet.has(s.shareToken)).map((s) => s.conversationId);
+    if (ids.length === 0) {
+      setBulkConfirm(false);
+      return;
+    }
+    setBulkBusy(true);
+    const result = await unshareMany(ids);
+    setBulkBusy(false);
+    setBulkConfirm(false);
+    if (result.ok) {
+      showSuccess(`${ids.length} conversation${ids.length === 1 ? '' : 's'} unshared`);
+      exitSelectMode();
+    } else {
+      const restored = result.failures.length;
+      showError(
+        restored === ids.length
+          ? "Couldn't unshare the selected conversations."
+          : `Couldn't unshare ${restored} of ${ids.length}.`
+      );
+      setSelectedTokens(new Set());
+    }
+  }, [selectedTokens, sharesList, unshareMany, showError, showSuccess, exitSelectMode]);
+
+  const handleOpenConversation = useCallback(
+    (conversationId) => {
+      if (selectMode) return;
+      navigate(`/conversations/${conversationId}`);
+    },
+    [navigate, selectMode]
+  );
+
+  const totalCount = sharesList.length;
+  const filteredCount = filteredShares.length;
+  const hasSelection = selectedTokens.size > 0;
+
+  if (!isAuthenticated) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.inner}>
+          <div className={styles.header}>
+            <h1 className={styles.title}>Shared chats</h1>
+          </div>
+          <GuestGate
+            icon={<ShareIcon />}
+            title="Your shared links live here"
+            description="Sign in to manage conversations you've shared publicly — view, copy, or unshare in one place."
+            actionLabel="Sign in to manage shared chats"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.inner}>
+        <div className={styles.header}>
+          <div className={styles.titleBlock}>
+            <h1 className={styles.title}>Shared chats</h1>
+            {shares !== null && (
+              <span className={styles.subtitle}>
+                {totalCount === 0
+                  ? 'No conversations shared publicly.'
+                  : `${totalCount} conversation${totalCount === 1 ? '' : 's'} shared publicly.`}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {shares !== null && totalCount > 0 && (
+          <div className={styles.searchWrapper}>
+            <div className={styles.searchIcon}>
+              <SearchIcon />
+            </div>
+            <input
+              type="text"
+              className={styles.searchInput}
+              placeholder="Search shared chats..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                className={styles.searchClear}
+                onClick={() => setSearchQuery('')}
+                aria-label="Clear search"
+              >
+                <CloseIcon />
+              </button>
+            )}
+          </div>
+        )}
+
+        {shares !== null && totalCount > 0 && (
+          <div className={styles.toolbar}>
+            <SortMenu value={sortId} onChange={setSortId} />
+            <button
+              type="button"
+              className={`${styles.selectToggle} ${selectMode ? styles.selectToggleActive : ''}`}
+              onClick={() => (selectMode ? exitSelectMode() : setSelectMode(true))}
+            >
+              {selectMode ? 'Cancel' : 'Select'}
+            </button>
+          </div>
+        )}
+
+        {selectMode && (
+          <div className={styles.selectionBar}>
+            <div className={styles.selectionLeft}>
+              <span className={styles.selectionCount}>{selectedTokens.size} selected</span>
+              {selectedTokens.size < filteredCount && (
+                <button type="button" className={styles.selectAllBtn} onClick={selectAll}>
+                  Select all
+                </button>
+              )}
+            </div>
+            <button
+              type="button"
+              className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
+              onClick={() => hasSelection && setBulkConfirm(true)}
+              disabled={!hasSelection || bulkBusy}
+            >
+              <TrashIcon />
+              <span>Unshare</span>
+            </button>
+            <button
+              type="button"
+              className={styles.selectionClose}
+              onClick={exitSelectMode}
+              aria-label="Exit selection"
+            >
+              <CloseIcon />
+            </button>
+          </div>
+        )}
+
+        <div className={styles.list}>
+          {shares === null && loading ? (
+            <SharedListSkeleton />
+          ) : error ? (
+            <div className={styles.errorState}>
+              <p className={styles.errorMessage}>{error}</p>
+              <button type="button" className={styles.errorRetryBtn} onClick={refetch}>
+                Try again
+              </button>
+            </div>
+          ) : totalCount === 0 ? (
+            <SharedEmptyState onBrowse={() => navigate('/conversations')} />
+          ) : filteredCount === 0 ? (
+            <NoResultsState query={searchQuery} onClear={() => setSearchQuery('')} />
+          ) : groupedShares ? (
+            groupedShares.map((group) => (
+              <div key={group.label} className={styles.timeGroup}>
+                <div className={styles.timeGroupLabel}>{group.label}</div>
+                {group.items.map((share) => (
+                  <SharedRow
+                    key={share.shareToken}
+                    share={share}
+                    selectMode={selectMode}
+                    isSelected={selectedTokens.has(share.shareToken)}
+                    busy={busyConversationId === share.conversationId}
+                    onToggleSelect={() => toggleSelect(share.shareToken)}
+                    onOpen={() => handleOpenConversation(share.conversationId)}
+                    onCopy={() => handleCopy(share.shareToken)}
+                    onUnshare={() => setUnshareTarget(share)}
+                  />
+                ))}
+              </div>
+            ))
+          ) : (
+            <div className={styles.timeGroup}>
+              {filteredShares.map((share) => (
+                <SharedRow
+                  key={share.shareToken}
+                  share={share}
+                  selectMode={selectMode}
+                  isSelected={selectedTokens.has(share.shareToken)}
+                  busy={busyConversationId === share.conversationId}
+                  onToggleSelect={() => toggleSelect(share.shareToken)}
+                  onOpen={() => handleOpenConversation(share.conversationId)}
+                  onCopy={() => handleCopy(share.shareToken)}
+                  onUnshare={() => setUnshareTarget(share)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {unshareTarget && (
+        <ConfirmDialog
+          title="Unshare this conversation?"
+          description="The public link will stop working immediately. The conversation itself stays in your history."
+          confirmLabel={busyConversationId ? 'Unsharing…' : 'Unshare'}
+          busy={!!busyConversationId}
+          onCancel={() => (busyConversationId ? null : setUnshareTarget(null))}
+          onConfirm={handleUnshareConfirmed}
+        />
+      )}
+
+      {bulkConfirm && (
+        <ConfirmDialog
+          title={`Unshare ${selectedTokens.size} conversation${
+            selectedTokens.size === 1 ? '' : 's'
+          }?`}
+          description="Every selected public link will stop working immediately. The conversations themselves stay in your history."
+          confirmLabel={bulkBusy ? 'Unsharing…' : 'Unshare all'}
+          busy={bulkBusy}
+          onCancel={() => (bulkBusy ? null : setBulkConfirm(false))}
+          onConfirm={handleBulkUnshareConfirmed}
+        />
+      )}
+    </div>
+  );
+}
+
+function SharedRow({
+  share,
+  selectMode,
+  isSelected,
+  busy,
+  onToggleSelect,
+  onOpen,
+  onCopy,
+  onUnshare,
+}) {
+  const shareUrl = buildPublicUrl(share.shareToken);
+  const title = share.title || 'Untitled conversation';
+  const handleClick = () => {
+    if (selectMode) onToggleSelect();
+    else onOpen();
+  };
+
+  return (
+    <div
+      className={`${styles.row} ${isSelected ? styles.rowSelected : ''} ${
+        selectMode ? styles.rowSelectMode : ''
+      } ${busy ? styles.rowBusy : ''}`}
+      onClick={handleClick}
+      role={selectMode ? 'checkbox' : 'button'}
+      aria-checked={selectMode ? isSelected : undefined}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+    >
+      {selectMode && (
+        <div className={styles.checkboxArea}>
+          <div className={`${styles.checkbox} ${isSelected ? styles.checkboxChecked : ''}`}>
+            {isSelected && (
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            )}
+          </div>
+        </div>
+      )}
+      <div className={styles.rowMeta}>
+        <span className={styles.rowTitle}>{title}</span>
+        <span className={styles.rowSub}>
+          <span>Shared {formatShareDate(share.createdAt)}</span>
+          <span className={styles.rowDot}>•</span>
+          <span className={styles.rowViews}>
+            <EyeIcon />
+            {formatViewCount(share.viewCount)}
+          </span>
+        </span>
+      </div>
+      {!selectMode && (
+        <ShareRowMenu
+          shareUrl={shareUrl}
+          disabled={busy}
+          onOpen={onOpen}
+          onCopy={onCopy}
+          onUnshare={onUnshare}
+        />
+      )}
+    </div>
+  );
+}
+
+function SharedListSkeleton() {
+  return (
+    <div className={styles.skeleton}>
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className={styles.skeletonItem}>
+          <div className={styles.skeletonTitle} style={{ width: `${45 + ((i * 13) % 35)}%` }} />
+          <div className={styles.skeletonSub} style={{ width: `${25 + ((i * 7) % 18)}%` }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SharedEmptyState({ onBrowse }) {
+  return (
+    <div className={styles.empty}>
+      <div className={styles.emptyIcon}>
+        <ShareIcon />
+      </div>
+      <h3 className={styles.emptyTitle}>No shared chats yet</h3>
+      <p className={styles.emptyDesc}>
+        When you share a conversation publicly, it&rsquo;ll appear here so you can manage every
+        active link in one place.
+      </p>
+      <button type="button" className={styles.emptyAction} onClick={onBrowse}>
+        Browse your conversations
+      </button>
+    </div>
+  );
+}
+
+function NoResultsState({ query, onClear }) {
+  return (
+    <div className={styles.empty}>
+      <div className={styles.emptyIcon}>
+        <SearchIcon />
+      </div>
+      <h3 className={styles.emptyTitle}>No matches for &ldquo;{query}&rdquo;</h3>
+      <p className={styles.emptyDesc}>Try a different search term.</p>
+      <button type="button" className={styles.emptyAction} onClick={onClear}>
+        Clear search
+      </button>
+    </div>
+  );
+}
+
+function ConfirmDialog({ title, description, confirmLabel, busy, onCancel, onConfirm }) {
+  return (
+    <div className={styles.confirmOverlay} onClick={onCancel} role="presentation">
+      <div
+        className={styles.confirmDialog}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shared-confirm-title"
+      >
+        <div className={styles.confirmIcon}>
+          <TrashIcon />
+        </div>
+        <h3 id="shared-confirm-title" className={styles.confirmTitle}>
+          {title}
+        </h3>
+        <p className={styles.confirmDesc}>{description}</p>
+        <div className={styles.confirmActions}>
+          <button
+            type="button"
+            className={styles.confirmCancelBtn}
+            onClick={onCancel}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={styles.confirmConfirmBtn}
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SharedView/SharedView.module.css
+++ b/src/components/SharedView/SharedView.module.css
@@ -1,0 +1,871 @@
+.page {
+  flex: 1;
+  height: 100%;
+  overflow-y: auto;
+  background-color: var(--bg-primary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.inner {
+  width: 100%;
+  max-width: 720px;
+  padding: 48px 28px 120px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Header */
+.header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.titleBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.title {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+}
+
+.subtitle {
+  font-size: 13.5px;
+  color: var(--text-muted);
+}
+
+/* Search */
+.searchWrapper {
+  position: relative;
+  margin-bottom: 16px;
+}
+
+.searchIcon {
+  position: absolute;
+  left: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  display: flex;
+  pointer-events: none;
+}
+
+.searchIcon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 11px 40px 11px 42px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  font-size: 14px;
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.searchInput::placeholder {
+  color: var(--text-muted);
+}
+
+.searchInput:focus {
+  border-color: var(--text-muted);
+  background-color: var(--bg-primary);
+  box-shadow: 0 0 0 3px rgba(128, 128, 128, 0.06);
+}
+
+.searchClear {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  border-radius: 6px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.searchClear svg {
+  width: 14px;
+  height: 14px;
+}
+
+.searchClear:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+/* Toolbar */
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+/* Sort dropdown */
+.sortWrapper {
+  position: relative;
+}
+
+.sortBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 9px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.sortBtn:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.sortBtn svg {
+  width: 13px;
+  height: 13px;
+}
+
+.sortLabel {
+  white-space: nowrap;
+}
+
+.sortMenu {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 6px);
+  z-index: 20;
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  min-width: 180px;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  animation: menuFadeIn 0.15s ease;
+}
+
+.sortMenuItem {
+  width: 100%;
+  text-align: left;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.sortMenuItem:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.sortMenuItemActive {
+  background-color: var(--bg-active);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+@keyframes menuFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Select toggle */
+.selectToggle {
+  padding: 7px 14px;
+  border-radius: 9px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  white-space: nowrap;
+}
+
+.selectToggle:hover {
+  color: var(--text-secondary);
+  background-color: var(--bg-secondary);
+}
+
+.selectToggleActive {
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+  border-color: var(--border-color);
+}
+
+/* Selection bar */
+.selectionBar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px 8px 16px;
+  margin-bottom: 12px;
+  border-radius: 12px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  animation: selectionSlideDown 0.2s ease;
+}
+
+@keyframes selectionSlideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.selectionLeft {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-right: auto;
+}
+
+.selectionCount {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.selectAllBtn {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.selectAllBtn:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.selectionAction {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 9px;
+  font-size: 12.5px;
+  font-weight: 600;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  white-space: nowrap;
+}
+
+.selectionAction svg {
+  width: 14px;
+  height: 14px;
+}
+
+.selectionAction:hover:not(:disabled) {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.selectionAction:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.selectionActionDanger {
+  color: #ef4444;
+  border-color: rgba(239, 68, 68, 0.3);
+}
+
+.selectionActionDanger:hover:not(:disabled) {
+  background-color: rgba(239, 68, 68, 0.08);
+  color: #ef4444;
+  border-color: #ef4444;
+}
+
+.selectionClose {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.selectionClose svg {
+  width: 14px;
+  height: 14px;
+}
+
+.selectionClose:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* List */
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.timeGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.timeGroupLabel {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 0 4px 6px;
+}
+
+/* Row */
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-primary);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.05s ease,
+    opacity 0.2s ease;
+  position: relative;
+}
+
+.row:hover {
+  background-color: var(--bg-hover);
+  border-color: var(--text-muted);
+}
+
+.row:focus-visible {
+  outline: 2px solid var(--text-muted);
+  outline-offset: 2px;
+}
+
+.row:active {
+  transform: scale(0.997);
+}
+
+.rowSelected {
+  background-color: var(--bg-active);
+  border-color: var(--text-primary);
+}
+
+.rowSelected:hover {
+  background-color: var(--bg-active);
+  border-color: var(--text-primary);
+}
+
+.rowSelectMode {
+  padding-left: 12px;
+}
+
+.rowBusy {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.checkboxArea {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.checkbox {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  border: 1.5px solid var(--border-color);
+  background-color: var(--bg-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--bg-primary);
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.checkboxChecked {
+  background-color: var(--text-primary);
+  border-color: var(--text-primary);
+}
+
+.rowMeta {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.rowTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rowSub {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+
+.rowDot {
+  font-size: 8px;
+  line-height: 1;
+  opacity: 0.6;
+}
+
+.rowViews {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.rowViews svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* Row menu */
+.rowMenuWrapper {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.rowMenuBtn {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.rowMenuBtn svg {
+  width: 16px;
+  height: 16px;
+}
+
+.rowMenuBtn:hover:not(:disabled) {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.rowMenuBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.rowMenu {
+  position: absolute;
+  right: 0;
+  z-index: 20;
+  min-width: 190px;
+  padding: 6px;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  animation: menuFadeIn 0.15s ease;
+}
+
+.rowMenuItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.rowMenuItem svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.rowMenuItem:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.rowMenuDivider {
+  height: 1px;
+  margin: 4px 2px;
+  background-color: var(--border-color);
+}
+
+.rowMenuItemDanger {
+  color: #ef4444;
+}
+
+.rowMenuItemDanger:hover {
+  background-color: rgba(239, 68, 68, 0.08);
+  color: #ef4444;
+}
+
+/* Empty / error states */
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 64px 24px;
+  gap: 12px;
+}
+
+.emptyIcon {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.emptyIcon svg {
+  width: 22px;
+  height: 22px;
+}
+
+.emptyTitle {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+
+.emptyDesc {
+  font-size: 13.5px;
+  color: var(--text-muted);
+  line-height: 1.55;
+  max-width: 360px;
+}
+
+.emptyAction {
+  margin-top: 8px;
+  padding: 9px 18px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+}
+
+.emptyAction:hover {
+  background-color: var(--bg-hover);
+  border-color: var(--text-muted);
+  transform: translateY(-1px);
+}
+
+.errorState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 48px 24px;
+  text-align: center;
+  border: 1px dashed var(--border-color);
+  border-radius: 14px;
+  background-color: var(--bg-secondary);
+}
+
+.errorMessage {
+  font-size: 13.5px;
+  color: var(--text-secondary);
+  max-width: 360px;
+  line-height: 1.5;
+}
+
+.errorRetryBtn {
+  padding: 8px 16px;
+  border-radius: 9px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.errorRetryBtn:hover {
+  background-color: var(--bg-hover);
+  border-color: var(--text-muted);
+}
+
+/* Skeleton */
+.skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skeletonItem {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-primary);
+}
+
+.skeletonTitle,
+.skeletonSub {
+  height: 11px;
+  border-radius: 6px;
+  background: linear-gradient(
+    90deg,
+    var(--bg-secondary) 0%,
+    var(--bg-hover) 50%,
+    var(--bg-secondary) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeletonShimmer 1.4s ease-in-out infinite;
+}
+
+.skeletonSub {
+  height: 9px;
+  opacity: 0.7;
+}
+
+@keyframes skeletonShimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Confirm dialog */
+.confirmOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  animation: overlayFadeIn 0.15s ease;
+}
+
+@keyframes overlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.confirmDialog {
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  padding: 28px 24px 24px;
+  max-width: 400px;
+  width: 90%;
+  text-align: center;
+  box-shadow: 0 16px 50px rgba(0, 0, 0, 0.2);
+  animation: dialogIn 0.2s cubic-bezier(0.2, 0, 0, 1);
+}
+
+@keyframes dialogIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.confirmIcon {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 16px;
+}
+
+.confirmIcon svg {
+  width: 18px;
+  height: 18px;
+}
+
+.confirmTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.confirmDesc {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin-bottom: 20px;
+}
+
+.confirmActions {
+  display: flex;
+  gap: 10px;
+}
+
+.confirmCancelBtn {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+  transition: background-color 0.12s ease;
+}
+
+.confirmCancelBtn:hover:not(:disabled) {
+  background-color: var(--bg-button-hover);
+}
+
+.confirmConfirmBtn {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  background-color: #ef4444;
+  color: white;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.12s ease, transform 0.1s ease;
+}
+
+.confirmConfirmBtn:hover:not(:disabled) {
+  background-color: #dc2626;
+}
+
+.confirmConfirmBtn:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.confirmCancelBtn:disabled,
+.confirmConfirmBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .inner {
+    padding: 32px 16px 100px;
+  }
+
+  .title {
+    font-size: 22px;
+  }
+
+  .selectionBar {
+    flex-wrap: wrap;
+  }
+}

--- a/src/components/SharedView/index.js
+++ b/src/components/SharedView/index.js
@@ -1,0 +1,1 @@
+export { default } from './SharedView';

--- a/src/hooks/useSharedChats.js
+++ b/src/hooks/useSharedChats.js
@@ -1,0 +1,105 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { listMyShares, revokeConversationShare } from '../services/api';
+
+/**
+ * Manages the authenticated user's active share links — the single source of
+ * truth for the dedicated /shared page, the Conversations "Shared" tab, and
+ * the Settings > Data & privacy stub.
+ *
+ * `enabled` lets callers defer the network request until the surface that
+ * needs the data is actually visible (e.g. only fetch when the Conversations
+ * "Shared" tab is opened).
+ */
+export default function useSharedChats({ enabled = true } = {}) {
+  const [shares, setShares] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const abortRef = useRef(null);
+
+  const load = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listMyShares();
+      if (controller.signal.aborted) return;
+      setShares(Array.isArray(data?.shares) ? data.shares : []);
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      setShares((current) => current ?? []);
+      setError(err?.userMessage || err?.message || 'Failed to load shared chats');
+    } finally {
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    load();
+    return () => abortRef.current?.abort();
+  }, [enabled, load]);
+
+  const unshare = useCallback(async (conversationId) => {
+    if (!conversationId) {
+      return { ok: false, error: 'Missing conversation id' };
+    }
+    let snapshot;
+    setShares((current) => {
+      snapshot = current;
+      return (current || []).filter((s) => s.conversationId !== conversationId);
+    });
+    try {
+      await revokeConversationShare(conversationId);
+      return { ok: true };
+    } catch (err) {
+      setShares(snapshot);
+      return {
+        ok: false,
+        error: err?.userMessage || err?.message || 'Could not unshare conversation',
+      };
+    }
+  }, []);
+
+  const unshareMany = useCallback(async (conversationIds) => {
+    const ids = (conversationIds || []).filter(Boolean);
+    if (ids.length === 0) return { ok: true, failures: [] };
+    let snapshot;
+    const idSet = new Set(ids);
+    setShares((current) => {
+      snapshot = current;
+      return (current || []).filter((s) => !idSet.has(s.conversationId));
+    });
+    const failures = [];
+    await Promise.all(
+      ids.map((id) =>
+        revokeConversationShare(id).catch(() => {
+          failures.push(id);
+        })
+      )
+    );
+    if (failures.length > 0) {
+      const failedSet = new Set(failures);
+      const restored = (snapshot || []).filter((s) => failedSet.has(s.conversationId));
+      setShares((current) => {
+        const seen = new Set((current || []).map((s) => s.shareToken));
+        const merged = [...(current || [])];
+        for (const item of restored) {
+          if (!seen.has(item.shareToken)) merged.push(item);
+        }
+        return merged;
+      });
+    }
+    return { ok: failures.length === 0, failures };
+  }, []);
+
+  return {
+    shares,
+    loading,
+    error,
+    refetch: load,
+    unshare,
+    unshareMany,
+  };
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -11,6 +11,7 @@ import SettingsView from './components/SettingsView';
 import PricingView from './components/PricingView/PricingView';
 import SubscriptionView from './components/SubscriptionView/SubscriptionView';
 import SharedConversationView from './components/SharedConversationView';
+import SharedView from './components/SharedView';
 import RouteErrorBoundary from './components/ErrorBoundary/RouteErrorBoundary';
 import NotFound from './components/ErrorBoundary/NotFound';
 import RouteShell from './components/RouteShell/RouteShell';
@@ -143,6 +144,14 @@ const router = createBrowserRouter([
         element: (
           <RouteShell feature="chat" seo={{ title: 'Chat', noindex: true }}>
             <ConversationRoute />
+          </RouteShell>
+        ),
+      },
+      {
+        path: 'shared',
+        element: (
+          <RouteShell feature="shared" seo={{ title: 'Shared chats', noindex: true }}>
+            <SharedView />
           </RouteShell>
         ),
       },


### PR DESCRIPTION
## Summary

The Shared chats list previously lived inline inside Settings > Data & privacy, where it would grow unbounded as users accumulated shares. This moves shared-link management to its own page, modelled on how Notion / Linear / Figma treat "shared" as first-class content rather than a settings list.

- **New `/shared` page** — the source of truth. Search, sort (newest / oldest / most viewed), bulk select & unshare, time-grouped list, per-row 3-dot menu (open public link, copy link, unshare), polished loading / empty / error states.
- **Conversations "Shared" tab** — lazy-loaded preview alongside All / Starred / Archived / Recently deleted, with a tab badge for live count and a "Manage on Shared chats page" link to the full page.
- **Settings > Data & privacy stub** — replaces the inline list with a compact count summary that links to `/shared`. Keeps the panel from ever growing too tall.
- **`useSharedChats` hook** — single source of fetch + optimistic unshare / unshareMany so all three surfaces read identical data and update each other coherently.

## Test plan

- [ ] `/shared` renders with the user's existing shares; sort, search, and bulk unshare all behave correctly
- [ ] Conversations > Shared tab shows the lazy-loaded list; clicking a row opens the conversation; "Manage on Shared chats page" navigates to `/shared`
- [ ] Settings > Data & privacy shows the count stub; "Manage" navigates to `/shared`
- [ ] Unshare flows succeed (optimistic update) and rollback gracefully on backend failure
- [ ] Unauthenticated visitors hit the guest gate on `/shared`
- [ ] No regressions on Conversations All / Starred / Archived / Recently deleted tabs

https://claude.ai/code/session_01UGE7vM4qQHEXmHXxnTNSNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGE7vM4qQHEXmHXxnTNSNQ)_