### PR TITLE
Soften historical chat errors to a pill and add a dismiss button

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { selectEffectiveTheme } from '../../store/slices/themeSlice';
-import { setInputValue } from '../../store/slices/chatSlice';
+import { setInputValue, dismissMessageError } from '../../store/slices/chatSlice';
 import { selectSidebarCollapsed } from '../../store/slices/sidebarSlice';
 import { getProviderLogo } from '../getProviderLogo';
 import { PROVIDERS, MODELS, SPEED_TIERS, formatTokens } from '../../data/models';
@@ -2732,7 +2732,15 @@ function WebSearchBadgeWithSources({ isAutoDetected, citations }) {
 /**
  * Error card displayed inline below messages.
  */
-function ErrorCard({ error, onRetry, onSessionExpired, userPrompt, userImages }) {
+function ErrorCard({
+  error,
+  onRetry,
+  onSessionExpired,
+  userPrompt,
+  userImages,
+  isHistorical = false,
+  onDismiss,
+}) {
   if (!error) return null;
 
   const isFatal = error.code !== 'PROVIDER_RETRY';
@@ -2753,6 +2761,37 @@ function ErrorCard({ error, onRetry, onSessionExpired, userPrompt, userImages })
 
   const friendly = getFriendlyError(error);
   const hasRetryablePrompt = !!(userPrompt || (userImages && userImages.length > 0));
+  const canRetry = !!onRetry && hasRetryablePrompt && !isAuthExpired;
+
+  if (isHistorical) {
+    return (
+      <div className={styles.errorPill}>
+        <span className={styles.errorPillText}>
+          {isAuthExpired ? 'Session expired.' : friendly.title}
+        </span>
+        {canRetry && (
+          <button
+            type="button"
+            className={styles.errorPillAction}
+            onClick={() => onRetry(userPrompt, userImages)}
+          >
+            Try again
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            type="button"
+            className={styles.errorPillDismiss}
+            onClick={onDismiss}
+            aria-label="Dismiss error"
+            title="Dismiss"
+          >
+            <CloseIcon />
+          </button>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className={styles.errorCard}>
@@ -2770,18 +2809,33 @@ function ErrorCard({ error, onRetry, onSessionExpired, userPrompt, userImages })
         )}
         {friendly.code && <span className={styles.errorCardCode}>Error code: {friendly.code}</span>}
       </div>
-      {isAuthExpired && onSessionExpired ? (
-        <button className={styles.errorRetryBtn} onClick={onSessionExpired}>
-          Log in
-        </button>
-      ) : (
-        onRetry &&
-        hasRetryablePrompt && (
-          <button className={styles.errorRetryBtn} onClick={() => onRetry(userPrompt, userImages)}>
-            Try again
+      <div className={styles.errorCardActions}>
+        {isAuthExpired && onSessionExpired ? (
+          <button className={styles.errorRetryBtn} onClick={onSessionExpired}>
+            Log in
           </button>
-        )
-      )}
+        ) : (
+          canRetry && (
+            <button
+              className={styles.errorRetryBtn}
+              onClick={() => onRetry(userPrompt, userImages)}
+            >
+              Try again
+            </button>
+          )
+        )}
+        {onDismiss && !isAuthExpired && (
+          <button
+            type="button"
+            className={styles.errorCardDismiss}
+            onClick={onDismiss}
+            aria-label="Dismiss error"
+            title="Dismiss"
+          >
+            <CloseIcon />
+          </button>
+        )}
+      </div>
     </div>
   );
 }
@@ -5440,6 +5494,8 @@ function Message({
   onAlternateModelRequest,
   userPrompt,
   userImages,
+  isHistoricalError = false,
+  onDismissError,
   onSubConvPanelToggle,
   subConvPanelOwnerId,
   onSetSubConvPanelOwner,
@@ -6054,6 +6110,8 @@ function Message({
           onSessionExpired={onSessionExpired}
           userPrompt={userPrompt}
           userImages={userImages}
+          isHistorical={isHistoricalError}
+          onDismiss={onDismissError ? () => onDismissError(message.id) : undefined}
         />
       )}
 
@@ -6482,6 +6540,8 @@ export default function MessageList({
             }
           }
 
+          const isHistoricalError = !!msg.error && !isLast;
+
           return (
             <div key={msg.id || index} data-trail-anchor={msg.role === 'user' ? 'true' : undefined}>
               {/* Insert timeline before the streaming assistant message */}
@@ -6510,6 +6570,8 @@ export default function MessageList({
                 onAlternateModelRequest={onAlternateModelRequest}
                 userPrompt={userPrompt}
                 userImages={userImages}
+                isHistoricalError={isHistoricalError}
+                onDismissError={readOnly ? undefined : (id) => dispatch(dismissMessageError(id))}
                 onSubConvPanelToggle={onSubConvPanelToggle}
                 subConvPanelOwnerId={subConvPanelOwnerId}
                 onSetSubConvPanelOwner={setSubConvPanelOwnerId}

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -6771,6 +6771,13 @@
   color: var(--text-secondary);
 }
 
+.errorCardActions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
 .errorRetryBtn {
   padding: 6px 14px;
   border-radius: 8px;
@@ -6782,11 +6789,109 @@
   cursor: pointer;
   transition: all 0.15s ease;
   white-space: nowrap;
-  flex-shrink: 0;
 }
 
 .errorRetryBtn:hover {
   background-color: var(--bg-button-hover);
+}
+
+.errorCardDismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: #8b5c4e;
+  opacity: 0.6;
+  cursor: pointer;
+  transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+.errorCardDismiss:hover {
+  opacity: 1;
+  background-color: rgba(139, 92, 78, 0.08);
+}
+
+[data-theme='dark'] .errorCardDismiss {
+  color: #c9a097;
+}
+
+[data-theme='dark'] .errorCardDismiss:hover {
+  background-color: rgba(201, 160, 151, 0.1);
+}
+
+.errorCardDismiss svg {
+  width: 14px;
+  height: 14px;
+}
+
+.errorPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 6px 10px 6px 12px;
+  border-radius: 999px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  animation: messageFadeIn 0.3s ease;
+  max-width: 100%;
+}
+
+.errorPillText {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.errorPillAction {
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s ease;
+}
+
+.errorPillAction:hover {
+  background-color: var(--bg-hover);
+}
+
+.errorPillDismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  opacity: 0.65;
+  cursor: pointer;
+  transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+.errorPillDismiss:hover {
+  opacity: 1;
+  background-color: var(--bg-hover);
+}
+
+.errorPillDismiss svg {
+  width: 12px;
+  height: 12px;
 }
 
 /* ===== Stream Timeout Notice ===== */

--- a/src/store/slices/chatSlice.js
+++ b/src/store/slices/chatSlice.js
@@ -113,6 +113,13 @@ const chatSlice = createSlice({
         Object.assign(last, action.payload);
       }
     },
+    dismissMessageError: (state, action) => {
+      const id = action.payload;
+      const target = state.messages.find((m) => m.id === id);
+      if (target) {
+        target.error = null;
+      }
+    },
     setIsProcessing: (state, action) => {
       state.isProcessing = action.payload;
     },
@@ -245,6 +252,7 @@ export const {
   setAutoStrategy,
   addMessage,
   updateLastMessage,
+  dismissMessageError,
   setIsProcessing,
   clearMessages,
   setCurrentChat,

--- a/src/store/slices/chatSlice.test.js
+++ b/src/store/slices/chatSlice.test.js
@@ -12,6 +12,7 @@ import chatReducer, {
   setAutoStrategy,
   addMessage,
   updateLastMessage,
+  dismissMessageError,
   setIsProcessing,
   clearMessages,
   setCurrentChat,
@@ -221,6 +222,29 @@ describe('chatSlice', () => {
     it('updateLastMessage does nothing on empty messages', () => {
       const state = chatReducer(defaultState, updateLastMessage({ content: 'test' }));
       expect(state.messages).toHaveLength(0);
+    });
+
+    it('dismissMessageError clears the error on the matching message only', () => {
+      let state = chatReducer(
+        defaultState,
+        addMessage({ id: 'a', role: 'assistant', content: '', error: { message: 'boom' } })
+      );
+      state = chatReducer(
+        state,
+        addMessage({ id: 'b', role: 'assistant', content: '', error: { message: 'bang' } })
+      );
+      state = chatReducer(state, dismissMessageError('a'));
+      expect(state.messages[0].error).toBeNull();
+      expect(state.messages[1].error).toEqual({ message: 'bang' });
+    });
+
+    it('dismissMessageError is a no-op for an unknown id', () => {
+      let state = chatReducer(
+        defaultState,
+        addMessage({ id: 'a', role: 'assistant', content: '', error: { message: 'boom' } })
+      );
+      state = chatReducer(state, dismissMessageError('z'));
+      expect(state.messages[0].error).toEqual({ message: 'boom' });
     });
 
     it('clearMessages empties the messages array', () => {


### PR DESCRIPTION
## Summary

Companion to araviel-api#159 (which excludes failed user turns from the model context). This PR handles the **visual** half of the "hanging / loose messages" complaint.

Two complaints showed up when a chat reply failed and the user continued the conversation instead of retrying:

1. The big bordered error card stayed sitting between two real turns, making the thread look broken.
2. There was no way to walk away from the failure — every glance at the chat re-surfaced the same wall of error text.

### Two visual states

`ErrorCard` now picks a state based on `isHistoricalError`:

- **Active** (the failed turn is still the very last message) — unchanged from previous PR: full card with title, hint, "Error code: X", `Try again` button.
- **Historical** (error followed by any newer message) — collapses to a compact rounded pill: short title, inline `Try again` link, dismiss `X`. Visually subdued, fits the conversation flow.

`MessageList` computes `isHistoricalError = !!msg.error && !isLast` per message and threads it through `Message → ErrorCard`. No extra render passes.

### Dismiss

Both states (except `AUTH_EXPIRED`) get a dismiss `X`. Click → `dispatch(dismissMessageError(message.id))` clears the `error` field on that one message via a new reducer in `chatSlice`. The dispatch is wired once in `MessageList` so every message gets a stable callback.

The `PROVIDER_RETRY` soft-swap notice and the stream-timeout notice are unchanged.

## Test plan

- [x] `npm test -- --run src/store/slices/chatSlice.test.js` — new tests for `dismissMessageError` (clears matching id, no-op for unknown id)
- [x] `npm test -- --run` — full suite green (one pre-existing `authSlice` failure unrelated)
- [x] `npx eslint` on touched files — no new warnings
- [x] `npm run build` — production build succeeds
- [ ] Manual: trigger a failure → verify big card with code/hint/Try again
- [ ] Manual: send another message after the failure → previous error collapses to a pill below the failed user bubble
- [ ] Manual: click dismiss `X` on the pill → pill disappears
- [ ] Manual: click dismiss `X` on the active card → card disappears
- [ ] Manual: click `Try again` on the pill → retry fires with original prompt + images
- [ ] Manual: session expired → "Log in" still shows, no dismiss `X`
- [ ] Manual: dark theme — pill + dismiss look correct, no contrast issues
- [ ] Manual: mobile — pill wraps correctly and dismiss button is tappable

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_