### PR TITLE
Add drag-and-drop and clipboard-paste file attachment to chat inputs

### DIFF
--- a/src/components/DropOverlay/DropOverlay.jsx
+++ b/src/components/DropOverlay/DropOverlay.jsx
@@ -1,0 +1,28 @@
+import styles from './DropOverlay.module.css';
+
+export default function DropOverlay({ visible, label = 'Drop to attach' }) {
+  if (!visible) return null;
+  return (
+    <div className={styles.overlay} aria-hidden="true">
+      <div className={styles.card}>
+        <svg
+          className={styles.icon}
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M21.44 11.05l-9.19 9.19a6 6 0 01-8.49-8.49l9.19-9.19a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        <span className={styles.label}>{label}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DropOverlay/DropOverlay.module.css
+++ b/src/components/DropOverlay/DropOverlay.module.css
@@ -1,0 +1,61 @@
+.overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  background-color: color-mix(in srgb, var(--accent, #4a90e2) 10%, transparent);
+  backdrop-filter: blur(2px);
+  border: 2px dashed var(--accent, #4a90e2);
+  border-radius: 16px;
+  margin: 12px;
+  animation: dropOverlayFadeIn 0.16s ease;
+}
+
+.card {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  border-radius: 999px;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.1px;
+}
+
+.icon {
+  color: var(--accent, #4a90e2);
+  flex-shrink: 0;
+}
+
+.label {
+  white-space: nowrap;
+}
+
+@keyframes dropOverlayFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.995);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (max-width: 480px) {
+  .overlay {
+    margin: 6px;
+    border-radius: 12px;
+  }
+  .card {
+    padding: 10px 16px;
+    font-size: 13px;
+  }
+}

--- a/src/components/DropOverlay/index.js
+++ b/src/components/DropOverlay/index.js
@@ -1,0 +1,1 @@
+export { default } from './DropOverlay';

--- a/src/components/ImageGalleryView/ImageGalleryView.jsx
+++ b/src/components/ImageGalleryView/ImageGalleryView.jsx
@@ -47,6 +47,10 @@ import {
 import ModelSelector from '../ModelSelector/ModelSelector';
 import styles from './ImageGalleryView.module.css';
 import MarkdownTextarea from '../MarkdownTextarea/MarkdownTextarea';
+import useFileDrop from '../../hooks/useFileDrop';
+import usePasteImages from '../../hooks/usePasteImages';
+import DropOverlay from '../DropOverlay';
+import { setPendingAttachments } from '../../utils/pendingAttachments';
 
 const PAGE_SIZE = 9;
 
@@ -359,6 +363,28 @@ export default function ImageGalleryView() {
     }
   };
 
+  const handleDroppedFiles = useCallback(
+    (incoming) => {
+      if (!incoming || incoming.length === 0) return;
+      setShowAttachMenu(false);
+      setPendingAttachments(incoming);
+      const text = promptInput.trim();
+      setPromptInput('');
+      dispatch(createNewChat());
+      dispatch(setInputValue(text));
+      dispatch(setPendingAutoSubmit(true));
+      navigate('/');
+    },
+    [promptInput, dispatch, navigate]
+  );
+
+  const dropTargetRef = useRef(null);
+  const { isDragging } = useFileDrop(dropTargetRef, {
+    onFiles: handleDroppedFiles,
+    enabled: true,
+  });
+  usePasteImages({ onFiles: handleDroppedFiles, enabled: true });
+
   const handleQuickPromptClick = (item) => {
     // Allow guests to preview the prompt — gate happens on submit
     setPromptInput(item.prompt);
@@ -383,7 +409,8 @@ export default function ImageGalleryView() {
   const remaining = filteredImages.length - displayedCount;
 
   return (
-    <div className={styles.galleryPage}>
+    <div className={styles.galleryPage} ref={dropTargetRef}>
+      <DropOverlay visible={isDragging} label="Drop image to attach" />
       <div className={styles.galleryInner}>
         {/* Hero */}
         <div className={styles.heroSection}>
@@ -802,7 +829,6 @@ export default function ImageGalleryView() {
           />,
           document.body
         )}
-
     </div>
   );
 }

--- a/src/components/ImageGalleryView/ImageGalleryView.module.css
+++ b/src/components/ImageGalleryView/ImageGalleryView.module.css
@@ -6,6 +6,7 @@
   background: var(--bg-primary);
   scrollbar-width: none;
   -ms-overflow-style: none;
+  position: relative;
 }
 
 .galleryPage::-webkit-scrollbar {

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -125,6 +125,9 @@ import { PROVIDERS, isImageGenerationModel } from '../../data/models';
 import { getProviderLogo } from '../getProviderLogo';
 import { compressImage, isAcceptedImageType } from '../../utils/imageCompression';
 import { takePendingAttachments } from '../../utils/pendingAttachments';
+import useFileDrop from '../../hooks/useFileDrop';
+import usePasteImages from '../../hooks/usePasteImages';
+import DropOverlay from '../DropOverlay';
 import {
   canGenerateImage,
   recordGeneration,
@@ -659,6 +662,7 @@ export default function MainContent() {
   const chatMenuRef = useRef(null);
   const textareaRef = useRef(null);
   const fileInputRef = useRef(null);
+  const dropTargetRef = useRef(null);
   const cameraInputRef = useRef(null);
 
   // Derive conversationProject from Redux conversations (single source of truth)
@@ -2090,30 +2094,41 @@ export default function MainContent() {
     return colors[ext] || '#6b7280';
   };
 
+  const handleAttachFiles = useCallback(
+    (incomingFiles) => {
+      if (!incomingFiles || incomingFiles.length === 0) return;
+      const remainingSlots = maxAttachments - attachedFiles.length;
+      if (remainingSlots <= 0) {
+        setShowLimitToast(true);
+        return;
+      }
+      const filesToAdd = incomingFiles.slice(0, remainingSlots);
+      if (filesToAdd.length < incomingFiles.length) {
+        setShowLimitToast(true);
+      }
+      const newFiles = filesToAdd.map((file) => ({
+        id: `file-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        file,
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
+      }));
+      setAttachedFiles((prev) => [...prev, ...newFiles]);
+    },
+    [attachedFiles.length, maxAttachments]
+  );
+
   const handleFileSelect = (e) => {
-    const files = Array.from(e.target.files || []);
-    if (!files.length) return;
-    const remainingSlots = maxAttachments - attachedFiles.length;
-    if (remainingSlots <= 0) {
-      setShowLimitToast(true);
-      if (e.target) e.target.value = '';
-      return;
-    }
-    const filesToAdd = files.slice(0, remainingSlots);
-    if (filesToAdd.length < files.length) {
-      setShowLimitToast(true);
-    }
-    const newFiles = filesToAdd.map((file) => ({
-      id: `file-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      file,
-      name: file.name,
-      type: file.type,
-      size: file.size,
-      preview: file.type.startsWith('image/') ? URL.createObjectURL(file) : null,
-    }));
-    setAttachedFiles((prev) => [...prev, ...newFiles]);
+    handleAttachFiles(Array.from(e.target.files || []));
     if (e.target) e.target.value = '';
   };
+
+  const { isDragging } = useFileDrop(dropTargetRef, {
+    onFiles: handleAttachFiles,
+    enabled: !isProcessing,
+  });
+  usePasteImages({ onFiles: handleAttachFiles, enabled: !isProcessing });
 
   const handleRemoveFile = (fileId) => {
     setAttachedFiles((prev) => {
@@ -2316,12 +2331,14 @@ export default function MainContent() {
 
   return (
     <main
+      ref={dropTargetRef}
       className={`${styles.main} ${hasMessages ? styles.hasMessages : ''} ${
         isSubConvPanelOpen ? styles.subConvPanelOpen : ''
       } ${isCodePanelOpen ? styles.codePanelOpen : ''} ${
         isSourcesPanelOpen ? styles.sourcesPanelOpen : ''
       }`}
     >
+      <DropOverlay visible={isDragging} />
       {/* Top nav bar */}
       <div className={styles.topNav}>
         {/* Breadcrumb — title + project context */}

--- a/src/components/ProjectsView/ProjectsView.jsx
+++ b/src/components/ProjectsView/ProjectsView.jsx
@@ -22,6 +22,9 @@ import {
   setActiveProjectId,
 } from '../../store/slices/chatSlice';
 import { setPendingAttachments } from '../../utils/pendingAttachments';
+import useFileDrop from '../../hooks/useFileDrop';
+import usePasteImages from '../../hooks/usePasteImages';
+import DropOverlay from '../DropOverlay';
 import {
   fetchProjects,
   createProject as createProjectApi,
@@ -298,6 +301,18 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
     navigate('/');
   };
 
+  const handleAttachFiles = useCallback((incoming) => {
+    if (!incoming || incoming.length === 0) return;
+    setAttachedFiles((prev) => [...prev, ...incoming]);
+  }, []);
+
+  const dropTargetRef = useRef(null);
+  const { isDragging } = useFileDrop(dropTargetRef, {
+    onFiles: handleAttachFiles,
+    enabled: true,
+  });
+  usePasteImages({ onFiles: handleAttachFiles, enabled: true });
+
   const handleKeyDown = (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -318,7 +333,8 @@ function ProjectWorkspace({ project, onBack, onEdit, onDelete, onToggleStar, onT
 
   return (
     <>
-      <div className={styles.workspacePage}>
+      <div className={styles.workspacePage} ref={dropTargetRef}>
+        <DropOverlay visible={isDragging} />
         {/* Back nav */}
         <div className={styles.workspaceTopBar}>
           <button className={styles.detailBack} onClick={onBack}>

--- a/src/components/ProjectsView/ProjectsView.module.css
+++ b/src/components/ProjectsView/ProjectsView.module.css
@@ -937,6 +937,7 @@
   background-color: var(--bg-primary);
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .workspaceTopBar {

--- a/src/hooks/useFileDrop.js
+++ b/src/hooks/useFileDrop.js
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from 'react';
+
+const eventHasFiles = (event) => Array.from(event.dataTransfer?.types || []).includes('Files');
+
+export default function useFileDrop(targetRef, { onFiles, enabled = true }) {
+  const [isDragging, setIsDragging] = useState(false);
+  const counterRef = useRef(0);
+  const onFilesRef = useRef(onFiles);
+
+  useEffect(() => {
+    onFilesRef.current = onFiles;
+  }, [onFiles]);
+
+  useEffect(() => {
+    const el = targetRef.current;
+    if (!el || !enabled) {
+      counterRef.current = 0;
+      setIsDragging(false);
+      return undefined;
+    }
+
+    const handleDragEnter = (event) => {
+      if (!eventHasFiles(event)) return;
+      event.preventDefault();
+      counterRef.current += 1;
+      if (counterRef.current === 1) setIsDragging(true);
+    };
+
+    const handleDragLeave = (event) => {
+      if (!eventHasFiles(event)) return;
+      event.preventDefault();
+      counterRef.current = Math.max(0, counterRef.current - 1);
+      if (counterRef.current === 0) setIsDragging(false);
+    };
+
+    const handleDragOver = (event) => {
+      if (!eventHasFiles(event)) return;
+      event.preventDefault();
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
+    };
+
+    const handleDrop = (event) => {
+      if (!eventHasFiles(event)) return;
+      event.preventDefault();
+      counterRef.current = 0;
+      setIsDragging(false);
+      const files = Array.from(event.dataTransfer?.files || []);
+      if (files.length > 0) onFilesRef.current?.(files);
+    };
+
+    el.addEventListener('dragenter', handleDragEnter);
+    el.addEventListener('dragleave', handleDragLeave);
+    el.addEventListener('dragover', handleDragOver);
+    el.addEventListener('drop', handleDrop);
+
+    return () => {
+      el.removeEventListener('dragenter', handleDragEnter);
+      el.removeEventListener('dragleave', handleDragLeave);
+      el.removeEventListener('dragover', handleDragOver);
+      el.removeEventListener('drop', handleDrop);
+    };
+  }, [targetRef, enabled]);
+
+  useEffect(() => {
+    const prevent = (event) => {
+      if (eventHasFiles(event)) event.preventDefault();
+    };
+    window.addEventListener('dragover', prevent);
+    window.addEventListener('drop', prevent);
+    return () => {
+      window.removeEventListener('dragover', prevent);
+      window.removeEventListener('drop', prevent);
+    };
+  }, []);
+
+  return { isDragging };
+}

--- a/src/hooks/useFileDrop.test.js
+++ b/src/hooks/useFileDrop.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRef } from 'react';
+import useFileDrop from './useFileDrop';
+
+const makeFile = (name = 'a.png', type = 'image/png') =>
+  new File([new Uint8Array([0])], name, { type });
+
+const makeEvent = (type, files = []) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  event.dataTransfer = {
+    types: files.length > 0 ? ['Files'] : [],
+    files,
+    dropEffect: 'none',
+  };
+  return event;
+};
+
+describe('useFileDrop', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  const renderTargeted = (onFiles, enabled = true) =>
+    renderHook(() => {
+      const ref = useRef(container);
+      return useFileDrop(ref, { onFiles, enabled });
+    });
+
+  it('returns isDragging false initially', () => {
+    const { result } = renderTargeted(() => {});
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('flips isDragging on file dragenter and back on dragleave', () => {
+    const { result } = renderTargeted(() => {});
+    act(() => {
+      container.dispatchEvent(makeEvent('dragenter', [makeFile()]));
+    });
+    expect(result.current.isDragging).toBe(true);
+    act(() => {
+      container.dispatchEvent(makeEvent('dragleave', [makeFile()]));
+    });
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('ignores non-file drag events', () => {
+    const { result } = renderTargeted(() => {});
+    act(() => {
+      container.dispatchEvent(makeEvent('dragenter', []));
+    });
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('stays dragging across nested dragenter/dragleave pairs', () => {
+    const { result } = renderTargeted(() => {});
+    act(() => {
+      container.dispatchEvent(makeEvent('dragenter', [makeFile()]));
+      container.dispatchEvent(makeEvent('dragenter', [makeFile()]));
+      container.dispatchEvent(makeEvent('dragleave', [makeFile()]));
+    });
+    expect(result.current.isDragging).toBe(true);
+    act(() => {
+      container.dispatchEvent(makeEvent('dragleave', [makeFile()]));
+    });
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('calls onFiles with dropped files and resets isDragging', () => {
+    const onFiles = vi.fn();
+    const { result } = renderTargeted(onFiles);
+    const file = makeFile('dropped.png');
+    act(() => {
+      container.dispatchEvent(makeEvent('dragenter', [file]));
+      container.dispatchEvent(makeEvent('drop', [file]));
+    });
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(onFiles.mock.calls[0][0]).toEqual([file]);
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('does not call onFiles when drop carries no files', () => {
+    const onFiles = vi.fn();
+    renderTargeted(onFiles);
+    act(() => {
+      container.dispatchEvent(makeEvent('drop', []));
+    });
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', () => {
+    const onFiles = vi.fn();
+    const { result } = renderTargeted(onFiles, false);
+    act(() => {
+      container.dispatchEvent(makeEvent('dragenter', [makeFile()]));
+      container.dispatchEvent(makeEvent('drop', [makeFile()]));
+    });
+    expect(result.current.isDragging).toBe(false);
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it('preventDefault is called on dragover so the browser allows drop', () => {
+    renderTargeted(() => {});
+    const event = makeEvent('dragover', [makeFile()]);
+    container.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/src/hooks/usePasteImages.js
+++ b/src/hooks/usePasteImages.js
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+
+export default function usePasteImages({ onFiles, enabled = true }) {
+  const onFilesRef = useRef(onFiles);
+
+  useEffect(() => {
+    onFilesRef.current = onFiles;
+  }, [onFiles]);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    const handlePaste = (event) => {
+      const items = event.clipboardData?.items;
+      if (!items) return;
+      const files = [];
+      for (const item of items) {
+        if (item.kind !== 'file') continue;
+        if (!item.type.startsWith('image/')) continue;
+        const file = item.getAsFile();
+        if (file) files.push(file);
+      }
+      if (files.length === 0) return;
+      onFilesRef.current?.(files);
+    };
+
+    document.addEventListener('paste', handlePaste);
+    return () => document.removeEventListener('paste', handlePaste);
+  }, [enabled]);
+}

--- a/src/hooks/usePasteImages.test.js
+++ b/src/hooks/usePasteImages.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import usePasteImages from './usePasteImages';
+
+const makeFile = (name = 'pasted.png', type = 'image/png') =>
+  new File([new Uint8Array([0])], name, { type });
+
+const firePaste = (items) => {
+  const event = new Event('paste', { bubbles: true, cancelable: true });
+  event.clipboardData = { items };
+  document.dispatchEvent(event);
+};
+
+const fileItem = (file) => ({
+  kind: 'file',
+  type: file.type,
+  getAsFile: () => file,
+});
+
+const stringItem = (type = 'text/plain') => ({
+  kind: 'string',
+  type,
+  getAsFile: () => null,
+});
+
+describe('usePasteImages', () => {
+  it('calls onFiles with image files pasted from the clipboard', () => {
+    const onFiles = vi.fn();
+    renderHook(() => usePasteImages({ onFiles }));
+    const file = makeFile();
+    firePaste([fileItem(file)]);
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(onFiles.mock.calls[0][0]).toEqual([file]);
+  });
+
+  it('filters out non-image file items', () => {
+    const onFiles = vi.fn();
+    renderHook(() => usePasteImages({ onFiles }));
+    const pdf = makeFile('a.pdf', 'application/pdf');
+    firePaste([fileItem(pdf)]);
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it('ignores string clipboard items', () => {
+    const onFiles = vi.fn();
+    renderHook(() => usePasteImages({ onFiles }));
+    firePaste([stringItem()]);
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when disabled', () => {
+    const onFiles = vi.fn();
+    renderHook(() => usePasteImages({ onFiles, enabled: false }));
+    firePaste([fileItem(makeFile())]);
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it('returns image files alongside text items when both are present', () => {
+    const onFiles = vi.fn();
+    renderHook(() => usePasteImages({ onFiles }));
+    const file = makeFile();
+    firePaste([stringItem(), fileItem(file)]);
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(onFiles.mock.calls[0][0]).toEqual([file]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds drag-and-drop file attachment and clipboard image paste to all three chat-input surfaces (main chat, project workspace, image gallery), matching how ChatGPT / Claude / Gemini behave: drop or paste anywhere on the route's surface, files flow through the existing attachment pipeline — same validation, same caps, same toasts.

### Shared building blocks

- **`useFileDrop(targetRef, { onFiles, enabled })`** — ref-targeted hook using a `dragenter`/`dragleave` counter so the overlay does not flicker over child elements. Ignores non-file drags (e.g. text selections) so it never hijacks unrelated interactions. Calls back with `File[]` on drop. A window-level `dragover`/`drop` `preventDefault` stops the browser from navigating to the file if the user releases outside the target.
- **`usePasteImages({ onFiles, enabled })`** — document-level `paste` listener that extracts `image/*` file items. Non-image file items and string items are ignored, so pasting text into a textarea still pastes the text — the image is attached in addition.
- **`<DropOverlay visible label />`** — shared visual surface: accent-tinted dashed border, centered pill with paperclip icon + label. Renders via `position: absolute; inset: 0` inside the drop target, with a mobile-tightened margin and pill size at ≤480 px.

### Wired into

| Input | Drop target | Behavior |
|---|---|---|
| **MainContent** | `<main>` chat surface | Files go into the existing `attachedFiles` state through a shared `handleAttachFiles` helper that respects `maxAttachments` and shows the overflow toast. Disabled while a reply is streaming. |
| **ProjectsView** | `.workspacePage` | Files append to local `attachedFiles`, then ride the existing `pendingAttachments` handoff to main chat on submit. |
| **ImageGalleryView** | `.galleryPage` | Dropped/pasted files are treated as a vision request (not image generation) and handed off through `pendingAttachments` to main chat for auto-submit. |

`position: relative` was added to `.workspacePage` and `.galleryPage` so the absolute-positioned overlay can position correctly inside them. `.main` was already relative.

## Test plan

- [x] `npm test -- --run src/hooks/useFileDrop.test.js src/hooks/usePasteImages.test.js` — 13 tests covering counter pattern, disabled state, ignored non-file drags, non-image paste filtering
- [x] `npm test -- --run` — full suite green (one pre-existing `authSlice` failure unrelated)
- [x] `npx eslint` on touched files — no new warnings
- [x] `npm run build` — production build succeeds
- [ ] Manual: drag a single image into main chat → overlay shows → release → file attaches with same chip UX as picker
- [ ] Manual: drag onto sidebar / outside surface → no navigation (window catch works)
- [ ] Manual: drag while a reply is streaming → no overlay, drop ignored
- [ ] Manual: drag 12 files when `maxAttachments=10` → first 10 attach, overflow toast fires
- [ ] Manual: Cmd/Ctrl+V a screenshot from clipboard → image attaches
- [ ] Manual: Cmd/Ctrl+V plain text → only text pastes, no spurious file attempt
- [ ] Manual: drag in project workspace → file attaches, submit hands off to main chat with file
- [ ] Manual: drag in image gallery → navigates to main chat with file attached as vision request (not image-gen)
- [ ] Manual: rapidly drag in/out crossing child elements → overlay does not flicker
- [ ] Manual: mobile (≤480 px) — overlay sized smaller, no broken layout

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_