### PR TITLE
Drop the dark left-edge stripe on active sidebar items

### DIFF
--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -372,7 +372,6 @@
   background-color: var(--bg-active);
   color: var(--text-primary);
   font-weight: 600;
-  box-shadow: inset 3px 0 0 var(--text-primary);
 }
 
 .collapsed .nav {
@@ -399,7 +398,6 @@
 }
 
 .collapsed .navItem.active {
-  box-shadow: none;
   background-color: var(--bg-active);
 }
 


### PR DESCRIPTION
## Summary

The 3px dark stripe on the left edge of the active sidebar item was doing duplicate work — the background fill and bolder weight already mark the selection. Remove the `box-shadow: inset 3px 0 0 var(--text-primary)` on `.navItem.active` and the now-no-op `box-shadow: none` override in `.collapsed .navItem.active`.

## Test plan
- [ ] Active nav item shows the background + bolder weight, no left-edge stripe.
- [ ] Collapsed sidebar still highlights the active item.
- [ ] Hover and focus states unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGYdLF1Rx4EzmQrqjifNdz)_