### PR TITLE
Allow sending image-only messages without accompanying text

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -124,6 +124,7 @@ import { getNextTier, getUpgradeCtaLabel } from '../../config/subscription';
 import { PROVIDERS, isImageGenerationModel } from '../../data/models';
 import { getProviderLogo } from '../getProviderLogo';
 import { compressImage, isAcceptedImageType } from '../../utils/imageCompression';
+import { takePendingAttachments } from '../../utils/pendingAttachments';
 import {
   canGenerateImage,
   recordGeneration,
@@ -1675,7 +1676,7 @@ export default function MainContent() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     const prompt = inputValue.trim();
-    if (!prompt || isProcessing) return;
+    if ((!prompt && attachedFiles.length === 0) || isProcessing) return;
 
     // Determine if this prompt will generate an image
     const willGenerateImage =
@@ -1802,27 +1803,32 @@ export default function MainContent() {
     dispatch(revertQuickPromptImageOverride());
   };
 
-  // Auto-submit when navigating from another view (e.g. Image Gallery quick prompt).
-  // Uses a ref guard to guarantee this fires exactly once, even with StrictMode.
-  const autoSubmitFiredRef = useRef(null);
+  // Auto-submit when navigating from another view (e.g. Image Gallery quick
+  // prompt, Project workspace). Picks up any handed-off attachments from the
+  // pending-attachments cache so a file uploaded in another view travels with
+  // the message. The fired flag is reset when pendingAutoSubmit goes false so
+  // the next cycle can fire, while still guarding against StrictMode double-runs.
+  const autoSubmitFiredRef = useRef(false);
   useEffect(() => {
-    if (!pendingAutoSubmit || !inputValue.trim() || isProcessing) return;
-    // Guard: skip if we already fired for this exact prompt
-    const prompt = inputValue.trim();
-    if (autoSubmitFiredRef.current === prompt) return;
-    autoSubmitFiredRef.current = prompt;
-    const modality = pendingModality || undefined;
+    if (!pendingAutoSubmit) {
+      autoSubmitFiredRef.current = false;
+      return;
+    }
+    if (isProcessing || autoSubmitFiredRef.current) return;
 
-    // Sync ModalityBar when coming from image gallery
+    const prompt = inputValue.trim();
+    const handedOffFiles = takePendingAttachments();
+    if (!prompt && handedOffFiles.length === 0) return;
+    autoSubmitFiredRef.current = true;
+
+    const modality = pendingModality || undefined;
     if (modality === 'image') {
       dispatch(setSelectedModality('image'));
     }
 
-    // Check image generation limits before auto-submitting
     const willGenImage =
       modality === 'image' || (selectedModelId && isImageGenerationModel(selectedModelId));
 
-    // Guest image limit — bounce to /signup, not "Upgrade to Pro"
     if (!isAuthenticated && willGenImage && hasReachedGuestImageLimit()) {
       dispatch(setPendingAutoSubmit(false));
       dispatch(setPendingModality(null));
@@ -1830,7 +1836,6 @@ export default function MainContent() {
       return;
     }
 
-    // Authenticated user image rate limit: if balance has loaded and is zero, show modal
     if (
       isAuthenticated &&
       willGenImage &&
@@ -1849,13 +1854,31 @@ export default function MainContent() {
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-    runSSEPipeline(prompt, {
-      selectedModelId: selectedModelId || undefined,
-      addUserMessage: true,
-      webSearch: webSearchEnabled,
-      modality,
-      imageQuality: willGenImage ? imageQuality : undefined,
-    });
+
+    (async () => {
+      let compressedImages = [];
+      const imageFiles = handedOffFiles.filter(isAcceptedImageType);
+      if (imageFiles.length > 0) {
+        try {
+          compressedImages = await Promise.all(imageFiles.map((f) => compressImage(f)));
+        } catch (err) {
+          logger.warn('Image compression failed', {
+            route: 'chat.auto-submit',
+            error: err?.message,
+          });
+          compressedImages = [];
+        }
+      }
+      runSSEPipeline(prompt, {
+        selectedModelId: selectedModelId || undefined,
+        addUserMessage: true,
+        webSearch: webSearchEnabled,
+        modality,
+        imageQuality: willGenImage ? imageQuality : undefined,
+        conversationHasImages: compressedImages.length > 0 || undefined,
+        images: compressedImages.length > 0 ? compressedImages : undefined,
+      });
+    })();
   }, [pendingAutoSubmit]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
@@ -3273,8 +3296,10 @@ export default function MainContent() {
                   ) : (
                     <button
                       type="submit"
-                      className={`${styles.submitBtn} ${inputValue.trim() ? styles.active : ''}`}
-                      disabled={!inputValue.trim()}
+                      className={`${styles.submitBtn} ${
+                        inputValue.trim() || attachedFiles.length > 0 ? styles.active : ''
+                      }`}
+                      disabled={!inputValue.trim() && attachedFiles.length === 0}
                       aria-label="Send message"
                     >
                       <SendIcon />

--- a/src/components/ProjectsView/ProjectsView.jsx
+++ b/src/components/ProjectsView/ProjectsView.jsx
@@ -21,6 +21,7 @@ import {
   setPendingAutoSubmit,
   setActiveProjectId,
 } from '../../store/slices/chatSlice';
+import { setPendingAttachments } from '../../utils/pendingAttachments';
 import {
   fetchProjects,
   createProject as createProjectApi,
@@ -288,8 +289,8 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
   const handleSendMessage = (e) => {
     e.preventDefault();
     const text = chatInput.trim();
-    if (!text) return;
-    // Navigate to MainContent with the message ready to send
+    if (!text && attachedFiles.length === 0) return;
+    setPendingAttachments(attachedFiles);
     dispatch(createNewChat());
     dispatch(setActiveProjectId(project.id));
     dispatch(setInputValue(text));
@@ -504,9 +505,9 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
                     <button
                       type="submit"
                       className={`${styles.wsChatSend} ${
-                        chatInput.trim() ? styles.wsChatSendActive : ''
+                        chatInput.trim() || attachedFiles.length > 0 ? styles.wsChatSendActive : ''
                       }`}
-                      disabled={!chatInput.trim()}
+                      disabled={!chatInput.trim() && attachedFiles.length === 0}
                       aria-label="Send message"
                     >
                       <SendIcon />

--- a/src/utils/pendingAttachments.js
+++ b/src/utils/pendingAttachments.js
@@ -1,0 +1,15 @@
+let pending = [];
+
+export const setPendingAttachments = (files) => {
+  pending = Array.isArray(files) ? files.filter((f) => f instanceof File) : [];
+};
+
+export const takePendingAttachments = () => {
+  const out = pending;
+  pending = [];
+  return out;
+};
+
+export const clearPendingAttachments = () => {
+  pending = [];
+};

--- a/src/utils/pendingAttachments.test.js
+++ b/src/utils/pendingAttachments.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setPendingAttachments,
+  takePendingAttachments,
+  clearPendingAttachments,
+} from './pendingAttachments';
+
+const makeFile = (name = 'a.png', type = 'image/png') =>
+  new File([new Uint8Array([0])], name, { type });
+
+describe('pendingAttachments cache', () => {
+  beforeEach(() => clearPendingAttachments());
+
+  it('returns an empty array when nothing has been set', () => {
+    expect(takePendingAttachments()).toEqual([]);
+  });
+
+  it('stores and returns set files', () => {
+    const files = [makeFile('one.png'), makeFile('two.jpg', 'image/jpeg')];
+    setPendingAttachments(files);
+    expect(takePendingAttachments()).toEqual(files);
+  });
+
+  it('clears the cache after take so a second take returns empty', () => {
+    setPendingAttachments([makeFile()]);
+    takePendingAttachments();
+    expect(takePendingAttachments()).toEqual([]);
+  });
+
+  it('overwrites previously stashed files on a subsequent set', () => {
+    setPendingAttachments([makeFile('old.png')]);
+    const next = [makeFile('new.png')];
+    setPendingAttachments(next);
+    expect(takePendingAttachments()).toEqual(next);
+  });
+
+  it('ignores non-File entries defensively', () => {
+    setPendingAttachments([makeFile('valid.png'), 'not-a-file', null, undefined, 42]);
+    const result = takePendingAttachments();
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('valid.png');
+  });
+
+  it('treats a non-array input as empty', () => {
+    setPendingAttachments(null);
+    expect(takePendingAttachments()).toEqual([]);
+    setPendingAttachments('files');
+    expect(takePendingAttachments()).toEqual([]);
+  });
+
+  it('clearPendingAttachments empties the cache', () => {
+    setPendingAttachments([makeFile()]);
+    clearPendingAttachments();
+    expect(takePendingAttachments()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The send button on the main chat input and the project workspace input was disabled whenever the textarea was empty, even when one or more files were attached. This blocked the "drop an image, hit send, ask the model to describe it" flow that ChatGPT, Claude, and Gemini all support.

- Send is now enabled when either the trimmed text **or** the attachment list is non-empty, in both the main chat input and the project workspace input. The matching submit-handler guards were relaxed to match.
- The project workspace previously dropped attachments on the Redux handoff to the main chat (File objects don't survive a serializable store). A small module-level cache (`utils/pendingAttachments`) now carries the File objects across the navigation. The auto-submit pipeline takes them, compresses any accepted images via the existing `compressImage` helper, and ships them with the first message.
- The auto-submit `firedRef` was reworked into a per-cycle boolean (reset when `pendingAutoSubmit` goes false). The old prompt-string fingerprint would have falsely skipped a legitimate image-only message because an empty trimmed prompt equals the previous empty prompt.
- ImageGalleryView was intentionally left untouched — its quick-prompt flow is text-driven.

## Test plan

- [x] `npm test -- --run src/utils/pendingAttachments.test.js` — new unit tests for set/take/clear behaviour
- [x] `npm test -- --run` — full suite green (one pre-existing `authSlice` failure unrelated to this change)
- [x] `npx eslint` on touched files — no new warnings
- [x] `npm run build` — production build succeeds
- [x] Manual: main chat — attach an image with no text, send, verify the image appears in the user bubble and the model responds
- [ ] Manual: main chat — attach an image AND type text, send, verify both go through
- [ ] Manual: main chat — empty text and no attachments, verify send stays disabled
- [ ] Manual: project workspace — attach a file with no text, send, verify it auto-submits in main chat with the file attached
- [ ] Manual: project workspace — attach a file with text, send, verify both travel through the handoff
- [ ] Manual: image gallery quick-prompt flow still works unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_