### PR TITLE
Drop the dark left-edge stripe on active Settings nav items

### DIFF
--- a/src/components/SettingsView/SettingsView.module.css
+++ b/src/components/SettingsView/SettingsView.module.css
@@ -134,18 +134,6 @@
   font-weight: 600;
 }
 
-.navItemActive::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 3px;
-  height: 18px;
-  border-radius: 0 3px 3px 0;
-  background-color: var(--text-primary);
-}
-
 /* ── Content ── */
 
 .content {
@@ -1149,10 +1137,6 @@
     white-space: nowrap;
     padding: 8px 14px;
     font-size: 13px;
-  }
-
-  .navItemActive::before {
-    display: none;
   }
 
   .themeCards {


### PR DESCRIPTION
## Summary

Same change as #420 but for the Settings side nav. The `.navItemActive::before` pseudo-element rendered the 3px dark stripe on the left edge of the active section — redundant alongside the background fill and bolder weight. Remove the pseudo-element and the matching mobile `display: none` override that is no longer needed.

## Test plan
- [ ] Active Settings tab (e.g. Appearance) shows the background highlight and bolder weight, no left-edge stripe.
- [ ] Inactive tabs and hover state unchanged.
- [ ] Mobile / narrow viewports still render the nav correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGYdLF1Rx4EzmQrqjifNdz)_