### PR TITLE
Auto-detect HTML documents so users see the visual without asking

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -233,7 +233,7 @@ function renderMarkdown(text, isStreaming = false, citations = null, panelOpener
         elements.push(<ComparisonBlock key={key++} spec={codeContent} isStreaming={isStreaming} />);
       } else if (lang === 'file') {
         elements.push(<FileBlock key={key++} spec={codeContent} isStreaming={isStreaming} />);
-      } else if (lang === 'artifact' || lang === 'html-artifact') {
+      } else if (isArtifactCandidate(lang, codeContent)) {
         if (!tryEmitPanelOpener(lang, codeContent)) {
           elements.push(<ArtifactBlock key={key++} spec={codeContent} isStreaming={isStreaming} />);
         }
@@ -770,6 +770,22 @@ function parseArtifactName(html) {
   return null;
 }
 
+const HTML_DOCTYPE_REGEX = /<!doctype\s+html/i;
+const HTML_OPEN_TAG_REGEX = /<html[\s>]/i;
+const HTML_CLOSE_TAG_REGEX = /<\/html\s*>/i;
+
+function isLikelyHtmlDocument(code) {
+  if (!code) return false;
+  if (HTML_DOCTYPE_REGEX.test(code)) return true;
+  return HTML_OPEN_TAG_REGEX.test(code) && HTML_CLOSE_TAG_REGEX.test(code);
+}
+
+function isArtifactCandidate(lang, code) {
+  if (lang === 'artifact' || lang === 'html-artifact') return true;
+  if (lang === 'html') return isLikelyHtmlDocument(code);
+  return false;
+}
+
 function extractContextName(textBefore) {
   const headingMatch = textBefore.match(
     /(?:^|\n)#{1,4}\s+(?:\d+\.\s+)?(?:\*\*)?([^\n*#]+?)(?:\*\*)?(?:\s*\([^)]*\))?\s*$/
@@ -811,7 +827,7 @@ function extractPanelBlocks(text) {
     const lang = m[1] || '';
     const code = m[2];
 
-    if (lang === 'artifact' || lang === 'html-artifact') {
+    if (isArtifactCandidate(lang, code)) {
       blocks.push({
         type: 'artifact',
         lang: 'html',


### PR DESCRIPTION
## Summary
When the model fenced its output as `\`\`\`html` instead of the explicit `\`\`\`artifact` wrapper, the block fell through to the regular code path and the visual/source toggle never showed — users had to follow up with "let me see the visual" every single time. Matching Claude / ChatGPT / Perplexity, a complete HTML document is now auto-promoted to an artifact so the canvas opens with the rendered preview by default.

## The rule
A block is treated as an artifact when:
- the model explicitly fenced it as `artifact` or `html-artifact`, **or**
- `lang` is `html` AND the body contains `<!DOCTYPE html` (case-insensitive), **or**
- `lang` is `html` AND the body contains both `<html` and `</html>`.

Snippets — single elements, fragments, anything without a document signal — stay inline as code. Conservative on purpose so we don't promote things like `<div>...</div>` into a full-screen iframe.

## Implementation
A single `isArtifactCandidate(lang, code)` helper is the only thing that decides, called from both `extractPanelBlocks` and `renderMarkdown` so the panel indices stay aligned and there's exactly one source of truth. No other state, no new components, no new patterns.

## Edge cases
- **Streaming with DOCTYPE first** — opener shows the "Building visual" spinner immediately; flips to clickable opener once the closing fence arrives.
- **Streaming before DOCTYPE** — renders inline as code at first; once the heuristic matches, swaps to the artifact opener at the same position. Single helper means no index drift.
- **`\`\`\`html` with just a fragment** — stays as code. No regression for embedding snippets.
- **Existing `artifact` / `html-artifact` blocks** — untouched; the explicit path still wins.
- **Case variations** — `<!DOCTYPE`, `<!doctype`, mixed case all match.
- **Sub-conversation / shared view contexts** — same disabled-opener fallback already in place.

## What's untouched
Canvas, drag, view-mode toggle, iframe sandbox, width math, sidebar, sub-conv panel, sources panel, mobile breakpoint — all unchanged.

## Test plan
- [ ] Ask the model for an HTML landing page (`\`\`\`html` fenced) — opener appears with the visual already available; canvas opens in visual mode.
- [ ] Ask for an HTML snippet (`\`\`\`html` with just `<div>...</div>`) — stays as a plain code block.
- [ ] Existing `\`\`\`artifact` flows — no change.
- [ ] Stream a long HTML page — opener shows the spinner during stream, becomes interactive on completion.
- [ ] Mix of long code + HTML doc in one message — both openers appear in order; sidebar lists both with correct icons; toggle adapts per active block.
- [ ] Light / dark mode unchanged.
- [ ] Mobile unchanged.

https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw)_