### PR TITLE
Fix iframe-blocked drag and give the canvas resize handle a clear pull

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -894,6 +894,7 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
   }));
   const codeRef = useRef(null);
   const panelRef = useRef(null);
+  const iframeRef = useRef(null);
   const isDraggingRef = useRef(false);
   const maxWidthRef = useRef(0);
 
@@ -1028,6 +1029,15 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
         ? panelRef.current.getBoundingClientRect().width
         : PANEL_MIN_WIDTH;
 
+      // The artifact iframe owns its own document and would otherwise capture
+      // mousemove/mouseup the moment the cursor enters its area — which
+      // happens immediately when the user drags rightward to shrink. Disable
+      // pointer events for the lifetime of the drag so events pass through to
+      // the document handlers below, then restore them on mouseup.
+      const iframe = iframeRef.current;
+      const previousIframePointerEvents = iframe ? iframe.style.pointerEvents : null;
+      if (iframe) iframe.style.pointerEvents = 'none';
+
       const handleMouseMove = (moveEvent) => {
         if (!isDraggingRef.current) return;
         const delta = startX - moveEvent.clientX;
@@ -1036,8 +1046,6 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
           Math.max(PANEL_MIN_WIDTH, startWidth + delta)
         );
         setDesiredWidth(newWidth);
-        // --code-panel-width is published from the renderedWidth effect, which
-        // covers both drag and sidebar-driven re-clamping in one place.
       };
 
       const handleMouseUp = () => {
@@ -1047,6 +1055,7 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
         document.removeEventListener('mouseup', handleMouseUp);
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
+        if (iframe) iframe.style.pointerEvents = previousIframePointerEvents ?? '';
       };
 
       document.body.style.cursor = 'col-resize';
@@ -1093,12 +1102,14 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
   return createPortal(
     <div className={panelClassName} ref={panelRef} style={panelStyle || undefined}>
       {/* Resize handle on the left edge */}
-      <div className={styles.codeSidePanelResizeHandle} onMouseDown={handleResizeStart}>
-        <div className={styles.codeSidePanelResizeGrip}>
-          <span />
-          <span />
-          <span />
-        </div>
+      <div
+        className={styles.codeSidePanelResizeHandle}
+        onMouseDown={handleResizeStart}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize panel"
+      >
+        <div className={styles.codeSidePanelResizeGrip} />
       </div>
 
       <div className={styles.codeSidePanelLayout}>
@@ -1218,6 +1229,7 @@ function CodeSidePanel({ codeBlocks, initialActiveIdx = 0, onClose, onWidthChang
             <div className={styles.artifactViewArea}>
               <iframe
                 key={`${activeIdx}-visual`}
+                ref={iframeRef}
                 className={styles.artifactIframe}
                 srcDoc={activeBlock.code}
                 sandbox=""

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -6892,44 +6892,51 @@
 .codeSidePanelResizeHandle {
   position: absolute;
   top: 0;
-  left: -4px;
+  left: -7px;
   bottom: 0;
-  width: 9px;
+  width: 14px;
   cursor: col-resize;
   z-index: 10;
   display: flex;
   align-items: center;
   justify-content: center;
+  touch-action: none;
 }
 
 .codeSidePanelResizeGrip {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 3px;
-  padding: 8px 2px;
-  border-radius: 6px;
-  opacity: 0.5;
-  transition: opacity 0.2s ease, background-color 0.2s ease;
-  background-color: transparent;
+  width: 4px;
+  height: 44px;
+  border-radius: 999px;
+  background-color: var(--border-color);
+  opacity: 0.85;
+  transition: background-color 0.18s ease, opacity 0.18s ease, height 0.2s ease, width 0.18s ease;
 }
 
 .codeSidePanelResizeHandle:hover .codeSidePanelResizeGrip {
-  opacity: 1;
-  background-color: var(--bg-hover);
-}
-
-.codeSidePanelResizeHandle:active .codeSidePanelResizeGrip {
-  opacity: 1;
-  background-color: var(--bg-active);
-}
-
-.codeSidePanelResizeGrip span {
-  display: block;
-  width: 3px;
-  height: 3px;
-  border-radius: 50%;
   background-color: var(--text-muted);
+  opacity: 1;
+  height: 56px;
+}
+
+.codeSidePanelResizeHandle:active .codeSidePanelResizeGrip,
+.codeSidePanelResizing .codeSidePanelResizeGrip {
+  background-color: var(--text-secondary);
+  opacity: 1;
+  width: 5px;
+  height: 60px;
+}
+
+[data-theme='dark'] .codeSidePanelResizeGrip {
+  background-color: rgba(255, 255, 255, 0.18);
+}
+
+[data-theme='dark'] .codeSidePanelResizeHandle:hover .codeSidePanelResizeGrip {
+  background-color: rgba(255, 255, 255, 0.4);
+}
+
+[data-theme='dark'] .codeSidePanelResizeHandle:active .codeSidePanelResizeGrip,
+[data-theme='dark'] .codeSidePanelResizing .codeSidePanelResizeGrip {
+  background-color: rgba(255, 255, 255, 0.65);
 }
 
 /* Root layout: sidebar + main content side by side */


### PR DESCRIPTION
## Summary
Two follow-ups on the canvas drag behaviour, both reported live by the user.

### 1. Reducing the canvas while the artifact visual is showing was stuck
The iframe owns its own document and was capturing `mousemove` / `mouseup` the moment the cursor crossed into its area. That's why expanding (drag leftward, cursor stays on the handle) worked but reducing (drag rightward, cursor enters the iframe) stalled — the parent `document` never saw the events.

`handleResizeStart` now flips the iframe's `pointer-events` to `none` via a ref for the lifetime of a drag, so the events fall through to the document handlers and reducing tracks the cursor 1:1. The previous value is captured and restored on `mouseup` regardless of where the cursor ends up, so nothing leaks.

### 2. The resize handle was too easy to miss
Replaced the three faint 3 px dots with a single rounded pull-bar (Claude-style):
- Always visible at a comfortable opacity.
- Hover: brighter colour, taller pill.
- While dragging: full prominence, slightly thicker.
- Hit area widened from 9 px to 14 px.
- Theme-aware colours so dark mode reads cleanly.
- `aria-label` + `role="separator"` on the handle for screen-reader users.

## What's untouched
- Width math, reserved-space cap, sidebar interaction, mobile breakpoint, z-index — all unchanged.
- Source view, copy/close buttons, view toggle, sidebar — unchanged.

## Test plan
- [ ] Open an artifact in visual mode and drag the handle rightward to shrink — tracks the cursor smoothly the whole way.
- [ ] Drag leftward to expand — still smooth.
- [ ] Click anywhere inside the iframe after dragging — page is interactive again (pointer-events restored).
- [ ] Hover the new pill — it grows and brightens; pressing keeps it at full prominence until release.
- [ ] Light and dark mode both look polished.
- [ ] Source mode drag — unchanged, still smooth.
- [ ] Mobile (≤768 px) — handle hidden via existing CSS, no change.

https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw)_