### PR TITLE
Stabilise ConversationTrail with fixed positioning, dot markers, always-visible

### DIFF
--- a/src/components/MessageList/ConversationTrail.jsx
+++ b/src/components/MessageList/ConversationTrail.jsx
@@ -3,9 +3,10 @@ import styles from './ConversationTrail.module.css';
 
 const MIN_MARKERS_TO_SHOW = 3;
 const ACTIVE_ANCHOR_RATIO = 0.32;
-const AUTO_HIDE_DELAY_MS = 1500;
-const EDGE_HOVER_ZONE_PX = 96;
 const FLASH_DURATION_MS = 1100;
+const TOP_INSET_PX = 96;
+const BOTTOM_INSET_PX = 120;
+const RIGHT_INSET_PX = 18;
 
 function formatTime(value) {
   if (!value) return null;
@@ -43,9 +44,8 @@ export default function ConversationTrail({ messages, scrollContainerRef, hidden
   const [markers, setMarkers] = useState([]);
   const [activeIndex, setActiveIndex] = useState(0);
   const [hoveredIndex, setHoveredIndex] = useState(null);
-  const [visible, setVisible] = useState(false);
+  const [containerBounds, setContainerBounds] = useState(null);
 
-  const hideTimeoutRef = useRef(null);
   const rafRef = useRef(null);
   const flashTimeoutRef = useRef(null);
 
@@ -87,19 +87,34 @@ export default function ConversationTrail({ messages, scrollContainerRef, hidden
   useEffect(() => {
     if (!shouldRender) {
       setMarkers([]);
+      setContainerBounds(null);
       return undefined;
     }
     const container = scrollContainerRef.current;
     if (!container) return undefined;
 
+    const updateBounds = () => {
+      const rect = container.getBoundingClientRect();
+      setContainerBounds({ top: rect.top, bottom: rect.bottom, right: rect.right });
+    };
+
+    updateBounds();
     recomputeMarkers();
 
-    const resizeObserver = new ResizeObserver(() => recomputeMarkers());
+    const resizeObserver = new ResizeObserver(() => {
+      updateBounds();
+      recomputeMarkers();
+    });
     resizeObserver.observe(container);
-    const anchors = container.querySelectorAll('[data-trail-anchor="true"]');
-    anchors.forEach((node) => resizeObserver.observe(node));
+    container.querySelectorAll('[data-trail-anchor="true"]').forEach((node) => {
+      resizeObserver.observe(node);
+    });
 
-    return () => resizeObserver.disconnect();
+    window.addEventListener('resize', updateBounds);
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateBounds);
+    };
   }, [shouldRender, recomputeMarkers, scrollContainerRef]);
 
   useEffect(() => {
@@ -134,40 +149,6 @@ export default function ConversationTrail({ messages, scrollContainerRef, hidden
     };
   }, [shouldRender, markers, scrollContainerRef]);
 
-  useEffect(() => {
-    if (!shouldRender) {
-      setVisible(false);
-      return undefined;
-    }
-    const container = scrollContainerRef.current;
-    if (!container) return undefined;
-
-    const reveal = () => {
-      setVisible(true);
-      if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
-      hideTimeoutRef.current = setTimeout(() => setVisible(false), AUTO_HIDE_DELAY_MS);
-    };
-
-    const handleMouseMove = (event) => {
-      const rect = container.getBoundingClientRect();
-      const distanceFromRight = rect.right - event.clientX;
-      if (distanceFromRight >= 0 && distanceFromRight <= EDGE_HOVER_ZONE_PX) {
-        reveal();
-      }
-    };
-
-    container.addEventListener('scroll', reveal, { passive: true });
-    container.addEventListener('mousemove', handleMouseMove);
-    return () => {
-      container.removeEventListener('scroll', reveal);
-      container.removeEventListener('mousemove', handleMouseMove);
-      if (hideTimeoutRef.current) {
-        clearTimeout(hideTimeoutRef.current);
-        hideTimeoutRef.current = null;
-      }
-    };
-  }, [shouldRender, scrollContainerRef]);
-
   useEffect(
     () => () => {
       if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
@@ -190,65 +171,58 @@ export default function ConversationTrail({ messages, scrollContainerRef, hidden
     [markers]
   );
 
-  const handleMarkerEnter = useCallback((index) => {
-    setHoveredIndex(index);
-    setVisible(true);
-    if (hideTimeoutRef.current) {
-      clearTimeout(hideTimeoutRef.current);
-      hideTimeoutRef.current = null;
-    }
-  }, []);
+  if (!shouldRender || markers.length === 0 || !containerBounds) return null;
 
-  const handleMarkerLeave = useCallback(() => {
-    setHoveredIndex(null);
-    if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
-    hideTimeoutRef.current = setTimeout(() => setVisible(false), AUTO_HIDE_DELAY_MS);
-  }, []);
-
-  if (!shouldRender || markers.length === 0) return null;
-
+  const railTop = containerBounds.top + TOP_INSET_PX;
+  const railHeight = Math.max(
+    0,
+    containerBounds.bottom - containerBounds.top - TOP_INSET_PX - BOTTOM_INSET_PX
+  );
+  const railRight = Math.max(
+    RIGHT_INSET_PX,
+    window.innerWidth - containerBounds.right + RIGHT_INSET_PX
+  );
   const progressPercent = markers.length <= 1 ? 0 : (markers[activeIndex]?.ratio ?? 0) * 100;
 
   return (
-    <div className={styles.trailViewport} aria-hidden={!visible}>
-      <nav
-        className={`${styles.trail} ${visible ? styles.trailVisible : ''}`}
-        aria-label="Conversation navigation"
-      >
-        <div className={styles.rail}>
-          <div className={styles.railLine} />
-          <div className={styles.railProgress} style={{ '--progress': `${progressPercent}%` }} />
-          {markers.map((marker, index) => {
-            const isActive = index === activeIndex;
-            const time = formatTime(marker.createdAt);
-            return (
-              <button
-                key={marker.id}
-                type="button"
-                className={`${styles.marker} ${isActive ? styles.markerActive : ''}`}
-                style={{ top: `${marker.ratio * 100}%` }}
-                onClick={() => handleJump(index)}
-                onMouseEnter={() => handleMarkerEnter(index)}
-                onMouseLeave={handleMarkerLeave}
-                onFocus={() => handleMarkerEnter(index)}
-                onBlur={handleMarkerLeave}
-                aria-label={`Jump to prompt ${index + 1}${
-                  marker.preview ? `: ${marker.preview.slice(0, 60)}` : ''
-                }`}
-                aria-current={isActive ? 'true' : undefined}
-              >
-                <span className={styles.markerStroke} />
-                {hoveredIndex === index && marker.preview && (
-                  <div className={styles.tooltip} role="tooltip">
-                    <span className={styles.tooltipPreview}>{marker.preview}</span>
-                    {time && <span className={styles.tooltipTime}>{time}</span>}
-                  </div>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      </nav>
-    </div>
+    <nav
+      className={styles.trail}
+      style={{ top: `${railTop}px`, height: `${railHeight}px`, right: `${railRight}px` }}
+      aria-label="Conversation navigation"
+    >
+      <div className={styles.rail}>
+        <div className={styles.railLine} />
+        <div className={styles.railProgress} style={{ '--progress': `${progressPercent}%` }} />
+        {markers.map((marker, index) => {
+          const isActive = index === activeIndex;
+          const time = formatTime(marker.createdAt);
+          return (
+            <button
+              key={marker.id}
+              type="button"
+              className={`${styles.marker} ${isActive ? styles.markerActive : ''}`}
+              style={{ top: `${marker.ratio * 100}%` }}
+              onClick={() => handleJump(index)}
+              onMouseEnter={() => setHoveredIndex(index)}
+              onMouseLeave={() => setHoveredIndex(null)}
+              onFocus={() => setHoveredIndex(index)}
+              onBlur={() => setHoveredIndex(null)}
+              aria-label={`Jump to prompt ${index + 1}${
+                marker.preview ? `: ${marker.preview.slice(0, 60)}` : ''
+              }`}
+              aria-current={isActive ? 'true' : undefined}
+            >
+              <span className={styles.markerDot} />
+              {hoveredIndex === index && marker.preview && (
+                <div className={styles.tooltip} role="tooltip">
+                  <span className={styles.tooltipPreview}>{marker.preview}</span>
+                  {time && <span className={styles.tooltipTime}>{time}</span>}
+                </div>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </nav>
   );
 }

--- a/src/components/MessageList/ConversationTrail.module.css
+++ b/src/components/MessageList/ConversationTrail.module.css
@@ -1,27 +1,20 @@
-.trailViewport {
-  position: sticky;
-  top: 0;
-  height: 0;
-  z-index: 8;
-  pointer-events: none;
-}
-
 .trail {
-  position: absolute;
-  top: 96px;
-  right: 18px;
-  height: calc(var(--app-height) - 192px);
-  width: 22px;
+  position: fixed;
+  width: 24px;
+  z-index: 8;
   pointer-events: auto;
-  opacity: 0;
-  transform: translateX(6px);
-  transition: opacity 0.28s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+  animation: trailFadeIn 0.32s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.trailVisible {
-  opacity: 1;
-  transform: translateX(0);
+@keyframes trailFadeIn {
+  from {
+    opacity: 0;
+    transform: translateX(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 .rail {
@@ -40,8 +33,8 @@
   background: linear-gradient(
     to bottom,
     transparent 0%,
-    var(--border-color) 8%,
-    var(--border-color) 92%,
+    var(--border-color) 10%,
+    var(--border-color) 90%,
     transparent 100%
   );
   border-radius: 1px;
@@ -57,19 +50,19 @@
   background: linear-gradient(
     to bottom,
     transparent 0%,
-    var(--text-secondary) 12%,
+    var(--text-secondary) 20%,
     var(--text-primary) 100%
   );
   border-radius: 1px;
-  transition: height 0.32s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: height 0.4s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .marker {
   position: absolute;
   left: 0;
   right: 0;
-  height: 18px;
-  margin-top: -9px;
+  height: 22px;
+  margin-top: -11px;
   padding: 0;
   border: none;
   background: transparent;
@@ -81,37 +74,41 @@
   outline: none;
 }
 
-.markerStroke {
+.markerDot {
   display: block;
-  width: 10px;
-  height: 2px;
-  border-radius: 2px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
   background-color: var(--text-muted);
-  box-shadow: 0 1px 0 var(--emboss-highlight);
-  transition: width 0.22s cubic-bezier(0.16, 1, 0.3, 1), background-color 0.22s ease,
-    box-shadow 0.22s ease;
-  will-change: width, background-color;
+  box-shadow: 0 0 0 3px var(--bg-primary), 0 1px 0 var(--emboss-highlight);
+  transition: transform 0.22s cubic-bezier(0.16, 1, 0.3, 1), background-color 0.22s ease;
+  will-change: transform, background-color;
 }
 
-.marker:hover .markerStroke {
-  width: 16px;
+.marker:hover .markerDot {
+  transform: scale(1.4);
   background-color: var(--text-secondary);
 }
 
-.markerActive .markerStroke {
-  width: 16px;
+.markerActive .markerDot {
+  width: 7px;
+  height: 7px;
   background-color: var(--text-primary);
-  box-shadow: 0 0 0 0.5px var(--bg-primary), 0 1px 0 var(--emboss-highlight);
+  box-shadow: 0 0 0 3px var(--bg-primary), 0 0 0 4px var(--border-color),
+    0 1px 0 var(--emboss-highlight);
 }
 
-.marker:focus-visible .markerStroke {
-  outline: 2px solid var(--text-secondary);
-  outline-offset: 3px;
+.markerActive:hover .markerDot {
+  transform: scale(1.15);
+}
+
+.marker:focus-visible .markerDot {
+  box-shadow: 0 0 0 3px var(--bg-primary), 0 0 0 4.5px var(--text-secondary);
 }
 
 .tooltip {
   position: absolute;
-  right: 32px;
+  right: 24px;
   top: 50%;
   transform: translateY(-50%);
   width: 260px;


### PR DESCRIPTION
## Summary

Follow-up to #422. Two fixes:

**1. Stabilise the rail position.** The previous sticky + absolute combo extended the scroll height past the last message — scrolling continued into empty space below the conversation. Switched to `position: fixed`, computing top/right/height from the scroll container's `getBoundingClientRect()` (updated via `ResizeObserver` + window resize). The rail no longer participates in document flow, so it can't affect scrollable height.

**2. Always visible + cleaner visual.** Dropped the auto-hide so the rail is predictably present at all scroll positions, and replaced the horizontal "strokes" with soft round dots — they read as waypoints rather than scrollbar ticks, and feel more on-brand. Active dot grows with a warm outer ring (using `--border-color`) so you can see where you are at a glance without hovering.

## What changed

- `ConversationTrail.jsx`: drop visibility state and auto-hide logic; add `containerBounds` state derived from `getBoundingClientRect`; compute `top` / `right` / `height` inline.
- `ConversationTrail.module.css`: rewrite for `position: fixed`; replace `.markerStroke` with `.markerDot`; refine progress line and active-state ring.

## Test plan

- [ ] No empty scroll space below the last message.
- [ ] Rail stays at the right edge regardless of scroll position.
- [ ] Active dot updates as you scroll; warm ring is visible.
- [ ] Hover any dot → prompt preview card appears to its left.
- [ ] Click any dot → smooth scroll + flash on the target message.
- [ ] Rail hidden on screens < 900px and when a side panel (code / sources / sub-conv) is open.
- [ ] Sidebar collapse/expand and code panel open/close re-align the rail without flicker.
- [ ] No console errors, no layout regressions.

https://claude.ai/code/session_01AzJ98vPnD936naTauL4nGy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzJ98vPnD936naTauL4nGy)_