### PR TITLE
Display attached images in the user bubble with a count-aware grid

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -5273,6 +5273,18 @@ function UserPrompt({ content, images, onEdit, createdAt, onRetry }) {
     return images;
   }, [images]);
 
+  const imageGridLayoutClass = useMemo(() => {
+    if (!imageList) return '';
+    const n = imageList.length;
+    if (n === 1) return styles.userPromptImagesGrid1;
+    if (n === 2) return styles.userPromptImagesGrid2;
+    if (n === 3) return styles.userPromptImagesGrid3;
+    if (n === 4) return styles.userPromptImagesGrid4;
+    return styles.userPromptImagesGridMany;
+  }, [imageList]);
+
+  const isSingleImage = imageList?.length === 1;
+
   useEffect(() => {
     const lineCount = (content || '').split('\n').length;
     setIsLong(lineCount > LINE_LIMIT);
@@ -5312,11 +5324,17 @@ function UserPrompt({ content, images, onEdit, createdAt, onRetry }) {
     <div className={styles.userPromptWrapper}>
       <div className={styles.userPromptCard}>
         {imageList && (
-          <div className={styles.userPromptImages}>
+          <div
+            className={`${styles.userPromptImages} ${imageGridLayoutClass} ${
+              content ? '' : styles.userPromptImagesNoText
+            }`}
+          >
             {imageList.map((img, idx) => (
               <button
                 key={idx}
-                className={styles.userPromptImageThumb}
+                className={
+                  isSingleImage ? styles.userPromptImageSingle : styles.userPromptImageTile
+                }
                 onClick={() => setLightboxIdx(idx)}
                 aria-label={img.fileName || `Attached image ${idx + 1}`}
               >

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -78,32 +78,119 @@
 }
 
 .userPromptImages {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  display: grid;
+  gap: 4px;
   margin-bottom: 10px;
 }
 
-.userPromptImageThumb {
-  all: unset;
-  cursor: pointer;
-  width: 120px;
-  height: 120px;
-  border-radius: 8px;
-  overflow: hidden;
-  flex-shrink: 0;
+.userPromptImagesNoText {
+  margin-bottom: 0;
 }
 
-.userPromptImageThumb img {
+.userPromptImagesGrid1 {
+  max-width: 360px;
+  grid-template-columns: 1fr;
+}
+
+.userPromptImagesGrid2 {
+  width: 360px;
+  max-width: 100%;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.userPromptImagesGrid3 {
+  width: 360px;
+  max-width: 100%;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.userPromptImagesGrid4 {
+  width: 360px;
+  max-width: 100%;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.userPromptImagesGridMany {
+  width: 360px;
+  max-width: 100%;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.userPromptImageTile {
+  all: unset;
+  cursor: pointer;
+  display: block;
+  aspect-ratio: 1 / 1;
+  border-radius: 10px;
+  overflow: hidden;
+  position: relative;
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+[data-theme='dark'] .userPromptImageTile {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.userPromptImageTile img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   display: block;
-  transition: transform 0.15s ease;
+  transition: transform 0.2s ease;
 }
 
-.userPromptImageThumb:hover img {
-  transform: scale(1.04);
+.userPromptImageTile:hover img {
+  transform: scale(1.05);
+}
+
+.userPromptImageTile:focus-visible {
+  outline: 2px solid var(--accent, #4a90e2);
+  outline-offset: 2px;
+}
+
+.userPromptImageSingle {
+  all: unset;
+  cursor: pointer;
+  display: inline-block;
+  border-radius: 12px;
+  overflow: hidden;
+  line-height: 0;
+  max-width: 100%;
+}
+
+.userPromptImageSingle img {
+  display: block;
+  max-width: 360px;
+  max-height: 360px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  transition: transform 0.2s ease;
+}
+
+.userPromptImageSingle:hover img {
+  transform: scale(1.02);
+}
+
+.userPromptImageSingle:focus-visible {
+  outline: 2px solid var(--accent, #4a90e2);
+  outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+  .userPromptImagesGrid1,
+  .userPromptImagesGrid2,
+  .userPromptImagesGrid3,
+  .userPromptImagesGrid4,
+  .userPromptImagesGridMany {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .userPromptImageSingle img {
+    max-width: 100%;
+    max-height: 320px;
+  }
 }
 
 .imageLightbox {


### PR DESCRIPTION
## Summary

The user bubble used to render attached images as a flat row of 120×120 thumbs regardless of how many were attached — one image looked tiny, ten images wrapped awkwardly. The bubble now picks a layout based on the count, matching how ChatGPT / Claude / Gemini render attachments.

- **1 image** → hero preview, aspect ratio preserved, capped at 360×360
- **2 images** → 2-column 1:1 grid
- **3 images** → 3-column 1:1 grid
- **4 images** → 2×2 1:1 grid
- **5–10** → 3-column 1:1 grid

All tile-mode renders use `object-fit: cover` with a subtle scale-on-hover. The single-image render uses `object-fit: contain` so portrait and landscape photos keep their aspect. Both modes have `focus-visible` outlines for keyboard nav and dark-theme aware placeholder backgrounds while images decode. The whole image block also drops its trailing margin when there is no text below, so an image-only message stops sitting in a half-padded bubble.

A `max-width: 480px` breakpoint lets the grid fill the bubble on phones and caps the single-image height to 320 px.

Click-to-lightbox behaviour is unchanged.

## Test plan

- [x] `npx eslint src/components/MessageList/MessageList.jsx` — no new warnings
- [x] `npm test -- --run` — full suite green (one pre-existing `authSlice` failure unrelated to this change)
- [x] `npm run build` — production build succeeds
- [ ] Manual: send a single landscape image, verify aspect preserved at ≤360 px
- [ ] Manual: send a single portrait image, verify aspect preserved, capped at 360 px tall
- [ ] Manual: send 2 / 3 / 4 / 5 / 10 images, verify grid swaps cleanly at each boundary
- [ ] Manual: send image with no text, verify no extra bottom padding inside the bubble
- [ ] Manual: send image with text, verify image sits above text with a tidy gap
- [ ] Manual: keyboard tab through tiles, verify focus rings show
- [ ] Manual: on phone (≤480 px), verify the grid fills the bubble width and feels right
- [ ] Manual: click any image, lightbox still opens to that one

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_