### PR TITLE
Fix Projects page crash and stuck error fallback on navigation

### DIFF
--- a/src/components/ErrorBoundary/FeatureErrorBoundary.jsx
+++ b/src/components/ErrorBoundary/FeatureErrorBoundary.jsx
@@ -8,17 +8,37 @@ import ErrorFallback from './ErrorFallback';
  * re-renders children after a retry so sibling state (auth, theme) is
  * preserved.
  *
+ * The `resetKey` prop lets the caller clear the error automatically when
+ * something external changes (e.g. route navigation). Without it a caught
+ * error would persist across navigations, leaving the fallback stuck on
+ * unrelated pages.
+ *
  * @param {object} props
  * @param {string} props.feature - Short label used in log lines (e.g. "chat").
  * @param {React.ReactNode} props.children
  * @param {string} [props.title]
  * @param {string} [props.description]
+ * @param {string} [props.resetKey] - Changing this value clears the error.
  */
 export default class FeatureErrorBoundary extends React.Component {
-  state = { error: null, requestId: null, retryKey: 0 };
+  state = { error: null, requestId: null, retryKey: 0, lastResetKey: undefined };
 
   static getDerivedStateFromError(error) {
     return { error, requestId: generateRequestId() };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (state.lastResetKey === undefined) {
+      return { lastResetKey: props.resetKey };
+    }
+    if (props.resetKey !== state.lastResetKey) {
+      return {
+        error: null,
+        requestId: null,
+        lastResetKey: props.resetKey,
+      };
+    }
+    return null;
   }
 
   componentDidCatch(error, info) {

--- a/src/components/ProjectsView/ProjectsView.jsx
+++ b/src/components/ProjectsView/ProjectsView.jsx
@@ -316,384 +316,434 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
       : instructionsText;
 
   return (
-    <div className={styles.workspacePage}>
-      {/* Back nav */}
-      <div className={styles.workspaceTopBar}>
-        <button className={styles.detailBack} onClick={onBack}>
-          <ChevronLeftIcon />
-          <span>All projects</span>
-        </button>
-      </div>
+    <>
+      <div className={styles.workspacePage}>
+        {/* Back nav */}
+        <div className={styles.workspaceTopBar}>
+          <button className={styles.detailBack} onClick={onBack}>
+            <ChevronLeftIcon />
+            <span>All projects</span>
+          </button>
+        </div>
 
-      <div className={styles.workspaceLayout}>
-        {/* ── Main Column ── */}
-        <div className={styles.workspaceMain}>
-          {/* Project header */}
-          <div className={styles.wsHeader}>
-            <div className={styles.wsHeaderTop}>
-              <div className={styles.wsHeaderIcon}>
-                <ProjectsIcon />
-              </div>
-              <div className={styles.wsHeaderActions} ref={moreRef}>
-                <button
-                  className={styles.wsHeaderActionBtn}
-                  onClick={() => onToggleStar(project)}
-                  title={project.is_starred ? 'Unstar' : 'Star'}
-                >
-                  <StarIcon filled={project.is_starred} />
-                </button>
-                <button
-                  className={styles.wsHeaderActionBtn}
-                  onClick={() => setShowMore(!showMore)}
-                  title="More options"
-                >
-                  <MoreVerticalIcon />
-                </button>
+        <div className={styles.workspaceLayout}>
+          {/* ── Main Column ── */}
+          <div className={styles.workspaceMain}>
+            {/* Project header */}
+            <div className={styles.wsHeader}>
+              <div className={styles.wsHeaderTop}>
+                <div className={styles.wsHeaderIcon}>
+                  <ProjectsIcon />
+                </div>
+                <div className={styles.wsHeaderActions} ref={moreRef}>
+                  <button
+                    className={styles.wsHeaderActionBtn}
+                    onClick={() => onToggleStar(project)}
+                    title={project.is_starred ? 'Unstar' : 'Star'}
+                  >
+                    <StarIcon filled={project.is_starred} />
+                  </button>
+                  <button
+                    className={styles.wsHeaderActionBtn}
+                    onClick={() => setShowMore(!showMore)}
+                    title="More options"
+                  >
+                    <MoreVerticalIcon />
+                  </button>
 
-                {showMore && (
-                  <div className={styles.wsMoreDropdown}>
-                    <button
-                      className={styles.cardDropdownItem}
-                      onClick={() => {
-                        onEdit(project);
-                        setShowMore(false);
-                      }}
-                    >
-                      <EditIcon />
-                      <span>Edit details</span>
-                    </button>
-                    <button
-                      className={styles.cardDropdownItem}
-                      onClick={() => {
-                        onToggleArchive(project);
-                        setShowMore(false);
-                      }}
-                    >
-                      <ArchiveIcon />
-                      <span>{project.is_archived ? 'Unarchive' : 'Archive'}</span>
-                    </button>
-                    <div className={styles.cardDropdownDivider} />
-                    <button
-                      className={`${styles.cardDropdownItem} ${styles.cardDropdownItemDanger}`}
-                      onClick={() => {
-                        onDelete(project);
-                        setShowMore(false);
-                      }}
-                    >
-                      <TrashIcon />
-                      <span>Delete</span>
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            <h1 className={styles.wsTitle}>{project.name}</h1>
-
-            {descriptionText && <p className={styles.wsDescription}>{descriptionText}</p>}
-          </div>
-
-          {/* Chat input */}
-          <form className={styles.wsChatBox} onSubmit={handleSendMessage}>
-            <div className={styles.wsChatInputWrap}>
-              {attachedFiles.length > 0 && (
-                <div className={styles.wsAttachedFiles}>
-                  {attachedFiles.map((file, i) => (
-                    <div key={i} className={styles.wsAttachedFile}>
-                      <FileTextIcon />
-                      <span>{file.name}</span>
+                  {showMore && (
+                    <div className={styles.wsMoreDropdown}>
                       <button
-                        type="button"
-                        className={styles.wsAttachedFileRemove}
-                        onClick={() => setAttachedFiles((prev) => prev.filter((_, j) => j !== i))}
-                        aria-label="Remove file"
+                        className={styles.cardDropdownItem}
+                        onClick={() => {
+                          onEdit(project);
+                          setShowMore(false);
+                        }}
                       >
-                        <CloseIcon />
+                        <EditIcon />
+                        <span>Edit details</span>
+                      </button>
+                      <button
+                        className={styles.cardDropdownItem}
+                        onClick={() => {
+                          onToggleArchive(project);
+                          setShowMore(false);
+                        }}
+                      >
+                        <ArchiveIcon />
+                        <span>{project.is_archived ? 'Unarchive' : 'Archive'}</span>
+                      </button>
+                      <div className={styles.cardDropdownDivider} />
+                      <button
+                        className={`${styles.cardDropdownItem} ${styles.cardDropdownItemDanger}`}
+                        onClick={() => {
+                          onDelete(project);
+                          setShowMore(false);
+                        }}
+                      >
+                        <TrashIcon />
+                        <span>Delete</span>
                       </button>
                     </div>
-                  ))}
+                  )}
                 </div>
-              )}
-              <MarkdownTextarea
-                ref={textareaRef}
-                className={styles.wsChatInput}
-                value={chatInput}
-                onChange={(e) => setChatInput(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder={`Ask anything about ${project.name}...`}
-                rows={1}
-                aria-label={`Project ${project.name} input`}
-              />
-              <div className={styles.wsChatActions}>
-                <div className={styles.wsChatLeft}>
-                  <div className={styles.wsPlusWrap} ref={plusMenuRef}>
-                    <button
-                      type="button"
-                      className={`${styles.wsPlusBtn} ${
-                        showPlusMenu ? styles.wsPlusBtnActive : ''
-                      }`}
-                      onClick={() => setShowPlusMenu(!showPlusMenu)}
-                      aria-label="Add content"
-                    >
-                      <PlusIcon />
-                    </button>
-                    {showPlusMenu && (
-                      <div className={styles.wsPlusDropdown}>
+              </div>
+
+              <h1 className={styles.wsTitle}>{project.name}</h1>
+
+              {descriptionText && <p className={styles.wsDescription}>{descriptionText}</p>}
+            </div>
+
+            {/* Chat input */}
+            <form className={styles.wsChatBox} onSubmit={handleSendMessage}>
+              <div className={styles.wsChatInputWrap}>
+                {attachedFiles.length > 0 && (
+                  <div className={styles.wsAttachedFiles}>
+                    {attachedFiles.map((file, i) => (
+                      <div key={i} className={styles.wsAttachedFile}>
+                        <FileTextIcon />
+                        <span>{file.name}</span>
                         <button
                           type="button"
-                          className={styles.wsPlusDropdownItem}
-                          onClick={() => {
-                            fileInputRef.current?.click();
-                            setShowPlusMenu(false);
-                          }}
+                          className={styles.wsAttachedFileRemove}
+                          onClick={() => setAttachedFiles((prev) => prev.filter((_, j) => j !== i))}
+                          aria-label="Remove file"
                         >
-                          <FilePlusIcon />
-                          <span>Upload files or images</span>
-                        </button>
-                        <button
-                          type="button"
-                          className={styles.wsPlusDropdownItem}
-                          onClick={() => setShowPlusMenu(false)}
-                        >
-                          <CloudIcon />
-                          <span>Add files from cloud</span>
-                        </button>
-                        <button
-                          type="button"
-                          className={styles.wsPlusDropdownItem}
-                          onClick={() => setShowPlusMenu(false)}
-                        >
-                          <CameraIcon />
-                          <span>Take a screenshot</span>
-                        </button>
-                        <button
-                          type="button"
-                          className={styles.wsPlusDropdownItem}
-                          onClick={() => setShowPlusMenu(false)}
-                        >
-                          <GlobeIcon />
-                          <span>Web Search</span>
-                        </button>
-                        <button
-                          type="button"
-                          className={styles.wsPlusDropdownItem}
-                          onClick={() => setShowPlusMenu(false)}
-                        >
-                          <BookIcon />
-                          <span>Research</span>
+                          <CloseIcon />
                         </button>
                       </div>
-                    )}
+                    ))}
                   </div>
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    multiple
-                    style={{ display: 'none' }}
-                    onChange={(e) => {
-                      const files = Array.from(e.target.files || []);
-                      if (files.length) setAttachedFiles((prev) => [...prev, ...files]);
-                      e.target.value = '';
-                    }}
-                  />
-                  <ModalityBar compact />
-                </div>
-                <div className={styles.wsChatRight}>
-                  <ModelSelector />
-                  <button
-                    type="submit"
-                    className={`${styles.wsChatSend} ${
-                      chatInput.trim() ? styles.wsChatSendActive : ''
-                    }`}
-                    disabled={!chatInput.trim()}
-                    aria-label="Send message"
-                  >
-                    <SendIcon />
-                  </button>
-                </div>
-              </div>
-            </div>
-          </form>
-
-          {/* Conversations list */}
-          <div className={styles.wsConversations}>
-            <div className={styles.wsConvHeader}>
-              <span>Conversations</span>
-              <span className={styles.wsConvCount}>{conversations.length}</span>
-            </div>
-
-            {convsLoading ? (
-              <div className={styles.wsConvLoading}>
-                <div className={styles.wsConvSkeleton} />
-                <div className={styles.wsConvSkeleton} />
-                <div className={styles.wsConvSkeleton} />
-              </div>
-            ) : conversations.length > 0 ? (
-              <div className={styles.wsConvList}>
-                {conversations.map((conv) => (
-                  <div
-                    key={conv.id}
-                    className={styles.wsConvItem}
-                    onClick={() => handleConvClick(conv)}
-                  >
-                    <div className={styles.wsConvItemBody}>
-                      <span className={styles.wsConvItemTitle}>{conv.title || 'Untitled'}</span>
-                      <span className={styles.wsConvItemTime}>
-                        Last message {formatRelativeTime(conv.updated_at || conv.created_at)}
-                      </span>
-                    </div>
-                    <div
-                      className={styles.wsConvItemActions}
-                      ref={convMenuOpen === conv.id ? convMenuRef : null}
-                    >
+                )}
+                <MarkdownTextarea
+                  ref={textareaRef}
+                  className={styles.wsChatInput}
+                  value={chatInput}
+                  onChange={(e) => setChatInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder={`Ask anything about ${project.name}...`}
+                  rows={1}
+                  aria-label={`Project ${project.name} input`}
+                />
+                <div className={styles.wsChatActions}>
+                  <div className={styles.wsChatLeft}>
+                    <div className={styles.wsPlusWrap} ref={plusMenuRef}>
                       <button
-                        className={`${styles.wsConvItemMenuBtn} ${
-                          convMenuOpen === conv.id ? styles.wsConvItemMenuBtnActive : ''
+                        type="button"
+                        className={`${styles.wsPlusBtn} ${
+                          showPlusMenu ? styles.wsPlusBtnActive : ''
                         }`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setConvMenuOpen(convMenuOpen === conv.id ? null : conv.id);
-                        }}
-                        aria-label="Conversation options"
+                        onClick={() => setShowPlusMenu(!showPlusMenu)}
+                        aria-label="Add content"
                       >
-                        <MoreVerticalIcon />
+                        <PlusIcon />
                       </button>
-                      {convMenuOpen === conv.id && (
-                        <div className={styles.wsConvItemDropdown}>
+                      {showPlusMenu && (
+                        <div className={styles.wsPlusDropdown}>
                           <button
-                            className={styles.cardDropdownItem}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleConvClick(conv);
-                              setConvMenuOpen(null);
+                            type="button"
+                            className={styles.wsPlusDropdownItem}
+                            onClick={() => {
+                              fileInputRef.current?.click();
+                              setShowPlusMenu(false);
                             }}
                           >
-                            <ChatIcon />
-                            <span>Open chat</span>
-                          </button>
-                          <div className={styles.cardDropdownDivider} />
-                          <button
-                            className={`${styles.cardDropdownItem} ${styles.cardDropdownItemDanger}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setConvMenuOpen(null);
-                              updateConversation(conv.id, { project_id: null }).then(() => {
-                                setConversations((prev) => prev.filter((c) => c.id !== conv.id));
-                              });
-                            }}
-                          >
-                            <CloseIcon />
-                            <span>Remove from project</span>
+                            <FilePlusIcon />
+                            <span>Upload files or images</span>
                           </button>
                           <button
-                            className={`${styles.cardDropdownItem} ${styles.cardDropdownItemDanger}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setConvMenuOpen(null);
-                              setConvDeleteConfirm(conv);
-                            }}
+                            type="button"
+                            className={styles.wsPlusDropdownItem}
+                            onClick={() => setShowPlusMenu(false)}
                           >
-                            <TrashIcon />
-                            <span>Delete</span>
+                            <CloudIcon />
+                            <span>Add files from cloud</span>
+                          </button>
+                          <button
+                            type="button"
+                            className={styles.wsPlusDropdownItem}
+                            onClick={() => setShowPlusMenu(false)}
+                          >
+                            <CameraIcon />
+                            <span>Take a screenshot</span>
+                          </button>
+                          <button
+                            type="button"
+                            className={styles.wsPlusDropdownItem}
+                            onClick={() => setShowPlusMenu(false)}
+                          >
+                            <GlobeIcon />
+                            <span>Web Search</span>
+                          </button>
+                          <button
+                            type="button"
+                            className={styles.wsPlusDropdownItem}
+                            onClick={() => setShowPlusMenu(false)}
+                          >
+                            <BookIcon />
+                            <span>Research</span>
                           </button>
                         </div>
                       )}
                     </div>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      multiple
+                      style={{ display: 'none' }}
+                      onChange={(e) => {
+                        const files = Array.from(e.target.files || []);
+                        if (files.length) setAttachedFiles((prev) => [...prev, ...files]);
+                        e.target.value = '';
+                      }}
+                    />
+                    <ModalityBar compact />
                   </div>
-                ))}
+                  <div className={styles.wsChatRight}>
+                    <ModelSelector />
+                    <button
+                      type="submit"
+                      className={`${styles.wsChatSend} ${
+                        chatInput.trim() ? styles.wsChatSendActive : ''
+                      }`}
+                      disabled={!chatInput.trim()}
+                      aria-label="Send message"
+                    >
+                      <SendIcon />
+                    </button>
+                  </div>
+                </div>
               </div>
-            ) : (
-              <div className={styles.wsConvEmpty}>
-                <p>No conversations yet. Use the chat above to start one.</p>
-              </div>
-            )}
-          </div>
-        </div>
+            </form>
 
-        {/* ── Side Panel ── */}
-        <div className={styles.workspaceSide}>
-          {/* Instructions card */}
-          <div className={styles.wsSideCard}>
-            <div className={styles.wsSideCardHeader}>
-              <div className={styles.wsSideCardTitle}>
-                <FileTextIcon />
-                <span>Instructions</span>
+            {/* Conversations list */}
+            <div className={styles.wsConversations}>
+              <div className={styles.wsConvHeader}>
+                <span>Conversations</span>
+                <span className={styles.wsConvCount}>{conversations.length}</span>
               </div>
-              <button
-                className={styles.wsSideCardAction}
-                onClick={() => onEdit(project)}
-                title="Edit instructions"
-              >
-                <EditIcon />
-              </button>
+
+              {convsLoading ? (
+                <div className={styles.wsConvLoading}>
+                  <div className={styles.wsConvSkeleton} />
+                  <div className={styles.wsConvSkeleton} />
+                  <div className={styles.wsConvSkeleton} />
+                </div>
+              ) : conversations.length > 0 ? (
+                <div className={styles.wsConvList}>
+                  {conversations.map((conv) => (
+                    <div
+                      key={conv.id}
+                      className={styles.wsConvItem}
+                      onClick={() => handleConvClick(conv)}
+                    >
+                      <div className={styles.wsConvItemBody}>
+                        <span className={styles.wsConvItemTitle}>{conv.title || 'Untitled'}</span>
+                        <span className={styles.wsConvItemTime}>
+                          Last message {formatRelativeTime(conv.updated_at || conv.created_at)}
+                        </span>
+                      </div>
+                      <div
+                        className={styles.wsConvItemActions}
+                        ref={convMenuOpen === conv.id ? convMenuRef : null}
+                      >
+                        <button
+                          className={`${styles.wsConvItemMenuBtn} ${
+                            convMenuOpen === conv.id ? styles.wsConvItemMenuBtnActive : ''
+                          }`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setConvMenuOpen(convMenuOpen === conv.id ? null : conv.id);
+                          }}
+                          aria-label="Conversation options"
+                        >
+                          <MoreVerticalIcon />
+                        </button>
+                        {convMenuOpen === conv.id && (
+                          <div className={styles.wsConvItemDropdown}>
+                            <button
+                              className={styles.cardDropdownItem}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleConvClick(conv);
+                                setConvMenuOpen(null);
+                              }}
+                            >
+                              <ChatIcon />
+                              <span>Open chat</span>
+                            </button>
+                            <div className={styles.cardDropdownDivider} />
+                            <button
+                              className={`${styles.cardDropdownItem} ${styles.cardDropdownItemDanger}`}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setConvMenuOpen(null);
+                                updateConversation(conv.id, { project_id: null }).then(() => {
+                                  setConversations((prev) => prev.filter((c) => c.id !== conv.id));
+                                });
+                              }}
+                            >
+                              <CloseIcon />
+                              <span>Remove from project</span>
+                            </button>
+                            <button
+                              className={`${styles.cardDropdownItem} ${styles.cardDropdownItemDanger}`}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setConvMenuOpen(null);
+                                setConvDeleteConfirm(conv);
+                              }}
+                            >
+                              <TrashIcon />
+                              <span>Delete</span>
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className={styles.wsConvEmpty}>
+                  <p>No conversations yet. Use the chat above to start one.</p>
+                </div>
+              )}
             </div>
-            {instructionsText ? (
-              <div className={styles.wsSideCardBody}>
-                <p className={styles.wsInstructionsText}>{instructionsPreview}</p>
-                {instructionsText.length > 120 && (
-                  <button
-                    className={styles.wsShowMoreBtn}
-                    onClick={() => setInstructionsExpanded(!instructionsExpanded)}
-                  >
-                    {instructionsExpanded ? 'Show less' : 'Show more'}
-                  </button>
-                )}
-              </div>
-            ) : (
-              <div className={styles.wsSideCardEmpty}>
-                <p>Add instructions to tailor responses for this project.</p>
-                <button className={styles.wsSideCardEmptyAction} onClick={() => onEdit(project)}>
-                  <PlusIcon />
-                  <span>Add instructions</span>
+          </div>
+
+          {/* ── Side Panel ── */}
+          <div className={styles.workspaceSide}>
+            {/* Instructions card */}
+            <div className={styles.wsSideCard}>
+              <div className={styles.wsSideCardHeader}>
+                <div className={styles.wsSideCardTitle}>
+                  <FileTextIcon />
+                  <span>Instructions</span>
+                </div>
+                <button
+                  className={styles.wsSideCardAction}
+                  onClick={() => onEdit(project)}
+                  title="Edit instructions"
+                >
+                  <EditIcon />
                 </button>
               </div>
-            )}
-          </div>
-
-          {/* Project info card */}
-          <div className={styles.wsSideCard}>
-            <div className={styles.wsSideCardHeader}>
-              <div className={styles.wsSideCardTitle}>
-                <ProjectsIcon />
-                <span>Project info</span>
-              </div>
+              {instructionsText ? (
+                <div className={styles.wsSideCardBody}>
+                  <p className={styles.wsInstructionsText}>{instructionsPreview}</p>
+                  {instructionsText.length > 120 && (
+                    <button
+                      className={styles.wsShowMoreBtn}
+                      onClick={() => setInstructionsExpanded(!instructionsExpanded)}
+                    >
+                      {instructionsExpanded ? 'Show less' : 'Show more'}
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <div className={styles.wsSideCardEmpty}>
+                  <p>Add instructions to tailor responses for this project.</p>
+                  <button className={styles.wsSideCardEmptyAction} onClick={() => onEdit(project)}>
+                    <PlusIcon />
+                    <span>Add instructions</span>
+                  </button>
+                </div>
+              )}
             </div>
-            <div className={styles.wsSideInfoList}>
-              <div className={styles.wsSideInfoRow}>
-                <span className={styles.wsSideInfoLabel}>Created</span>
-                <span className={styles.wsSideInfoValue}>{formatFullDate(project.created_at)}</span>
+
+            {/* Project info card */}
+            <div className={styles.wsSideCard}>
+              <div className={styles.wsSideCardHeader}>
+                <div className={styles.wsSideCardTitle}>
+                  <ProjectsIcon />
+                  <span>Project info</span>
+                </div>
               </div>
-              {project.updated_at && project.updated_at !== project.created_at && (
+              <div className={styles.wsSideInfoList}>
                 <div className={styles.wsSideInfoRow}>
-                  <span className={styles.wsSideInfoLabel}>Updated</span>
+                  <span className={styles.wsSideInfoLabel}>Created</span>
                   <span className={styles.wsSideInfoValue}>
-                    {formatRelativeTime(project.updated_at)}
+                    {formatFullDate(project.created_at)}
                   </span>
                 </div>
-              )}
-              <div className={styles.wsSideInfoRow}>
-                <span className={styles.wsSideInfoLabel}>Conversations</span>
-                <span className={styles.wsSideInfoValue}>{conversations.length}</span>
+                {project.updated_at && project.updated_at !== project.created_at && (
+                  <div className={styles.wsSideInfoRow}>
+                    <span className={styles.wsSideInfoLabel}>Updated</span>
+                    <span className={styles.wsSideInfoValue}>
+                      {formatRelativeTime(project.updated_at)}
+                    </span>
+                  </div>
+                )}
+                <div className={styles.wsSideInfoRow}>
+                  <span className={styles.wsSideInfoLabel}>Conversations</span>
+                  <span className={styles.wsSideInfoValue}>{conversations.length}</span>
+                </div>
+                {project.is_starred && (
+                  <div className={styles.wsSideInfoRow}>
+                    <span className={styles.wsSideInfoLabel}>Starred</span>
+                    <span className={styles.wsSideInfoStarred}>
+                      <StarIcon filled />
+                    </span>
+                  </div>
+                )}
+                {project.is_archived && (
+                  <div className={styles.wsSideInfoRow}>
+                    <span className={styles.wsSideInfoLabel}>Status</span>
+                    <span className={styles.wsSideInfoBadge}>Archived</span>
+                  </div>
+                )}
               </div>
-              {project.is_starred && (
-                <div className={styles.wsSideInfoRow}>
-                  <span className={styles.wsSideInfoLabel}>Starred</span>
-                  <span className={styles.wsSideInfoStarred}>
-                    <StarIcon filled />
-                  </span>
-                </div>
-              )}
-              {project.is_archived && (
-                <div className={styles.wsSideInfoRow}>
-                  <span className={styles.wsSideInfoLabel}>Status</span>
-                  <span className={styles.wsSideInfoBadge}>Archived</span>
-                </div>
-              )}
             </div>
           </div>
         </div>
       </div>
-    </div>
+
+      {convDeleteConfirm && (
+        <div className={styles.modalOverlay} onClick={() => setConvDeleteConfirm(null)}>
+          <div className={styles.confirmDialog} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.confirmIcon}>
+              <TrashIcon />
+            </div>
+            <h3 className={styles.confirmTitle}>
+              Delete &ldquo;{convDeleteConfirm.title || 'this conversation'}&rdquo;?
+            </h3>
+            <p className={styles.confirmDesc}>
+              This will permanently delete the conversation and all its messages. This action cannot
+              be undone.
+            </p>
+            <div className={styles.confirmActions}>
+              <button
+                className={styles.confirmCancelBtn}
+                onClick={() => setConvDeleteConfirm(null)}
+              >
+                Cancel
+              </button>
+              <button
+                className={styles.confirmDeleteBtn}
+                onClick={async () => {
+                  const convId = convDeleteConfirm.id;
+                  setConvDeleteConfirm(null);
+                  setConversations((prev) => prev.filter((c) => c.id !== convId));
+                  const ok = await deleteConversation(convId);
+                  if (!ok) {
+                    try {
+                      const data = await fetchConversations(100, 0, {
+                        projectId: project.id,
+                      });
+                      setConversations(data.conversations || []);
+                    } catch {
+                      /* hook already toasted */
+                    }
+                  }
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 
@@ -1322,52 +1372,6 @@ export default function ProjectsView() {
               </button>
               <button className={styles.confirmDeleteBtn} onClick={handleDelete}>
                 Delete{deleteOption === 'everything' ? ' everything' : ' project'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {convDeleteConfirm && (
-        <div className={styles.modalOverlay} onClick={() => setConvDeleteConfirm(null)}>
-          <div className={styles.confirmDialog} onClick={(e) => e.stopPropagation()}>
-            <div className={styles.confirmIcon}>
-              <TrashIcon />
-            </div>
-            <h3 className={styles.confirmTitle}>
-              Delete &ldquo;{convDeleteConfirm.title || 'this conversation'}&rdquo;?
-            </h3>
-            <p className={styles.confirmDesc}>
-              This will permanently delete the conversation and all its messages. This action cannot
-              be undone.
-            </p>
-            <div className={styles.confirmActions}>
-              <button
-                className={styles.confirmCancelBtn}
-                onClick={() => setConvDeleteConfirm(null)}
-              >
-                Cancel
-              </button>
-              <button
-                className={styles.confirmDeleteBtn}
-                onClick={async () => {
-                  const convId = convDeleteConfirm.id;
-                  setConvDeleteConfirm(null);
-                  setConversations((prev) => prev.filter((c) => c.id !== convId));
-                  const ok = await deleteConversation(convId);
-                  if (!ok) {
-                    try {
-                      const data = await fetchConversations(100, 0, {
-                        projectId: project.id,
-                      });
-                      setConversations(data.conversations || []);
-                    } catch {
-                      /* hook already toasted */
-                    }
-                  }
-                }}
-              >
-                Delete
               </button>
             </div>
           </div>

--- a/src/components/RouteShell/RouteShell.jsx
+++ b/src/components/RouteShell/RouteShell.jsx
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router-dom';
 import FeatureErrorBoundary from '../ErrorBoundary/FeatureErrorBoundary';
 import SEO from '../SEO/SEO';
 
@@ -7,14 +8,18 @@ import SEO from '../SEO/SEO';
  * one place means individual views don't need to know about either
  * concern — they remain focused on their own rendering.
  *
+ * `pathname` is passed as the boundary's reset key so a caught error on one
+ * route doesn't leak into the next — navigating away clears the fallback.
+ *
  * @param {object} props
  * @param {string} props.feature - Short label for logs (e.g. "chat").
  * @param {object} [props.seo] - Props forwarded to the SEO helper.
  * @param {React.ReactNode} props.children
  */
 export default function RouteShell({ feature, seo, children }) {
+  const { pathname } = useLocation();
   return (
-    <FeatureErrorBoundary feature={feature}>
+    <FeatureErrorBoundary feature={feature} resetKey={pathname}>
       {seo && <SEO {...seo} />}
       {children}
     </FeatureErrorBoundary>


### PR DESCRIPTION
## Summary

Two bugs explained the "Something went wrong" fallback the user saw on `/projects` and the fact that no other page would load afterwards.

**1. Projects view threw on every render.** The conversation-delete confirmation modal in `ProjectsView.jsx` referenced state (`convDeleteConfirm`, `setConvDeleteConfirm`, `setConversations`, `deleteConversation`, `project.id`) that's declared inside the nested `ProjectWorkspace` component — but the JSX itself lived in the outer `ProjectsView` body. As soon as the projects list rendered, JavaScript hit `ReferenceError: convDeleteConfirm is not defined`, the feature error boundary caught it, and the user saw the fallback. Fix: move the modal into `ProjectWorkspace` where the state actually lives, since that's the only place it can be triggered from.

**2. `FeatureErrorBoundary` stayed stuck across route changes.** Because every route's element is wrapped in `<RouteShell>` of the same type, React reused the same boundary instance when the user navigated. The boundary only cleared its `error` on the "Try again" button, never on prop changes, so the fallback persisted on every other page. Fix: thread `pathname` from `useLocation()` into a new `resetKey` prop on `FeatureErrorBoundary`. A `getDerivedStateFromProps` hook compares `resetKey` against the previous value and clears the error when the route changes — navigation now restores the page.

## Test plan
- [ ] Navigate to `/projects` while authenticated — the projects grid renders without the error fallback.
- [ ] Inside a project, open a conversation's menu → Delete → confirm. The conversation is removed without errors.
- [ ] Trigger an error in any feature route, then click a different sidebar item — the new page loads instead of the fallback persisting.
- [ ] Clicking "Try again" within a fallback still resets the boundary as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGYdLF1Rx4EzmQrqjifNdz)_