### PR TITLE
Stop canvas panel from crushing the chat column when expanded

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -847,6 +847,8 @@ const SIDEBAR_WIDTH_OPEN = 260;
 const SIDEBAR_WIDTH_COLLAPSED = 48;
 const MOBILE_BREAKPOINT = 768;
 const PANEL_MIN_WIDTH = 380;
+const PANEL_DEFAULT_MAX_WIDTH = 680; // mirrors .codeSidePanel max-width in the stylesheet
+const CHAT_MIN_WIDTH = 520; // floor for the chat column once the panel starts to overlay
 const PANEL_VIEWPORT_GAP = 12; // matches the panel's right inset (and the breathing room on the left)
 
 const defaultViewModeForBlock = (block) => (block?.type === 'artifact' ? 'visual' : 'source');
@@ -934,14 +936,33 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
   const renderedWidth =
     desiredWidth == null ? null : Math.min(Math.max(PANEL_MIN_WIDTH, desiredWidth), maxWidth);
 
-  // Publish the rendered width so the chat layout reserves the right amount of
-  // room. Fires on drag and on sidebar-driven clamping alike, which keeps the
-  // chat margin in sync without a custom call site for each.
+  // JS mirror of the .codeSidePanel CSS default (width: 50vw; max: 680; min: 380).
+  // Used to compute the chat reservation before the user drags, so the floor
+  // applies at the default size too.
+  const cssDefaultPanelWidth = Math.max(
+    PANEL_MIN_WIDTH,
+    Math.min(PANEL_DEFAULT_MAX_WIDTH, viewport.width * 0.5)
+  );
+  const paintedPanelWidth = renderedWidth ?? cssDefaultPanelWidth;
+
+  // Cap the space reserved for the panel in the chat layout so the chat column
+  // never shrinks below CHAT_MIN_WIDTH. Once the painted panel exceeds this cap
+  // it overlays the chat instead of squeezing it further. Mobile reserves
+  // nothing — the panel is full-screen via CSS.
+  const reservedSpaceCap = viewport.isMobile
+    ? 0
+    : Math.max(0, viewport.width - sidebarWidth - CHAT_MIN_WIDTH - PANEL_VIEWPORT_GAP * 2);
+  const reservedWidth = viewport.isMobile ? 0 : Math.min(paintedPanelWidth, reservedSpaceCap);
+
+  // Publish the reserved width so the chat layout reserves the right amount of
+  // room. Decoupled from the painted panel width so dragging past the threshold
+  // overlays the chat instead of crushing it. Fires on drag, sidebar toggle,
+  // viewport resize, and mobile-breakpoint flip alike.
   useEffect(() => {
-    if (renderedWidth != null && onWidthChange) {
-      onWidthChange(renderedWidth);
+    if (onWidthChange) {
+      onWidthChange(reservedWidth);
     }
-  }, [renderedWidth, onWidthChange]);
+  }, [reservedWidth, onWidthChange]);
 
   const activeBlock = codeBlocks[activeIdx];
   const isArtifact = activeBlock?.type === 'artifact';


### PR DESCRIPTION
## Summary
Fixes the regression where dragging the canvas side panel wider forced the chat column to shrink until it broke (letters wrapping vertically). Now the panel and the chat reservation are decoupled: the panel still paints up to the full viewport cap, but the chat column never drops below a readable minimum. Once the panel exceeds the reservation cap it overlays the chat instead of crushing it — the "expand until chat can't shrink, then overlay" behaviour from Claude / ChatGPT / v0.

## How it works
- Introduced `CHAT_MIN_WIDTH = 520` (the floor for the chat column) and `PANEL_DEFAULT_MAX_WIDTH = 680` (JS mirror of the CSS default).
- `renderedWidth` still drives the panel's painted width, capped by the existing `maxWidth` so painting respects the sidebar and viewport.
- New `reservedWidth = min(paintedPanelWidth, reservedSpaceCap)` is what's published to `--code-panel-width`. `reservedSpaceCap` clamps at `viewport − sidebar − CHAT_MIN_WIDTH − gap`.
- On mobile (≤768 px) the panel is already full-screen via CSS; reserved space is `0` so the chat behind doesn't pretend to reserve anything.
- Sidebar toggles, viewport resizes, and mobile-breakpoint flips all flow through the same derived values, so the chat reservation re-clamps in one place without extra wiring.

## What's untouched
- Sub-conversation panel reservation (`440px` in `MainContent.module.css`) — independent of `--code-panel-width`.
- Sources panel reservation (`400px`) — independent.
- Drag handler / sidebar layout / panel CSS / artifact iframe rendering — all unchanged.

## Test plan
- [ ] Open canvas on a 1280 px viewport, drag wide — chat stops shrinking around 520 px and panel overlays the right edge.
- [ ] Toggle sidebar mid-drag — both the painted width and the chat reservation re-clamp cleanly.
- [ ] Resize browser narrower while panel is wide — chat snaps to floor, panel overlays without jump.
- [ ] iPad portrait / narrow desktop (~810 px) — panel opens already in overlay mode; chat readable.
- [ ] Mobile (≤768 px) — panel still full-screen, no chat squeeze, no extra var pushed.
- [ ] Open sub-conv panel + canvas together — sub-conv reservation unaffected.
- [ ] Open sources panel + canvas together — sources reservation unaffected.
- [ ] Close panel — chat margin clears smoothly, no residual reservation.
- [ ] Light and dark mode parity.

https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw)_