### PR TITLE
Make the canvas resize handle thicker, not taller

### DIFF
--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -6892,9 +6892,9 @@
 .codeSidePanelResizeHandle {
   position: absolute;
   top: 0;
-  left: -8px;
+  left: -10px;
   bottom: 0;
-  width: 16px;
+  width: 20px;
   cursor: col-resize;
   z-index: 10;
   display: flex;
@@ -6904,48 +6904,48 @@
 }
 
 .codeSidePanelResizeGrip {
-  width: 5px;
-  height: 64px;
+  width: 8px;
+  height: 56px;
   border-radius: 999px;
-  background-color: var(--text-muted);
-  opacity: 0.55;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  background-color: var(--text-secondary);
+  opacity: 0.75;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   transition: background-color 0.18s ease, opacity 0.18s ease, height 0.22s ease, width 0.18s ease,
     box-shadow 0.18s ease;
 }
 
 .codeSidePanelResizeHandle:hover .codeSidePanelResizeGrip {
-  background-color: var(--text-secondary);
+  background-color: var(--text-primary);
   opacity: 1;
-  height: 80px;
-  width: 6px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  height: 64px;
+  width: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.16);
 }
 
 .codeSidePanelResizeHandle:active .codeSidePanelResizeGrip,
 .codeSidePanelResizing .codeSidePanelResizeGrip {
   background-color: var(--text-primary);
   opacity: 1;
-  width: 6px;
-  height: 88px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  width: 11px;
+  height: 72px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.22);
 }
 
 [data-theme='dark'] .codeSidePanelResizeGrip {
-  background-color: rgba(255, 255, 255, 0.32);
+  background-color: rgba(255, 255, 255, 0.45);
   opacity: 1;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
 }
 
 [data-theme='dark'] .codeSidePanelResizeHandle:hover .codeSidePanelResizeGrip {
-  background-color: rgba(255, 255, 255, 0.55);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+  background-color: rgba(255, 255, 255, 0.7);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.55);
 }
 
 [data-theme='dark'] .codeSidePanelResizeHandle:active .codeSidePanelResizeGrip,
 [data-theme='dark'] .codeSidePanelResizing .codeSidePanelResizeGrip {
-  background-color: rgba(255, 255, 255, 0.78);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.55);
+  background-color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
 }
 
 /* Root layout: sidebar + main content side by side */


### PR DESCRIPTION
## Summary
Previous attempt grew the grip taller without fixing the actual problem — it still read as a thin line. Flipping the priority: **width drives prominence now**, height stays proportional.

| State | Width | Height |
| --- | --- | --- |
| Default | 8 px | 56 px |
| Hover | 10 px | 64 px |
| Active / dragging | 11 px | 72 px |

Hit area widened 16 → 20 px. Slightly heavier shadow at hover / active for depth. Tokens unchanged (`--text-secondary` → `--text-primary`); dark mode whites bumped 0.45 → 0.7 → 0.9 to match the brighter visual weight.

## What's untouched
Drag logic, width math, panel layout, other handles — all unchanged. CSS-only diff in a single block.

## Test plan
- [ ] Open the canvas — pull-bar reads as a chunky pill, not a line.
- [ ] Hover — fattens to 10 px, full opacity.
- [ ] Drag — holds at 11 px with deeper shadow.
- [ ] Light and dark mode both look polished.

https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnT8JQykBbT9sWCGykQopw)_