### PR TITLE
Render HTML artifacts in canvas-style side panel with visual/source toggle

### DIFF
--- a/src/components/ArtifactBlock/ArtifactBlock.jsx
+++ b/src/components/ArtifactBlock/ArtifactBlock.jsx
@@ -1,121 +1,53 @@
-import { useMemo, useId, useState } from 'react';
-import DOMPurify from 'dompurify';
+import { useMemo } from 'react';
+import { EyeIcon, MaximizeIcon } from '../Icons';
 import styles from './ArtifactBlock.module.css';
 
-/**
- * ArtifactBlock — renders model-generated HTML+CSS safely via DOMPurify.
- *
- * All JavaScript is stripped. Only safe HTML elements and CSS are rendered.
- * CSS is scoped to a unique wrapper class to prevent style leakage.
- *
- * Expects `spec` to be a raw HTML string (with optional <style> tags).
- */
+const TITLE_REGEX = /<title[^>]*>([\s\S]*?)<\/title>/i;
+const H1_REGEX = /<h1[^>]*>([\s\S]*?)<\/h1>/i;
+const TAG_STRIP_REGEX = /<[^>]+>/g;
 
-const ALLOWED_TAGS = [
-  'div', 'span', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-  'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td', 'caption', 'colgroup', 'col',
-  'ul', 'ol', 'li', 'dl', 'dt', 'dd',
-  'strong', 'em', 'b', 'i', 'u', 'br', 'hr', 'wbr',
-  'img', 'svg', 'path', 'circle', 'rect', 'ellipse', 'text', 'tspan',
-  'g', 'line', 'polygon', 'polyline', 'defs', 'clippath', 'use',
-  'lineargradient', 'radialgradient', 'stop',
-  'style', 'section', 'header', 'footer', 'nav', 'main', 'article',
-  'aside', 'figure', 'figcaption', 'details', 'summary',
-  'sup', 'sub', 'abbr', 'small', 'mark', 'del', 'ins', 'blockquote',
-  'pre', 'code', 'a',
-];
+function parseArtifactTitle(html) {
+  const titleMatch = html.match(TITLE_REGEX);
+  if (titleMatch) {
+    const decoded = titleMatch[1].trim();
+    if (decoded) return decoded.slice(0, 80);
+  }
+  const h1Match = html.match(H1_REGEX);
+  if (h1Match) {
+    const stripped = h1Match[1].replace(TAG_STRIP_REGEX, '').trim();
+    if (stripped) return stripped.slice(0, 80);
+  }
+  return null;
+}
 
-const ALLOWED_ATTR = [
-  'class', 'style', 'id', 'colspan', 'rowspan', 'alt', 'title',
-  'href', 'target', 'rel',
-  // SVG attributes
-  'viewBox', 'viewbox', 'd', 'fill', 'stroke', 'stroke-width', 'stroke-linecap',
-  'stroke-linejoin', 'stroke-dasharray', 'stroke-dashoffset',
-  'cx', 'cy', 'r', 'rx', 'ry', 'x', 'y', 'x1', 'y1', 'x2', 'y2',
-  'width', 'height', 'transform', 'xmlns', 'xmlns:xlink',
-  'font-size', 'text-anchor', 'dominant-baseline', 'alignment-baseline',
-  'points', 'opacity', 'fill-opacity', 'stroke-opacity',
-  'offset', 'stop-color', 'stop-opacity', 'gradientUnits', 'gradientTransform',
-  'clip-path', 'clip-rule', 'fill-rule',
-  'preserveAspectRatio', 'xlink:href',
-  // Table attributes
-  'scope', 'span',
-];
+export default function ArtifactBlock({ spec, isStreaming = false, onOpen }) {
+  const meta = useMemo(() => {
+    if (!spec || typeof spec !== 'string') return null;
+    const trimmed = spec.trim();
+    if (!trimmed) return null;
+    return {
+      title: parseArtifactTitle(trimmed) || 'Visual',
+      lineCount: trimmed.split('\n').length,
+    };
+  }, [spec]);
 
-const FORBID_TAGS = [
-  'script', 'iframe', 'object', 'embed', 'form', 'input',
-  'textarea', 'button', 'select', 'option', 'link', 'meta',
-  'base', 'applet', 'frame', 'frameset', 'layer',
-];
+  const interactive = typeof onOpen === 'function';
 
-/**
- * Scope all CSS selectors in <style> blocks to a wrapper class.
- * This prevents artifact styles from leaking to the parent page.
- */
-function scopeCSS(html, scopeClass) {
-  return html.replace(/<style[^>]*>([\s\S]*?)<\/style>/gi, (match, cssContent) => {
-    const scoped = cssContent.replace(
-      /([^{}@/][^{]*)\{/g,
-      (ruleMatch, selector) => {
-        const scopedSelectors = selector
-          .split(',')
-          .map((s) => {
-            const trimmed = s.trim();
-            if (!trimmed) return s;
-            if (trimmed.startsWith('@')) return s;
-            if (trimmed === ':root' || trimmed === 'html' || trimmed === 'body') {
-              return ` .${scopeClass}`;
-            }
-            if (trimmed === '*') return ` .${scopeClass} *`;
-            return ` .${scopeClass} ${trimmed}`;
-          })
-          .join(',');
-        return `${scopedSelectors}{`;
-      }
+  if (!interactive && isStreaming) {
+    return (
+      <div className={styles.opener} data-state="streaming" aria-busy="true">
+        <span className={styles.icon}>
+          <span className={styles.spinner} />
+        </span>
+        <span className={styles.text}>
+          <span className={styles.title}>{meta?.title || 'Building visual'}</span>
+          <span className={styles.meta}>HTML · streaming</span>
+        </span>
+      </div>
     );
-    return `<style>${scoped}</style>`;
-  });
-}
+  }
 
-function sanitizeHTML(html, scopeClass) {
-  const scoped = scopeCSS(html, scopeClass);
-  return DOMPurify.sanitize(scoped, {
-    ALLOWED_TAGS,
-    ALLOWED_ATTR,
-    ALLOW_DATA_ATTR: false,
-    ADD_TAGS: ['style'],
-    FORBID_TAGS,
-    FORBID_ATTR: [
-      'onerror', 'onload', 'onclick', 'ondblclick', 'onmousedown',
-      'onmouseup', 'onmouseover', 'onmousemove', 'onmouseout',
-      'onfocus', 'onblur', 'onsubmit', 'onchange', 'onkeydown',
-      'onkeyup', 'onkeypress', 'oncontextmenu',
-    ],
-    ADD_URI_SAFE_ATTR: ['href'],
-  });
-}
-
-export default function ArtifactBlock({ spec, isStreaming = false }) {
-  const uniqueId = useId().replace(/:/g, '');
-  const scopeClass = `artifact-scope-${uniqueId}`;
-  const [showSource, setShowSource] = useState(false);
-
-  const sanitized = useMemo(() => {
-    if (!spec || typeof spec !== 'string' || spec.trim().length === 0) return null;
-    return sanitizeHTML(spec.trim(), scopeClass);
-  }, [spec, scopeClass]);
-
-  if (!sanitized) {
-    if (isStreaming) {
-      return (
-        <div className={styles.root}>
-          <div className={styles.placeholder}>
-            <div className={styles.placeholderPulse} />
-            <span className={styles.placeholderText}>Building visual...</span>
-          </div>
-        </div>
-      );
-    }
+  if (!meta) {
     return (
       <div className={styles.error}>
         <span>Could not render visual content</span>
@@ -123,29 +55,26 @@ export default function ArtifactBlock({ spec, isStreaming = false }) {
     );
   }
 
+  const metaLabel = `HTML · ${meta.lineCount} ${meta.lineCount === 1 ? 'line' : 'lines'} · Visual`;
+
   return (
-    <div className={styles.root}>
-      {showSource ? (
-        <div className={styles.sourceView}>
-          <pre className={styles.sourceCode}>{spec}</pre>
-        </div>
-      ) : (
-        <div
-          className={`${styles.artifactContent} ${scopeClass}`}
-          dangerouslySetInnerHTML={{ __html: sanitized }}
-        />
-      )}
-      <div className={styles.footer}>
-        <button
-          className={styles.sourceToggle}
-          onClick={(e) => {
-            e.stopPropagation();
-            setShowSource(!showSource);
-          }}
-        >
-          {showSource ? 'Show visual' : 'View source'}
-        </button>
-      </div>
-    </div>
+    <button
+      type="button"
+      className={styles.opener}
+      onClick={interactive ? onOpen : undefined}
+      disabled={!interactive}
+      aria-label={`Open ${meta.title} in canvas`}
+    >
+      <span className={styles.icon}>
+        <EyeIcon />
+      </span>
+      <span className={styles.text}>
+        <span className={styles.title}>{meta.title}</span>
+        <span className={styles.meta}>{metaLabel}</span>
+      </span>
+      <span className={styles.arrow}>
+        <MaximizeIcon />
+      </span>
+    </button>
   );
 }

--- a/src/components/ArtifactBlock/ArtifactBlock.module.css
+++ b/src/components/ArtifactBlock/ArtifactBlock.module.css
@@ -1,99 +1,120 @@
-/* ===== Root — no border, flows naturally in chat ===== */
+.opener {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  margin: 12px 0;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.15s ease,
+    box-shadow 0.2s ease;
+  font: inherit;
+  text-align: left;
+  color: inherit;
+}
 
-.root {
-  margin: 18px 0 12px;
-  position: relative;
+.opener:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--text-muted);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.opener:active:not(:disabled) {
+  transform: scale(0.99);
+}
+
+.opener:disabled {
+  cursor: default;
+}
+
+.opener[data-state='streaming'] {
+  cursor: default;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: var(--bg-active);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+
+.title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.arrow {
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-muted);
+  transition: color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.opener:hover:not(:disabled) .arrow {
+  color: var(--text-secondary);
+}
+
+.arrow svg {
+  width: 16px;
+  height: 16px;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1.6px solid var(--text-muted);
+  border-top-color: transparent;
+  animation: artifactSpin 0.9s linear infinite;
+}
+
+@keyframes artifactSpin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .error {
+  display: flex;
+  align-items: center;
   margin: 12px 0;
   padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px dashed var(--border-color);
   color: var(--text-muted);
   font-size: 12.5px;
-}
-
-/* Streaming placeholder */
-.placeholder {
-  padding: 32px 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 12px;
-}
-
-.placeholderPulse {
-  width: 70%;
-  max-width: 400px;
-  height: 100px;
-  border-radius: 8px;
-  background: linear-gradient(
-    90deg,
-    var(--bg-secondary) 25%,
-    var(--border-color) 50%,
-    var(--bg-secondary) 75%
-  );
-  background-size: 200% 100%;
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
-
-.placeholderText {
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-/* Rendered artifact content */
-.artifactContent {
-  overflow-x: auto;
-}
-
-/* Footer with source toggle */
-.footer {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 6px;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-}
-
-.root:hover .footer {
-  opacity: 1;
-}
-
-.sourceToggle {
-  font-size: 11px;
-  color: var(--text-muted);
-  background: none;
-  border: none;
-  padding: 2px 4px;
-  cursor: pointer;
-  font-family: inherit;
-  transition: color 0.15s ease;
-}
-
-.sourceToggle:hover {
-  color: var(--text-secondary);
-}
-
-/* Source code view */
-.sourceView {
-  max-height: 400px;
-  overflow: auto;
-  padding: 12px;
-  border-radius: 8px;
-  background: var(--bg-secondary);
-}
-
-.sourceCode {
-  font-size: 11.5px;
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
-  color: var(--text-secondary);
-  white-space: pre-wrap;
-  word-break: break-all;
-  margin: 0;
-  line-height: 1.5;
 }

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -44,6 +44,7 @@ import {
   InfoIcon,
   MaximizeIcon,
   CodeIcon,
+  EyeIcon,
   EditIcon,
   StarIcon,
   FlagIcon,
@@ -170,11 +171,12 @@ const CODE_VIEWER_MIN_LINES = 15;
  * Render basic markdown to React elements.
  * Handles: code blocks, inline code, bold, italic, horizontal rules, lists, images, links, paragraphs.
  *
- * codeOpenerContext (optional): { longBlocks, onOpen } — when provided, code
- * blocks whose body exceeds CODE_VIEWER_MIN_LINES render as a CodeOpener that
- * opens the side-panel viewer focused on that block instead of inlining the code.
+ * panelOpenerContext (optional): { panelBlocks, onOpen } — when provided, long
+ * code blocks and HTML artifacts collapse to opener cards that open the
+ * canvas-style side panel focused on that block. The opener indices must align
+ * with the document-order extraction performed by extractPanelBlocks.
  */
-function renderMarkdown(text, isStreaming = false, citations = null, codeOpenerContext = null) {
+function renderMarkdown(text, isStreaming = false, citations = null, panelOpenerContext = null) {
   _activeCitations = citations;
   if (!text) return null;
 
@@ -183,7 +185,24 @@ function renderMarkdown(text, isStreaming = false, citations = null, codeOpenerC
   const images = [];
   let i = 0;
   let key = 0;
-  let longCodeBlockIdx = 0;
+  let panelBlockIdx = 0;
+
+  const tryEmitPanelOpener = (lang, codeContent) => {
+    if (!panelOpenerContext) return false;
+    const block = panelOpenerContext.panelBlocks[panelBlockIdx];
+    if (!block) return false;
+    const idx = panelBlockIdx;
+    panelBlockIdx++;
+    const onOpen = () => panelOpenerContext.onOpen(panelOpenerContext.panelBlocks, idx);
+    if (block.type === 'artifact') {
+      elements.push(
+        <ArtifactBlock key={key++} spec={codeContent} isStreaming={isStreaming} onOpen={onOpen} />
+      );
+    } else {
+      elements.push(<CodeOpener key={key++} block={block} onOpen={onOpen} />);
+    }
+    return true;
+  };
 
   while (i < lines.length) {
     const line = lines[i];
@@ -201,20 +220,7 @@ function renderMarkdown(text, isStreaming = false, citations = null, codeOpenerC
       const codeContent = codeLines.join('\n');
       const pushInlineCode = () => {
         const lineCount = codeContent.split('\n').length;
-        if (codeOpenerContext && lineCount > CODE_VIEWER_MIN_LINES) {
-          const idx = longCodeBlockIdx++;
-          const block = codeOpenerContext.longBlocks[idx];
-          if (block) {
-            elements.push(
-              <CodeOpener
-                key={key++}
-                block={block}
-                onOpen={() => codeOpenerContext.onOpen(codeOpenerContext.longBlocks, idx)}
-              />
-            );
-            return;
-          }
-        }
+        if (lineCount > CODE_VIEWER_MIN_LINES && tryEmitPanelOpener(lang, codeContent)) return;
         elements.push(<CodeBlock key={key++} lang={lang} code={codeContent} />);
       };
       if (lang === 'mermaid') {
@@ -228,7 +234,9 @@ function renderMarkdown(text, isStreaming = false, citations = null, codeOpenerC
       } else if (lang === 'file') {
         elements.push(<FileBlock key={key++} spec={codeContent} isStreaming={isStreaming} />);
       } else if (lang === 'artifact' || lang === 'html-artifact') {
-        elements.push(<ArtifactBlock key={key++} spec={codeContent} isStreaming={isStreaming} />);
+        if (!tryEmitPanelOpener(lang, codeContent)) {
+          elements.push(<ArtifactBlock key={key++} spec={codeContent} isStreaming={isStreaming} />);
+        }
       } else if (lang === 'json' || lang === '') {
         // Auto-detect chart specs in json/untagged code blocks
         let isChartSpec = false;
@@ -724,81 +732,107 @@ function extractCodeBlockName(code, lang) {
   return null;
 }
 
+const PANEL_SKIP_LANGS = new Set([
+  'chart',
+  'araviel-chart',
+  'mermaid',
+  'timeline',
+  'comparison',
+  'file',
+]);
+
+const CHART_TYPES = new Set([
+  'line',
+  'area',
+  'bar',
+  'candlestick',
+  'pie',
+  'donut',
+  'composed',
+  'scatter',
+]);
+
+const ARTIFACT_TITLE_REGEX = /<title[^>]*>([\s\S]*?)<\/title>/i;
+const ARTIFACT_H1_REGEX = /<h1[^>]*>([\s\S]*?)<\/h1>/i;
+const ARTIFACT_TAG_STRIP_REGEX = /<[^>]+>/g;
+
+function parseArtifactName(html) {
+  const titleMatch = html.match(ARTIFACT_TITLE_REGEX);
+  if (titleMatch) {
+    const decoded = titleMatch[1].trim();
+    if (decoded) return decoded.slice(0, 80);
+  }
+  const h1Match = html.match(ARTIFACT_H1_REGEX);
+  if (h1Match) {
+    const stripped = h1Match[1].replace(ARTIFACT_TAG_STRIP_REGEX, '').trim();
+    if (stripped) return stripped.slice(0, 80);
+  }
+  return null;
+}
+
+function extractContextName(textBefore) {
+  const headingMatch = textBefore.match(
+    /(?:^|\n)#{1,4}\s+(?:\d+\.\s+)?(?:\*\*)?([^\n*#]+?)(?:\*\*)?(?:\s*\([^)]*\))?\s*$/
+  );
+  if (headingMatch) return headingMatch[1].trim();
+
+  const boldMatch = textBefore.match(/\*\*([^*]+)\*\*(?:\s*\([^)]*\))?\s*$/);
+  if (boldMatch) {
+    const label = boldMatch[1].trim();
+    if (label.includes('/')) {
+      const parts = label.split('/');
+      return parts[parts.length - 1].replace(/\.\w+$/, '');
+    }
+    return label;
+  }
+  return null;
+}
+
+function looksLikeChartSpec(code) {
+  try {
+    const parsed = JSON.parse(code);
+    return parsed && CHART_TYPES.has(parsed.type) && Array.isArray(parsed.data);
+  } catch {
+    return false;
+  }
+}
+
 /**
- * Extract code blocks from message text with smart naming.
- * Also captures markdown heading context above each code block.
+ * Extract blocks that belong in the canvas-style side panel.
+ * Returns code blocks longer than CODE_VIEWER_MIN_LINES and every HTML artifact,
+ * tagged with `type` and preserved in document order so opener indices in
+ * renderMarkdown align with this list.
  */
-function extractCodeBlocksWithNames(text) {
+function extractPanelBlocks(text) {
   const codeBlockRegex = /```(\w*)\n([\s\S]*?)```/g;
   const blocks = [];
   let m;
   while ((m = codeBlockRegex.exec(text)) !== null) {
     const lang = m[1] || '';
     const code = m[2];
-    if (
-      lang === 'chart' ||
-      lang === 'araviel-chart' ||
-      lang === 'mermaid' ||
-      lang === 'timeline' ||
-      lang === 'comparison' ||
-      lang === 'file' ||
-      lang === 'artifact' ||
-      lang === 'html-artifact'
-    )
+
+    if (lang === 'artifact' || lang === 'html-artifact') {
+      blocks.push({
+        type: 'artifact',
+        lang: 'html',
+        code,
+        name: parseArtifactName(code) || 'Visual',
+      });
       continue;
-    if (lang === 'json' || lang === '') {
-      try {
-        const parsed = JSON.parse(code);
-        const chartTypes = [
-          'line',
-          'area',
-          'bar',
-          'candlestick',
-          'pie',
-          'donut',
-          'composed',
-          'scatter',
-        ];
-        if (parsed && chartTypes.includes(parsed.type) && Array.isArray(parsed.data)) continue;
-      } catch {
-        /* not chart spec */
-      }
     }
 
-    // Look for markdown heading or bold label before this code block
-    const textBefore = text.slice(0, m.index);
-    let contextName = null;
+    if (PANEL_SKIP_LANGS.has(lang)) continue;
+    if ((lang === 'json' || lang === '') && looksLikeChartSpec(code)) continue;
+    if (code.split('\n').length <= CODE_VIEWER_MIN_LINES) continue;
 
-    // Check for heading like "### Controller (src/controllers/userController.js)"
-    const headingMatch = textBefore.match(
-      /(?:^|\n)#{1,4}\s+(?:\d+\.\s+)?(?:\*\*)?([^\n*#]+?)(?:\*\*)?(?:\s*\([^)]*\))?\s*$/
-    );
-    if (headingMatch) {
-      contextName = headingMatch[1].trim();
-    }
-
-    // Check for bold label like "**Controller** (src/...)" or "**src/controllers/userController.js**"
-    if (!contextName) {
-      const boldMatch = textBefore.match(/\*\*([^*]+)\*\*(?:\s*\([^)]*\))?\s*$/);
-      if (boldMatch) {
-        const label = boldMatch[1].trim();
-        // If it's a file path, use the filename
-        if (label.includes('/')) {
-          const parts = label.split('/');
-          contextName = parts[parts.length - 1].replace(/\.\w+$/, '');
-        } else {
-          contextName = label;
-        }
-      }
-    }
-
-    // Extract name from code content
     const codeName = extractCodeBlockName(code, lang);
-
-    // Build the display name with priority: code-extracted > context > fallback
-    const name = codeName || contextName || null;
-
-    blocks.push({ lang, code, name });
+    const contextName = codeName ? null : extractContextName(text.slice(0, m.index));
+    blocks.push({
+      type: 'code',
+      lang,
+      code,
+      name: codeName || contextName || null,
+    });
   }
   return blocks;
 }
@@ -815,12 +849,38 @@ const MOBILE_BREAKPOINT = 768;
 const PANEL_MIN_WIDTH = 380;
 const PANEL_VIEWPORT_GAP = 12; // matches the panel's right inset (and the breathing room on the left)
 
+const defaultViewModeForBlock = (block) => (block?.type === 'artifact' ? 'visual' : 'source');
+
+function BrowserFrameIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="4" width="18" height="16" rx="2" />
+      <line x1="3" y1="9" x2="21" y2="9" />
+      <circle cx="6.4" cy="6.6" r="0.6" fill="currentColor" />
+      <circle cx="8.6" cy="6.6" r="0.6" fill="currentColor" />
+      <circle cx="10.8" cy="6.6" r="0.6" fill="currentColor" />
+    </svg>
+  );
+}
+
 function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChange }) {
   const safeInitialIdx =
     initialActiveIdx >= 0 && initialActiveIdx < codeBlocks.length ? initialActiveIdx : 0;
   const [activeIdx, setActiveIdx] = useState(safeInitialIdx);
   const [copied, setCopied] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(codeBlocks.length > 1);
+  const [viewMode, setViewMode] = useState(() =>
+    defaultViewModeForBlock(codeBlocks[safeInitialIdx])
+  );
   // The width the user dragged the panel to. Null = render the CSS default.
   // Stored separately from the clamped/rendered width so toggling the side nav
   // shrinks the panel without losing the user's preferred expansion.
@@ -884,12 +944,16 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
   }, [renderedWidth, onWidthChange]);
 
   const activeBlock = codeBlocks[activeIdx];
+  const isArtifact = activeBlock?.type === 'artifact';
+  const renderedViewMode = isArtifact ? viewMode : 'source';
+  const showVisual = isArtifact && renderedViewMode === 'visual';
 
   // Reset active index when the underlying file list or requested entry changes
   useEffect(() => {
     setActiveIdx(safeInitialIdx);
     setCopied(false);
     setSidebarOpen(codeBlocks.length > 1);
+    setViewMode(defaultViewModeForBlock(codeBlocks[safeInitialIdx]));
   }, [codeBlocks, safeInitialIdx]);
 
   useEffect(() => {
@@ -901,19 +965,18 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
   }, [onClose]);
 
   useEffect(() => {
-    if (codeRef.current && activeBlock) {
-      try {
-        const langId = activeBlock.lang ? activeBlock.lang.toLowerCase() : null;
-        const result =
-          langId && hljs.getLanguage(langId)
-            ? hljs.highlight(activeBlock.code, { language: langId })
-            : hljs.highlightAuto(activeBlock.code);
-        codeRef.current.innerHTML = result.value;
-      } catch {
-        codeRef.current.textContent = activeBlock.code;
-      }
+    if (!codeRef.current || !activeBlock || renderedViewMode !== 'source') return;
+    try {
+      const langId = activeBlock.lang ? activeBlock.lang.toLowerCase() : null;
+      const result =
+        langId && hljs.getLanguage(langId)
+          ? hljs.highlight(activeBlock.code, { language: langId })
+          : hljs.highlightAuto(activeBlock.code);
+      codeRef.current.innerHTML = result.value;
+    } catch {
+      codeRef.current.textContent = activeBlock.code;
     }
-  }, [activeBlock]);
+  }, [activeBlock, renderedViewMode]);
 
   // Drag-to-resize handler. The cap is read from maxWidthRef so a sidebar
   // toggle mid-drag is honoured immediately.
@@ -1018,6 +1081,7 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
               const blockLang = block.lang ? block.lang.toUpperCase() : 'CODE';
               const blockLines = block.code.split('\n').length;
               const isActive = idx === activeIdx;
+              const blockIsArtifact = block.type === 'artifact';
 
               return (
                 <button
@@ -1032,7 +1096,7 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
                   title={blockName}
                 >
                   <div className={styles.codeSidePanelFileIcon}>
-                    <CodeIcon />
+                    {blockIsArtifact ? <BrowserFrameIcon /> : <CodeIcon />}
                   </div>
                   <div className={styles.codeSidePanelFileInfo}>
                     <span className={styles.codeSidePanelFileName}>{blockName}</span>
@@ -1067,6 +1131,36 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
               <span className={styles.codeSidePanelLangBadge}>{activeLang}</span>
             </div>
             <div className={styles.codeSidePanelHeaderActions}>
+              {isArtifact && (
+                <div className={styles.viewToggle} role="tablist" aria-label="View mode">
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={renderedViewMode === 'visual'}
+                    className={`${styles.viewToggleBtn} ${
+                      renderedViewMode === 'visual' ? styles.viewToggleBtnActive : ''
+                    }`}
+                    onClick={() => setViewMode('visual')}
+                    title="Preview"
+                    aria-label="Show visual preview"
+                  >
+                    <EyeIcon />
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={renderedViewMode === 'source'}
+                    className={`${styles.viewToggleBtn} ${
+                      renderedViewMode === 'source' ? styles.viewToggleBtnActive : ''
+                    }`}
+                    onClick={() => setViewMode('source')}
+                    title="Source"
+                    aria-label="Show source code"
+                  >
+                    <CodeIcon />
+                  </button>
+                </div>
+              )}
               <button
                 className={`${styles.codeSidePanelCopyBtn} ${
                   copied ? styles.codeSidePanelCopied : ''
@@ -1083,21 +1177,35 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
             </div>
           </div>
 
-          {/* Code area with line numbers */}
-          <div className={styles.codeSidePanelCodeArea}>
-            <div className={styles.codeSidePanelLineNumbers}>
-              {activeBlock.code.split('\n').map((_, idx) => (
-                <span key={idx}>{idx + 1}</span>
-              ))}
+          {showVisual ? (
+            <div className={styles.artifactViewArea}>
+              <iframe
+                key={`${activeIdx}-visual`}
+                className={styles.artifactIframe}
+                srcDoc={activeBlock.code}
+                sandbox=""
+                title={activeName}
+                loading="lazy"
+              />
             </div>
-            <pre className={styles.codeSidePanelPre}>
-              <code ref={codeRef}>{activeBlock.code}</code>
-            </pre>
-          </div>
+          ) : (
+            <div className={styles.codeSidePanelCodeArea}>
+              <div className={styles.codeSidePanelLineNumbers}>
+                {activeBlock.code.split('\n').map((_, idx) => (
+                  <span key={idx}>{idx + 1}</span>
+                ))}
+              </div>
+              <pre className={styles.codeSidePanelPre}>
+                <code ref={codeRef}>{activeBlock.code}</code>
+              </pre>
+            </div>
+          )}
 
           {/* Footer info */}
           <div className={styles.codeSidePanelFooter}>
-            <span>{lineCount} lines</span>
+            <span>
+              {showVisual ? 'Visual preview' : `${lineCount} ${lineCount === 1 ? 'line' : 'lines'}`}
+            </span>
             {codeBlocks.length > 1 && (
               <span>
                 {activeIdx + 1} of {codeBlocks.length} files
@@ -1132,46 +1240,6 @@ function CodeOpener({ block, onOpen }) {
         </span>
       </span>
       <span className={styles.codeOpenerArrow}>
-        <MaximizeIcon />
-      </span>
-    </button>
-  );
-}
-
-/**
- * Button shown below response content that opens the code side panel.
- */
-function CodeCanvasButton({ codeBlocks, onClick }) {
-  if (!codeBlocks || codeBlocks.length === 0) return null;
-
-  const totalLines = codeBlocks.reduce((sum, b) => sum + b.code.split('\n').length, 0);
-
-  // For single block, show the name; for multiple, list first few names
-  let title;
-  let meta;
-  if (codeBlocks.length === 1) {
-    title = codeBlocks[0].name || codeBlocks[0].lang || 'Code';
-    meta = `${
-      codeBlocks[0].lang ? codeBlocks[0].lang.toUpperCase() + ' · ' : ''
-    }${totalLines} lines`;
-  } else {
-    const names = codeBlocks.slice(0, 3).map((b) => b.name || b.lang || 'Code');
-    title = names.join(', ') + (codeBlocks.length > 3 ? ` +${codeBlocks.length - 3}` : '');
-    meta = `${codeBlocks.length} files · ${totalLines} lines`;
-  }
-
-  return (
-    <button className={styles.canvasOpenBtn} onClick={onClick}>
-      <div className={styles.canvasOpenBtnLeft}>
-        <span className={styles.canvasOpenBtnIcon}>
-          <CodeIcon />
-        </span>
-        <div className={styles.canvasOpenBtnText}>
-          <span className={styles.canvasOpenBtnTitle}>{title}</span>
-          <span className={styles.canvasOpenBtnMeta}>{meta}</span>
-        </div>
-      </div>
-      <span className={styles.canvasOpenBtnArrow}>
         <MaximizeIcon />
       </span>
     </button>
@@ -5317,24 +5385,20 @@ function Message({
     return displayText;
   }, [displayText, message.generatedImages]);
 
-  // Blocks long enough to skip inline rendering and live only in the side panel.
-  // Computed once per message and shared by both the inline renderer (via
-  // codeOpenerContext) and the footer CodeCanvasButton — keeps order/indices
-  // aligned so opener clicks land on the correct file.
-  const longCodeBlocks = useMemo(() => {
+  // Long code blocks and HTML artifacts that live in the canvas side panel.
+  // Extracted in document order so opener indices align with renderMarkdown.
+  const panelBlocks = useMemo(() => {
     if (!renderText) return [];
-    return extractCodeBlocksWithNames(renderText).filter(
-      (b) => b.code.split('\n').length > CODE_VIEWER_MIN_LINES
-    );
+    return extractPanelBlocks(renderText);
   }, [renderText]);
 
-  const codeOpenerContext = useMemo(() => {
-    if (longCodeBlocks.length === 0 || !onOpenCodePanel) return null;
+  const panelOpenerContext = useMemo(() => {
+    if (panelBlocks.length === 0 || !onOpenCodePanel) return null;
     return {
-      longBlocks: longCodeBlocks,
+      panelBlocks,
       onOpen: onOpenCodePanel,
     };
-  }, [longCodeBlocks, onOpenCodePanel]);
+  }, [panelBlocks, onOpenCodePanel]);
 
   // Sub-conversation state
   const [subConversations, setSubConversations] = useState([]);
@@ -5867,7 +5931,7 @@ function Message({
               renderText,
               isStreaming,
               message.citations || message.sources,
-              codeOpenerContext
+              panelOpenerContext
             )}
             {isStreaming && !renderText && (
               <span className={styles.typingDots} aria-label="Thinking">
@@ -5893,16 +5957,6 @@ function Message({
             />
           ))}
         </div>
-      )}
-
-      {/* Code panel button — shown below the response only when at least one
-          code block is long enough to live in the side panel. Short blocks stay
-          inline and don't appear here. */}
-      {!isUser && !isStreaming && longCodeBlocks.length > 0 && (
-        <CodeCanvasButton
-          codeBlocks={longCodeBlocks}
-          onClick={() => onOpenCodePanel && onOpenCodePanel(longCodeBlocks, 0)}
-        />
       )}
 
       {/* Error card */}

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -7154,8 +7154,74 @@
 .codeSidePanelHeaderActions {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   flex-shrink: 0;
+}
+
+.viewToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg-active);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+
+.viewToggleBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 26px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.viewToggleBtn:hover {
+  color: var(--text-secondary);
+}
+
+.viewToggleBtnActive {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+[data-theme='dark'] .viewToggleBtnActive {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.viewToggleBtn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.artifactViewArea {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  background: #ffffff;
+}
+
+[data-theme='dark'] .artifactViewArea {
+  background: #0f1115;
+}
+
+.artifactIframe {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+  background: transparent;
+  color-scheme: light;
 }
 
 .codeSidePanelCopyBtn {
@@ -7453,92 +7519,6 @@
 }
 
 .codeOpenerArrow svg {
-  width: 16px;
-  height: 16px;
-}
-
-/* ===== Code Canvas Open Button ===== */
-.canvasOpenBtn {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  width: 100%;
-  margin-top: 8px;
-  padding: 10px 14px;
-  border-radius: 10px;
-  border: 1px solid var(--border-color);
-  background: var(--bg-secondary);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  animation: messageFadeIn 0.3s ease;
-}
-
-.canvasOpenBtn:hover {
-  background: var(--bg-hover);
-  border-color: var(--text-muted);
-  transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-}
-
-.canvasOpenBtn:active {
-  transform: scale(0.99);
-}
-
-.canvasOpenBtnLeft {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.canvasOpenBtnIcon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  background: var(--bg-active);
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-
-.canvasOpenBtnIcon svg {
-  width: 16px;
-  height: 16px;
-}
-
-.canvasOpenBtnText {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.canvasOpenBtnTitle {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-primary);
-  text-transform: capitalize;
-}
-
-.canvasOpenBtnMeta {
-  font-size: 11px;
-  color: var(--text-muted);
-  font-weight: 500;
-}
-
-.canvasOpenBtnArrow {
-  display: flex;
-  align-items: center;
-  color: var(--text-muted);
-  transition: color 0.15s ease;
-}
-
-.canvasOpenBtn:hover .canvasOpenBtnArrow {
-  color: var(--text-secondary);
-}
-
-.canvasOpenBtnArrow svg {
   width: 16px;
   height: 16px;
 }


### PR DESCRIPTION
## Summary
- Inline `ArtifactBlock` is now a single, always-visible opener card that opens the existing canvas side panel — no more hover-revealed toggles or broken in-chat renders.
- Visual mode renders inside a sandboxed iframe (`sandbox=""`, `srcdoc`), giving artifacts the full canvas width and isolated CSS while keeping XSS guarantees stronger than the previous DOMPurify path.
- Added a segmented eye/code toggle to the panel header; it appears only when the active block is an artifact and switches between rendered visual and syntax-highlighted source.
- Code and artifact blocks now share one ordered panel list, so a message can mix the two without misaligned openers, and the duplicate footer "code canvas" button is removed in favour of the inline opener already placed where each block lives.

## How it works
- `extractPanelBlocks` walks the message in document order and returns long code blocks + every HTML artifact, tagged with a `type`. `renderMarkdown` shares a single counter with that list so opener clicks always land on the correct block.
- `CodeSidePanel` keeps `viewMode` state. For artifacts the default is `visual`; for code it's always `source`. Highlighting only runs in source mode; the sidebar file list shows a distinct browser-frame icon for artifacts.
- Dark mode chrome is themed via existing CSS vars; iframe background flashes match the panel (`#0f1115` dark, white light) so there's no jarring transition before the artifact paints.

## Test plan
- [ ] Generate an HTML artifact — opener card appears inline, click opens canvas in visual mode.
- [ ] Toggle to source — syntax highlighting renders, line numbers visible.
- [ ] Toggle back to visual — iframe re-mounts, no flicker.
- [ ] Mid-stream artifact — opener shows "Building visual" spinner state until the closing fence arrives.
- [ ] Message with code + artifact — both openers appear inline in correct order, sidebar lists both with correct icons.
- [ ] Resize panel + collapse sidebar — iframe reflows without breaking.
- [ ] Mobile (<768px) — panel goes full-screen, iframe fills.
- [ ] Light and dark mode — toggle, sidebar, header, and footer all polished.
- [ ] Esc closes; switching chats clears the panel.

https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw)_