### PR TITLE
Make the canvas resize handle clearly visible

### DIFF
--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -6892,9 +6892,9 @@
 .codeSidePanelResizeHandle {
   position: absolute;
   top: 0;
-  left: -7px;
+  left: -8px;
   bottom: 0;
-  width: 14px;
+  width: 16px;
   cursor: col-resize;
   z-index: 10;
   display: flex;
@@ -6904,39 +6904,48 @@
 }
 
 .codeSidePanelResizeGrip {
-  width: 4px;
-  height: 44px;
+  width: 5px;
+  height: 64px;
   border-radius: 999px;
-  background-color: var(--border-color);
-  opacity: 0.85;
-  transition: background-color 0.18s ease, opacity 0.18s ease, height 0.2s ease, width 0.18s ease;
+  background-color: var(--text-muted);
+  opacity: 0.55;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  transition: background-color 0.18s ease, opacity 0.18s ease, height 0.22s ease, width 0.18s ease,
+    box-shadow 0.18s ease;
 }
 
 .codeSidePanelResizeHandle:hover .codeSidePanelResizeGrip {
-  background-color: var(--text-muted);
+  background-color: var(--text-secondary);
   opacity: 1;
-  height: 56px;
+  height: 80px;
+  width: 6px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
 }
 
 .codeSidePanelResizeHandle:active .codeSidePanelResizeGrip,
 .codeSidePanelResizing .codeSidePanelResizeGrip {
-  background-color: var(--text-secondary);
+  background-color: var(--text-primary);
   opacity: 1;
-  width: 5px;
-  height: 60px;
+  width: 6px;
+  height: 88px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
 }
 
 [data-theme='dark'] .codeSidePanelResizeGrip {
-  background-color: rgba(255, 255, 255, 0.18);
+  background-color: rgba(255, 255, 255, 0.32);
+  opacity: 1;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 
 [data-theme='dark'] .codeSidePanelResizeHandle:hover .codeSidePanelResizeGrip {
-  background-color: rgba(255, 255, 255, 0.4);
+  background-color: rgba(255, 255, 255, 0.55);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
 [data-theme='dark'] .codeSidePanelResizeHandle:active .codeSidePanelResizeGrip,
 [data-theme='dark'] .codeSidePanelResizing .codeSidePanelResizeGrip {
-  background-color: rgba(255, 255, 255, 0.65);
+  background-color: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.55);
 }
 
 /* Root layout: sidebar + main content side by side */


### PR DESCRIPTION
## Summary
The canvas resize grip was rendered at 4 × 44 px on `--border-color` at 0.85 opacity — almost invisible against the panel edge unless you already knew where to look. Users couldn't tell the panel was draggable.

Now it reads as an intentional pull-bar at all times:

- **Default**: 5 × 64 px pill on `--text-muted` at 0.55 opacity with a soft 1px shadow.
- **Hover**: grows to 6 × 80 px, jumps to `--text-secondary` at full opacity, deeper shadow.
- **Active / dragging**: 6 × 88 px on `--text-primary`, strongest shadow.
- **Dark mode**: bright white tokens (0.32 → 0.55 → 0.78) so it reads against the dark chrome.
- **Hit area**: widened from 14 px to 16 px for easier grabbing without nudging.

Smooth 180 ms easing on every state so it feels alive, not jumpy.

## What's untouched
Drag logic, width math, iframe inert behaviour, panel layout, all other handles — unchanged. CSS-only diff in a single file.

## Test plan
- [ ] Open the canvas — pull-bar visible at rest, no hover required.
- [ ] Hover over it — grows and brightens; cursor flips to `col-resize`.
- [ ] Drag — grip stays at full prominence until release.
- [ ] Light and dark mode both look polished.
- [ ] Mobile (≤768 px) — handle hidden via existing CSS, no regression.

https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw)_