### PR TITLE
Lift canvas panel above the composer and stop chat margin from lagging during drag

### DIFF
--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -27,10 +27,13 @@
 }
 
 /* When code side panel is open, make room on the right.
-   Uses --code-panel-width CSS var when user drags to resize, otherwise defaults. */
+   Uses --code-panel-width CSS var when user drags to resize, otherwise defaults.
+   The transition duration is driven by --code-panel-margin-duration so the
+   CodeSidePanel can suppress the chase animation during drag and keep the
+   chat margin locked to the cursor without a 350ms lag. */
 .main.codePanelOpen {
   margin-right: var(--code-panel-width, min(50vw, 700px));
-  transition: margin-right 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: margin-right var(--code-panel-margin-duration, 0.35s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* When sources panel is open, make room on the right (panel width + spacing) */

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -977,6 +977,22 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
     setViewMode(defaultViewModeForBlock(codeBlocks[safeInitialIdx]));
   }, [codeBlocks, safeInitialIdx]);
 
+  // Suppress the chat margin's 0.35s ease while the user is dragging the
+  // resize handle. The panel itself snaps via the .codeSidePanelResizing class;
+  // pinning the chat margin to 0s on the same tick keeps the two edges locked
+  // together instead of letting the chat chase the panel 350ms behind.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isResizing) {
+      root.style.setProperty('--code-panel-margin-duration', '0s');
+    } else {
+      root.style.removeProperty('--code-panel-margin-duration');
+    }
+    return () => {
+      root.style.removeProperty('--code-panel-margin-duration');
+    };
+  }, [isResizing]);
+
   useEffect(() => {
     const handleEsc = (e) => {
       if (e.key === 'Escape') onClose();

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -6850,7 +6850,10 @@
   width: 50vw;
   max-width: 680px;
   min-width: 380px;
-  z-index: 100;
+  /* Above the composer (1050) and message-list scroll buttons (1100)
+     so the panel paints over them once it overlays the chat. Stays
+     below the sidebar overlay (1180). Matches sourcesPanel/subConvPanel. */
+  z-index: 1150;
   background-color: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 16px;


### PR DESCRIPTION
## Summary
Two follow-ups to the canvas overlay work surfaced as soon as the panel started overlapping the chat:

1. **Composer / scroll buttons painted on top of the canvas.** The desktop `.codeSidePanel` used `z-index: 100`, but the composer (`1050`) and message-list scroll buttons (`1100`) sit higher. The moment the panel started overlaying, those surfaces broke through. The sources panel already uses `1150` for the same reason — the canvas now matches.
2. **Drag was jittery because the chat margin chased the panel with a 0.35 s ease.** The panel itself snaps to the cursor (existing `.codeSidePanelResizing` rule), but the chat margin animated on every drag tick and lagged the panel by a third of a second, creating the wobble. The transition duration is now driven by `--code-panel-margin-duration`; `CodeSidePanel` pins it to `0s` while `isResizing` is true and clears it on drag end (and on unmount). Open / close keep their original ease.

## What's untouched
- Painted-panel width math, reserved-space cap, sidebar interaction, mobile breakpoint — all unchanged.
- Sub-conversation and sources panel reservations — unaffected (they don't read either CSS variable).

## Test plan
- [ ] Drag the canvas wide and narrow on a 1280 px viewport — the chat right edge tracks the panel left edge perfectly, no lag, no wobble.
- [ ] In overlay mode, the canvas paints above the composer and the floating "scroll to bottom" button.
- [ ] Open and close the panel — chat margin still slides in with the smooth 350 ms ease.
- [ ] Resize the window mid-drag — panel and chat stay glued.
- [ ] Mobile (≤768 px) — unchanged; panel still full-screen, no margin var consumed.
- [ ] Sub-conv panel + canvas open together — sub-conv reservation untouched.

https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw)_