### PR TITLE
Move Send-with-Enter toggle to Personalization

### DIFF
--- a/src/components/SettingsView/SettingsView.jsx
+++ b/src/components/SettingsView/SettingsView.jsx
@@ -713,21 +713,6 @@ export default function SettingsView() {
                       ))}
                     </div>
                   </div>
-
-                  <div className={styles.fieldGroup}>
-                    <div className={styles.toggleRow}>
-                      <div className={styles.toggleInfo}>
-                        <span className={styles.toggleLabel}>Send message with Enter</span>
-                        <span className={styles.toggleDesc}>
-                          Use Enter to send messages. When off, use {modKey}+Enter instead.
-                        </span>
-                      </div>
-                      <ToggleSwitch
-                        value={settings.sendWithEnter}
-                        onChange={(v) => updateSetting('sendWithEnter', v)}
-                      />
-                    </div>
-                  </div>
                 </section>
               )}
 
@@ -805,6 +790,21 @@ export default function SettingsView() {
                       <span className={styles.fieldHint}>
                         {settings.customInstructions.length} / 2,000 characters
                       </span>
+                    </div>
+                  </div>
+
+                  <div className={styles.fieldGroup}>
+                    <div className={styles.toggleRow}>
+                      <div className={styles.toggleInfo}>
+                        <span className={styles.toggleLabel}>Send message with Enter</span>
+                        <span className={styles.toggleDesc}>
+                          Use Enter to send messages. When off, use {modKey}+Enter instead.
+                        </span>
+                      </div>
+                      <ToggleSwitch
+                        value={settings.sendWithEnter}
+                        onChange={(v) => updateSetting('sendWithEnter', v)}
+                      />
                     </div>
                   </div>
                 </section>


### PR DESCRIPTION
## Summary

The **Send message with Enter** toggle was sitting under Settings → Appearance, but it isn't a visual preference — it controls an interaction behavior. Moved it into Settings → Personalization, placed after the custom-instructions field so it sits alongside the other "how should Araviel work for me" controls.

## Test plan
- [ ] Open Settings → Appearance: the toggle is no longer there.
- [ ] Open Settings → Personalization: the toggle appears at the bottom of the section, copy and description unchanged.
- [ ] Toggling it still persists and changes Enter behavior in the chat input.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGYdLF1Rx4EzmQrqjifNdz)_