### PR TITLE
Add ConversationTrail nav rail for jumping between prompts

### DIFF
--- a/src/components/MessageList/ConversationTrail.jsx
+++ b/src/components/MessageList/ConversationTrail.jsx
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import styles from './ConversationTrail.module.css';
+
+const MIN_MARKERS_TO_SHOW = 3;
+const ACTIVE_ANCHOR_RATIO = 0.32;
+const AUTO_HIDE_DELAY_MS = 1500;
+const EDGE_HOVER_ZONE_PX = 96;
+const FLASH_DURATION_MS = 1100;
+
+function formatTime(value) {
+  if (!value) return null;
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return null;
+  }
+}
+
+function buildPreview(content) {
+  if (!content || typeof content !== 'string') return '';
+  return content.replace(/\s+/g, ' ').trim();
+}
+
+export default function ConversationTrail({ messages, scrollContainerRef, hidden = false }) {
+  const userPrompts = useMemo(
+    () =>
+      messages
+        .map((msg, originalIndex) =>
+          msg.role === 'user'
+            ? {
+                id: msg.id ?? `idx-${originalIndex}`,
+                preview: buildPreview(msg.content),
+                createdAt: msg.createdAt,
+              }
+            : null
+        )
+        .filter(Boolean),
+    [messages]
+  );
+
+  const [markers, setMarkers] = useState([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+  const [visible, setVisible] = useState(false);
+
+  const hideTimeoutRef = useRef(null);
+  const rafRef = useRef(null);
+  const flashTimeoutRef = useRef(null);
+
+  const shouldRender = !hidden && userPrompts.length >= MIN_MARKERS_TO_SHOW;
+
+  const recomputeMarkers = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) {
+      setMarkers([]);
+      return;
+    }
+
+    const nodes = container.querySelectorAll('[data-trail-anchor="true"]');
+    const scrollableHeight = container.scrollHeight;
+    if (scrollableHeight <= 0 || nodes.length === 0) {
+      setMarkers([]);
+      return;
+    }
+
+    const next = [];
+    for (let i = 0; i < nodes.length; i += 1) {
+      const element = nodes[i];
+      const prompt = userPrompts[i];
+      if (!prompt) continue;
+      const offsetTop = element.offsetTop;
+      const ratio = Math.min(1, Math.max(0, offsetTop / scrollableHeight));
+      next.push({
+        id: prompt.id,
+        element,
+        offsetTop,
+        ratio,
+        preview: prompt.preview,
+        createdAt: prompt.createdAt,
+      });
+    }
+    setMarkers(next);
+  }, [scrollContainerRef, userPrompts]);
+
+  useEffect(() => {
+    if (!shouldRender) {
+      setMarkers([]);
+      return undefined;
+    }
+    const container = scrollContainerRef.current;
+    if (!container) return undefined;
+
+    recomputeMarkers();
+
+    const resizeObserver = new ResizeObserver(() => recomputeMarkers());
+    resizeObserver.observe(container);
+    const anchors = container.querySelectorAll('[data-trail-anchor="true"]');
+    anchors.forEach((node) => resizeObserver.observe(node));
+
+    return () => resizeObserver.disconnect();
+  }, [shouldRender, recomputeMarkers, scrollContainerRef]);
+
+  useEffect(() => {
+    if (!shouldRender || markers.length === 0) return undefined;
+    const container = scrollContainerRef.current;
+    if (!container) return undefined;
+
+    const updateActive = () => {
+      rafRef.current = null;
+      const anchor = container.scrollTop + container.clientHeight * ACTIVE_ANCHOR_RATIO;
+      let next = 0;
+      for (let i = 0; i < markers.length; i += 1) {
+        if (markers[i].offsetTop <= anchor) next = i;
+        else break;
+      }
+      setActiveIndex(next);
+    };
+
+    const handleScroll = () => {
+      if (rafRef.current != null) return;
+      rafRef.current = requestAnimationFrame(updateActive);
+    };
+
+    updateActive();
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      container.removeEventListener('scroll', handleScroll);
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [shouldRender, markers, scrollContainerRef]);
+
+  useEffect(() => {
+    if (!shouldRender) {
+      setVisible(false);
+      return undefined;
+    }
+    const container = scrollContainerRef.current;
+    if (!container) return undefined;
+
+    const reveal = () => {
+      setVisible(true);
+      if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = setTimeout(() => setVisible(false), AUTO_HIDE_DELAY_MS);
+    };
+
+    const handleMouseMove = (event) => {
+      const rect = container.getBoundingClientRect();
+      const distanceFromRight = rect.right - event.clientX;
+      if (distanceFromRight >= 0 && distanceFromRight <= EDGE_HOVER_ZONE_PX) {
+        reveal();
+      }
+    };
+
+    container.addEventListener('scroll', reveal, { passive: true });
+    container.addEventListener('mousemove', handleMouseMove);
+    return () => {
+      container.removeEventListener('scroll', reveal);
+      container.removeEventListener('mousemove', handleMouseMove);
+      if (hideTimeoutRef.current) {
+        clearTimeout(hideTimeoutRef.current);
+        hideTimeoutRef.current = null;
+      }
+    };
+  }, [shouldRender, scrollContainerRef]);
+
+  useEffect(
+    () => () => {
+      if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+    },
+    []
+  );
+
+  const handleJump = useCallback(
+    (index) => {
+      const marker = markers[index];
+      if (!marker || !marker.element) return;
+      marker.element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      marker.element.classList.add(styles.flash);
+      if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+      flashTimeoutRef.current = setTimeout(() => {
+        marker.element.classList.remove(styles.flash);
+        flashTimeoutRef.current = null;
+      }, FLASH_DURATION_MS);
+    },
+    [markers]
+  );
+
+  const handleMarkerEnter = useCallback((index) => {
+    setHoveredIndex(index);
+    setVisible(true);
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+  }, []);
+
+  const handleMarkerLeave = useCallback(() => {
+    setHoveredIndex(null);
+    if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
+    hideTimeoutRef.current = setTimeout(() => setVisible(false), AUTO_HIDE_DELAY_MS);
+  }, []);
+
+  if (!shouldRender || markers.length === 0) return null;
+
+  const progressPercent = markers.length <= 1 ? 0 : (markers[activeIndex]?.ratio ?? 0) * 100;
+
+  return (
+    <div className={styles.trailViewport} aria-hidden={!visible}>
+      <nav
+        className={`${styles.trail} ${visible ? styles.trailVisible : ''}`}
+        aria-label="Conversation navigation"
+      >
+        <div className={styles.rail}>
+          <div className={styles.railLine} />
+          <div className={styles.railProgress} style={{ '--progress': `${progressPercent}%` }} />
+          {markers.map((marker, index) => {
+            const isActive = index === activeIndex;
+            const time = formatTime(marker.createdAt);
+            return (
+              <button
+                key={marker.id}
+                type="button"
+                className={`${styles.marker} ${isActive ? styles.markerActive : ''}`}
+                style={{ top: `${marker.ratio * 100}%` }}
+                onClick={() => handleJump(index)}
+                onMouseEnter={() => handleMarkerEnter(index)}
+                onMouseLeave={handleMarkerLeave}
+                onFocus={() => handleMarkerEnter(index)}
+                onBlur={handleMarkerLeave}
+                aria-label={`Jump to prompt ${index + 1}${
+                  marker.preview ? `: ${marker.preview.slice(0, 60)}` : ''
+                }`}
+                aria-current={isActive ? 'true' : undefined}
+              >
+                <span className={styles.markerStroke} />
+                {hoveredIndex === index && marker.preview && (
+                  <div className={styles.tooltip} role="tooltip">
+                    <span className={styles.tooltipPreview}>{marker.preview}</span>
+                    {time && <span className={styles.tooltipTime}>{time}</span>}
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/src/components/MessageList/ConversationTrail.module.css
+++ b/src/components/MessageList/ConversationTrail.module.css
@@ -1,0 +1,180 @@
+.trailViewport {
+  position: sticky;
+  top: 0;
+  height: 0;
+  z-index: 8;
+  pointer-events: none;
+}
+
+.trail {
+  position: absolute;
+  top: 96px;
+  right: 18px;
+  height: calc(var(--app-height) - 192px);
+  width: 22px;
+  pointer-events: auto;
+  opacity: 0;
+  transform: translateX(6px);
+  transition: opacity 0.28s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.trailVisible {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.rail {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+.railLine {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  transform: translateX(-0.5px);
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    var(--border-color) 8%,
+    var(--border-color) 92%,
+    transparent 100%
+  );
+  border-radius: 1px;
+}
+
+.railProgress {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 1.5px;
+  height: var(--progress, 0%);
+  transform: translateX(-0.75px);
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    var(--text-secondary) 12%,
+    var(--text-primary) 100%
+  );
+  border-radius: 1px;
+  transition: height 0.32s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.marker {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 18px;
+  margin-top: -9px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-tap-highlight-color: transparent;
+  outline: none;
+}
+
+.markerStroke {
+  display: block;
+  width: 10px;
+  height: 2px;
+  border-radius: 2px;
+  background-color: var(--text-muted);
+  box-shadow: 0 1px 0 var(--emboss-highlight);
+  transition: width 0.22s cubic-bezier(0.16, 1, 0.3, 1), background-color 0.22s ease,
+    box-shadow 0.22s ease;
+  will-change: width, background-color;
+}
+
+.marker:hover .markerStroke {
+  width: 16px;
+  background-color: var(--text-secondary);
+}
+
+.markerActive .markerStroke {
+  width: 16px;
+  background-color: var(--text-primary);
+  box-shadow: 0 0 0 0.5px var(--bg-primary), 0 1px 0 var(--emboss-highlight);
+}
+
+.marker:focus-visible .markerStroke {
+  outline: 2px solid var(--text-secondary);
+  outline-offset: 3px;
+}
+
+.tooltip {
+  position: absolute;
+  right: 32px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 260px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background-color: var(--bg-input);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-lg);
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  animation: tooltipIn 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.tooltipPreview {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-primary);
+  font-weight: 450;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+
+.tooltipTime {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 450;
+  letter-spacing: 0.01em;
+}
+
+@keyframes tooltipIn {
+  from {
+    opacity: 0;
+    transform: translate(4px, -50%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(0, -50%);
+  }
+}
+
+.flash {
+  animation: trailFlash 1.1s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes trailFlash {
+  0% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+  20% {
+    box-shadow: 0 0 0 6px rgba(158, 146, 131, 0.18);
+  }
+  100% {
+    box-shadow: 0 0 0 6px transparent;
+  }
+}
+
+@media (max-width: 900px) {
+  .trail {
+    display: none;
+  }
+}

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -76,6 +76,7 @@ import { dedupeCitations } from '../../utils/dedupeCitations';
 import styles from './MessageList.module.css';
 import MarkdownTextarea from '../MarkdownTextarea/MarkdownTextarea';
 import { parseMarkdownTable } from './parseMarkdownTable';
+import ConversationTrail from './ConversationTrail';
 
 // Initialize mermaid with sensible defaults
 mermaid.initialize({
@@ -6333,7 +6334,7 @@ export default function MessageList({
           }
 
           return (
-            <div key={msg.id || index}>
+            <div key={msg.id || index} data-trail-anchor={msg.role === 'user' ? 'true' : undefined}>
               {/* Insert timeline before the streaming assistant message */}
               {isLast && timelineBeforeLastMsg && isProcessing && timelineStages && (
                 <div className={styles.timelineWrapper}>
@@ -6390,6 +6391,12 @@ export default function MessageList({
 
         <div ref={bottomRef} className={styles.scrollAnchor} />
       </div>
+
+      <ConversationTrail
+        messages={messages}
+        scrollContainerRef={containerRef}
+        hidden={!!codePanelState || !!sourcesPanelCitations || !!subConvPanelOwnerId}
+      />
 
       {/* Scroll-to-bottom floating button */}
       <div className={styles.scrollToBottomAnchor}>


### PR DESCRIPTION
## Summary

Adds a slim right-edge rail in long conversations that lets users jump between their previous prompts. Each prompt becomes a soft, embossed "trail marker" positioned proportionally to its location in the scrollable content — so the rail mirrors the actual shape of the conversation, not just its message count.

- Markers carved in the warm sand palette (`--text-muted` → `--text-primary` on active), with `--emboss-highlight` so they pick up the existing dune texture.
- A faint vertical line traces from the top to the active marker, giving a sense of *where you are in the journey*.
- Hover reveals a 260px soft card with a 3-line prompt preview and timestamp — same `--bg-input` / `--shadow-lg` language as the rest of the UI; no new visual idiom.
- Click smooth-scrolls to the message and pulses a warm flash so the eye lands gracefully.
- Auto-hides after 1.5s of inactivity; reveals on scroll or when the mouse approaches the right edge.
- Renders only when 3+ user prompts exist, only on screens ≥ 900px, and stays out of the way when a side panel (code / sources / sub-conversation) is open.

## Implementation notes

- New `ConversationTrail` component lives next to `MessageList` and uses the existing scroll-container ref.
- DOM positions are resolved through a `data-trail-anchor` marker on each user-message wrapper — no measuring magic, no class-name guessing.
- Scroll handler is rAF-throttled; `ResizeObserver` keeps marker positions in sync with content (streaming, edits, code panels) without polling.
- Sticky-viewport + absolute child mirrors the same pattern already used by `scrollToBottomAnchor`, so no new layout idioms were introduced.

## Test plan

- [ ] On a conversation with 3+ user prompts, the rail fades in on scroll near the right edge.
- [ ] Active marker updates as you scroll; the trace line lengthens to it.
- [ ] Hovering a marker shows the prompt preview card; click smooth-scrolls and flashes the target.
- [ ] Rail auto-hides after ~1.5s of no interaction.
- [ ] Rail does not appear on conversations with < 3 prompts, when a side panel is open, or on screens < 900px.
- [ ] Light/dark theme both render correctly.
- [ ] No console errors, no layout shift, no regressions on existing scroll-to-bottom or code panel behavior.

https://claude.ai/code/session_01AzJ98vPnD936naTauL4nGy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzJ98vPnD936naTauL4nGy)_