### PR TITLE
Make chat error cards clear and preserve attachments on retry

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -2002,11 +2002,13 @@ export default function MainContent() {
    * Retry handler.
    */
   const handleRetry = useCallback(
-    async (userPrompt) => {
+    async (userPrompt, userImages) => {
       if (isProcessing) return;
       dispatch(removeLastAssistantMessage());
 
       await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const images = Array.isArray(userImages) && userImages.length > 0 ? userImages : undefined;
 
       await runSSEPipeline(userPrompt, {
         selectedModelId: selectedModelId || undefined,
@@ -2014,6 +2016,8 @@ export default function MainContent() {
         addUserMessage: false,
         webSearch: webSearchEnabled,
         imageQuality: imageQuality || undefined,
+        images,
+        conversationHasImages: images ? true : undefined,
       });
     },
     [
@@ -2031,16 +2035,20 @@ export default function MainContent() {
    * Alternate model request handler.
    */
   const handleAlternateModelRequest = useCallback(
-    async (userPrompt, alternateModel) => {
+    async (userPrompt, alternateModel, userImages) => {
       if (isProcessing) return;
 
       await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const images = Array.isArray(userImages) && userImages.length > 0 ? userImages : undefined;
 
       await runSSEPipeline(userPrompt, {
         selectedModelId: alternateModel.modelId,
         conversationId: currentChatId || undefined,
         addUserMessage: false,
         imageQuality: imageQuality || undefined,
+        images,
+        conversationHasImages: images ? true : undefined,
       });
     },
     [isProcessing, currentChatId, runSSEPipeline, imageQuality]

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -20,6 +20,7 @@ import {
 import { useToast } from '../Toast/Toast';
 import { logger } from '../../lib/logger';
 import { readBooleanSetting } from '../../lib/localSettings';
+import { getFriendlyError } from '../../lib/chatErrorMessages';
 import {
   CopyIcon,
   CheckIcon,
@@ -2731,7 +2732,7 @@ function WebSearchBadgeWithSources({ isAutoDetected, citations }) {
 /**
  * Error card displayed inline below messages.
  */
-function ErrorCard({ error, onRetry, onSessionExpired, userPrompt }) {
+function ErrorCard({ error, onRetry, onSessionExpired, userPrompt, userImages }) {
   if (!error) return null;
 
   const isFatal = error.code !== 'PROVIDER_RETRY';
@@ -2750,14 +2751,14 @@ function ErrorCard({ error, onRetry, onSessionExpired, userPrompt }) {
     );
   }
 
+  const friendly = getFriendlyError(error);
+  const hasRetryablePrompt = !!(userPrompt || (userImages && userImages.length > 0));
+
   return (
     <div className={styles.errorCard}>
       <div className={styles.errorCardContent}>
-        <span className={styles.errorCardMessage}>
-          {isAuthExpired
-            ? 'Your session has expired. Please log in to continue.'
-            : error.message || 'Something went wrong'}
-        </span>
+        <span className={styles.errorCardMessage}>{friendly.title}</span>
+        {friendly.hint && <span className={styles.errorCardHint}>{friendly.hint}</span>}
         {error.suggestedPlatforms && error.suggestedPlatforms.length > 0 && (
           <div className={styles.errorSuggestedPlatforms}>
             {error.suggestedPlatforms.map((platform, idx) => (
@@ -2767,6 +2768,7 @@ function ErrorCard({ error, onRetry, onSessionExpired, userPrompt }) {
             ))}
           </div>
         )}
+        {friendly.code && <span className={styles.errorCardCode}>Error code: {friendly.code}</span>}
       </div>
       {isAuthExpired && onSessionExpired ? (
         <button className={styles.errorRetryBtn} onClick={onSessionExpired}>
@@ -2774,8 +2776,8 @@ function ErrorCard({ error, onRetry, onSessionExpired, userPrompt }) {
         </button>
       ) : (
         onRetry &&
-        userPrompt && (
-          <button className={styles.errorRetryBtn} onClick={() => onRetry(userPrompt)}>
+        hasRetryablePrompt && (
+          <button className={styles.errorRetryBtn} onClick={() => onRetry(userPrompt, userImages)}>
             Try again
           </button>
         )
@@ -4234,6 +4236,7 @@ function ResponseActions({
   isDark,
   onRetry,
   userPrompt,
+  userImages,
   onSelectAlternate,
   assistantIndex,
   conversationId,
@@ -4276,9 +4279,9 @@ function ResponseActions({
 
   const handleRetryClick = useCallback(() => {
     if (onRetry && userPrompt) {
-      onRetry(userPrompt);
+      onRetry(userPrompt, userImages);
     }
-  }, [onRetry, userPrompt]);
+  }, [onRetry, userPrompt, userImages]);
 
   const [feedbackPanel, setFeedbackPanel] = useState(null); // 'like' | 'dislike' | null
   const [feedbackDetails, setFeedbackDetails] = useState([]);
@@ -5302,8 +5305,8 @@ function UserPrompt({ content, images, onEdit, createdAt, onRetry }) {
   }, [content, onEdit]);
 
   const handleRetry = useCallback(() => {
-    if (onRetry) onRetry(content);
-  }, [content, onRetry]);
+    if (onRetry) onRetry(content, imageList);
+  }, [content, imageList, onRetry]);
 
   // Format time as HH:MM
   const timeStr = useMemo(() => {
@@ -5436,6 +5439,7 @@ function Message({
   onSessionExpired,
   onAlternateModelRequest,
   userPrompt,
+  userImages,
   onSubConvPanelToggle,
   subConvPanelOwnerId,
   onSetSubConvPanelOwner,
@@ -5955,7 +5959,7 @@ function Message({
             const alt = pendingAlternate;
             setPendingAlternate(null);
             if (onAlternateModelRequest && userPrompt) {
-              onAlternateModelRequest(userPrompt, alt);
+              onAlternateModelRequest(userPrompt, alt, userImages);
             }
           }}
           onCancel={() => setPendingAlternate(null)}
@@ -6049,6 +6053,7 @@ function Message({
           onRetry={onRetry}
           onSessionExpired={onSessionExpired}
           userPrompt={userPrompt}
+          userImages={userImages}
         />
       )}
 
@@ -6061,7 +6066,7 @@ function Message({
                   onRetry('Continue from where you left off. Do not repeat what was already said.')
               : null
           }
-          onRetry={onRetry && userPrompt ? () => onRetry(userPrompt) : null}
+          onRetry={onRetry && userPrompt ? () => onRetry(userPrompt, userImages) : null}
         />
       )}
 
@@ -6076,6 +6081,7 @@ function Message({
           isDark={isDark}
           onRetry={onRetry}
           userPrompt={userPrompt}
+          userImages={userImages}
           onSelectAlternate={(alt) => setPendingAlternate(alt)}
           assistantIndex={assistantIndex}
           conversationId={currentChatId}
@@ -6461,10 +6467,16 @@ export default function MessageList({
 
           // Find the user prompt that preceded this assistant message
           let userPrompt = null;
+          let userImages = null;
           if (msg.role === 'assistant') {
             for (let j = index - 1; j >= 0; j--) {
               if (messages[j].role === 'user') {
                 userPrompt = messages[j].content;
+                const attachedImages = messages[j].images || messages[j].attachments;
+                userImages =
+                  Array.isArray(attachedImages) && attachedImages.length > 0
+                    ? attachedImages
+                    : null;
                 break;
               }
             }
@@ -6497,6 +6509,7 @@ export default function MessageList({
                 onSessionExpired={onSessionExpired}
                 onAlternateModelRequest={onAlternateModelRequest}
                 userPrompt={userPrompt}
+                userImages={userImages}
                 onSubConvPanelToggle={onSubConvPanelToggle}
                 subConvPanelOwnerId={subConvPanelOwnerId}
                 onSetSubConvPanelOwner={setSubConvPanelOwnerId}

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -6724,10 +6724,34 @@
   font-size: 13px;
   color: #8b5c4e;
   line-height: 1.5;
+  font-weight: 500;
 }
 
 [data-theme='dark'] .errorCardMessage {
   color: #c9a097;
+}
+
+.errorCardHint {
+  font-size: 12px;
+  color: #a98777;
+  line-height: 1.5;
+}
+
+[data-theme='dark'] .errorCardHint {
+  color: #a08980;
+}
+
+.errorCardCode {
+  margin-top: 2px;
+  font-size: 11px;
+  color: #b89c92;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  letter-spacing: 0.2px;
+  opacity: 0.85;
+}
+
+[data-theme='dark'] .errorCardCode {
+  color: #8a7a73;
 }
 
 .errorSuggestedPlatforms {

--- a/src/lib/chatErrorMessages.js
+++ b/src/lib/chatErrorMessages.js
@@ -1,0 +1,81 @@
+const NETWORK_PATTERNS = /(network|connection|failed to fetch|offline|reach araviel)/i;
+const INTERNAL_PATTERNS = /(internal error|unexpected|went wrong)/i;
+
+const STATIC = {
+  AUTH_EXPIRED: {
+    title: 'Your session has expired.',
+    hint: 'Sign in to continue.',
+  },
+  NETWORK_ERROR: {
+    title: 'Network connection issue.',
+    hint: 'Check your internet and try again.',
+  },
+  INTERNAL_ERROR: {
+    title: 'Araviel ran into a problem while replying.',
+    hint: 'This is usually temporary. Try again, or pick a different model.',
+  },
+  NO_PROVIDER: {
+    title: 'No model is available for this request right now.',
+    hint: 'Try a different prompt or pick a model manually.',
+  },
+  MODEL_RETIRED: {
+    title: null,
+    hint: 'Pick a different model from the picker above.',
+  },
+  UNSUPPORTED_TASK: {
+    title: null,
+    hint: null,
+  },
+  CREDIT_CHARGE_FAILED: {
+    title: "We couldn't complete that image. Your credits weren't charged.",
+    hint: 'Try again — if it keeps happening, contact support.',
+  },
+  INSUFFICIENT_CREDITS: {
+    title: null,
+    hint: 'Buy more credits or pick a lower-quality option.',
+  },
+  MONTHLY_CREDITS_EXHAUSTED: { title: null, hint: null },
+  WINDOW_CREDITS_EXHAUSTED: {
+    title: null,
+    hint: 'Try again in a bit.',
+  },
+  GUEST_LIMIT: { title: null, hint: null },
+  NOT_FOUND: { title: null, hint: null },
+  VALIDATION_ERROR: {
+    title: null,
+    hint: 'Adjust your prompt and try again.',
+  },
+};
+
+const DEFAULT = {
+  title: 'Something went wrong.',
+  hint: 'Try again, or pick a different model.',
+};
+
+export function getFriendlyError(error) {
+  if (!error) return null;
+  const code = error.code;
+  const rawMessage = typeof error.message === 'string' ? error.message.trim() : '';
+
+  if (code && STATIC[code]) {
+    return {
+      title: STATIC[code].title || rawMessage || DEFAULT.title,
+      hint: STATIC[code].hint,
+      code,
+    };
+  }
+
+  if (rawMessage && NETWORK_PATTERNS.test(rawMessage)) {
+    return { ...STATIC.NETWORK_ERROR, code: code || 'NETWORK_ERROR' };
+  }
+
+  if (rawMessage && INTERNAL_PATTERNS.test(rawMessage)) {
+    return { ...STATIC.INTERNAL_ERROR, code: code || 'INTERNAL_ERROR' };
+  }
+
+  return {
+    title: rawMessage || DEFAULT.title,
+    hint: DEFAULT.hint,
+    code: code || null,
+  };
+}

--- a/src/lib/chatErrorMessages.test.js
+++ b/src/lib/chatErrorMessages.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { getFriendlyError } from './chatErrorMessages';
+
+describe('getFriendlyError', () => {
+  it('returns null when error is null', () => {
+    expect(getFriendlyError(null)).toBeNull();
+    expect(getFriendlyError(undefined)).toBeNull();
+  });
+
+  it('uses the static mapping for a known code', () => {
+    const result = getFriendlyError({ code: 'AUTH_EXPIRED' });
+    expect(result.title).toBe('Your session has expired.');
+    expect(result.hint).toBe('Sign in to continue.');
+    expect(result.code).toBe('AUTH_EXPIRED');
+  });
+
+  it('returns the server message as title when the static mapping has no title', () => {
+    const result = getFriendlyError({
+      code: 'MODEL_RETIRED',
+      message: 'gpt-4o-mini was retired.',
+    });
+    expect(result.title).toBe('gpt-4o-mini was retired.');
+    expect(result.hint).toBe('Pick a different model from the picker above.');
+  });
+
+  it('falls back to a generic title when neither static nor message is present', () => {
+    const result = getFriendlyError({ code: 'MODEL_RETIRED' });
+    expect(result.title).toBe('Something went wrong.');
+  });
+
+  it('classifies network-flavored messages as NETWORK_ERROR', () => {
+    const result = getFriendlyError({ message: 'Failed to fetch' });
+    expect(result.code).toBe('NETWORK_ERROR');
+    expect(result.title).toBe('Network connection issue.');
+  });
+
+  it('classifies "something went wrong"-flavored messages as INTERNAL_ERROR', () => {
+    const result = getFriendlyError({
+      message: 'Something went wrong. Please try again.',
+    });
+    expect(result.code).toBe('INTERNAL_ERROR');
+    expect(result.title).toBe('Araviel ran into a problem while replying.');
+  });
+
+  it('falls back to the raw message + generic hint for unknown errors', () => {
+    const result = getFriendlyError({ message: 'Unparseable JSON' });
+    expect(result.title).toBe('Unparseable JSON');
+    expect(result.hint).toBe('Try again, or pick a different model.');
+    expect(result.code).toBeNull();
+  });
+
+  it('preserves the original code field when a message-only classifier matches', () => {
+    const result = getFriendlyError({
+      code: 'CUSTOM_CODE',
+      message: 'connection refused',
+    });
+    expect(result.code).toBe('CUSTOM_CODE');
+    expect(result.title).toBe('Network connection issue.');
+  });
+
+  it('trims whitespace from incoming messages before classifying', () => {
+    const result = getFriendlyError({ message: '   network error   ' });
+    expect(result.code).toBe('NETWORK_ERROR');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two issues you flagged when a chat reply fails:

1. The error card read **"Something went wrong. Please try again."** with no indication of what actually happened or what to do next, so users guessed.
2. The **"Try again"** button only sent the text part of the previous user message — any attached images were silently dropped, so an image-prompted failure could not be retried without manually re-uploading and re-typing.

### Friendly errors

A new pure helper `lib/chatErrorMessages.getFriendlyError(error)` maps every known server error code (`AUTH_EXPIRED`, `INTERNAL_ERROR`, `NO_PROVIDER`, `MODEL_RETIRED`, `INSUFFICIENT_CREDITS`, `CREDIT_CHARGE_FAILED`, `MONTHLY_/WINDOW_CREDITS_EXHAUSTED`, `GUEST_LIMIT`, `NOT_FOUND`, `VALIDATION_ERROR`, `UNSUPPORTED_TASK`) to a `{ title, hint, code }` triple. Unknown codes degrade gracefully — the helper sniffs the raw message for network / internal patterns ("connection", "failed to fetch", "went wrong") and uses the right fallback. Server messages override generic titles when they're more specific (e.g. `MODEL_RETIRED` keeps the server's "gpt-4o-mini was retired" string).

ErrorCard now renders three lines:

- **Title** — clear plain-language statement of what happened ("Araviel ran into a problem while replying.")
- **Hint** — one short sentence on what to try next ("This is usually temporary. Try again, or pick a different model.")
- **Error code: X** — small, muted, monospaced. Users have a precise string to report when contacting support.

The PROVIDER_RETRY branch (the soft "model swap" notice) is unchanged.

### Image-preserving retry

The `MessageList` loop pairs every assistant message with the **attachments** of its preceding user message. `userImages` threads through `Message → ErrorCard / ResponseActions / StreamTimeoutNotice`. Every retry handler forwards both prompt and images.

`handleRetry` and `handleAlternateModelRequest` in `MainContent` accept the second `userImages` argument and pass it as the `runSSEPipeline` `images` payload, plus `conversationHasImages: true` so the backend router knows the conversation carries a vision attachment.

## Test plan

- [x] `npm test -- --run src/lib/chatErrorMessages.test.js` — 9 unit tests covering known codes, unknown codes, message-pattern classifiers, code passthrough
- [x] `npm test -- --run` — full suite green (one pre-existing `authSlice` failure unrelated)
- [x] `npx eslint` on touched files — no new warnings
- [x] `npm run build` — production build succeeds
- [ ] Manual: trigger an error (e.g. send an oversized image), verify three-line card with hint + error code
- [ ] Manual: send image + text → backend fails → click "Try again" → image is re-sent without re-uploading
- [ ] Manual: send text only → backend fails → click "Try again" → text retries (no spurious image)
- [ ] Manual: session expired → "Log in" button still shows
- [ ] Manual: alternate model picker → swap model on a failed image message → image is preserved
- [ ] Manual: stream timeout → "Try again" preserves image; "Continue" still sends just text
- [ ] Manual: dark theme — hint + code are subtly muted, not bold

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_