### PR TITLE
Show a dedicated shimmering placeholder during image generation

### DIFF
--- a/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.jsx
+++ b/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.jsx
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import useElapsedPhase from './useElapsedPhase';
+import styles from './ImageGenerationPlaceholder.module.css';
+
+export default function ImageGenerationPlaceholder({ startedAt, aspectRatio = '1 / 1' }) {
+  const safeStartedAt = useMemo(
+    () => (typeof startedAt === 'number' ? startedAt : Date.now()),
+    [startedAt]
+  );
+  const { label } = useElapsedPhase(safeStartedAt);
+  const cardRef = useRef(null);
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el || typeof IntersectionObserver !== 'function') return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry) setIsVisible(entry.isIntersecting);
+      },
+      { threshold: 0 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.statusRow} role="status" aria-live="polite">
+        <span key={label} className={styles.statusLabel}>
+          {label}
+        </span>
+      </div>
+      <div
+        ref={cardRef}
+        className={styles.card}
+        style={{ aspectRatio }}
+        data-paused={isVisible ? undefined : 'true'}
+        aria-hidden="true"
+      >
+        <div className={styles.dots} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.module.css
+++ b/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.module.css
@@ -1,0 +1,111 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 4px;
+  width: 100%;
+  max-width: 480px;
+}
+
+.statusRow {
+  min-height: 20px;
+}
+
+.statusLabel {
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.1px;
+  color: var(--text-secondary);
+  animation: statusFadeIn 0.22s ease-out;
+}
+
+.card {
+  position: relative;
+  width: 100%;
+  border-radius: 16px;
+  background-color: var(--bg-hover, rgba(0, 0, 0, 0.04));
+  overflow: hidden;
+  isolation: isolate;
+}
+
+[data-theme='dark'] .card {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.dots {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(
+    circle 1.5px at center,
+    rgba(0, 0, 0, 0.18) 100%,
+    transparent 100%
+  );
+  background-size: 18px 18px;
+  background-repeat: repeat;
+  mask-image: radial-gradient(closest-side, #000 55%, transparent 100%);
+  -webkit-mask-image: radial-gradient(closest-side, #000 55%, transparent 100%);
+  animation: dotDrift 14s linear infinite, dotBreathe 2.8s ease-in-out infinite;
+  will-change: background-position, opacity;
+}
+
+[data-theme='dark'] .dots {
+  background-image: radial-gradient(
+    circle 1.5px at center,
+    rgba(255, 255, 255, 0.13) 100%,
+    transparent 100%
+  );
+}
+
+.card[data-paused='true'] .dots {
+  animation-play-state: paused;
+}
+
+@keyframes dotDrift {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 18px 18px;
+  }
+}
+
+@keyframes dotBreathe {
+  0%,
+  100% {
+    opacity: 0.65;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes statusFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dots {
+    animation: none;
+    opacity: 0.85;
+  }
+  .statusLabel {
+    animation: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .wrapper {
+    max-width: 100%;
+  }
+  .statusLabel {
+    font-size: 12.5px;
+  }
+}

--- a/src/components/ImageGenerationPlaceholder/index.js
+++ b/src/components/ImageGenerationPlaceholder/index.js
@@ -1,0 +1,1 @@
+export { default } from './ImageGenerationPlaceholder';

--- a/src/components/ImageGenerationPlaceholder/useElapsedPhase.js
+++ b/src/components/ImageGenerationPlaceholder/useElapsedPhase.js
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+const PHASES = [
+  { atMs: 0, label: 'Thinking through your image…' },
+  { atMs: 6000, label: 'Composing the scene…' },
+  { atMs: 14000, label: 'Mixing the palette…' },
+  { atMs: 26000, label: 'Adding the final touches…' },
+  { atMs: 45000, label: 'Almost there — sometimes the best ones take a moment…' },
+];
+
+function phaseIndexForElapsed(elapsedMs) {
+  let index = 0;
+  for (let i = 0; i < PHASES.length; i++) {
+    if (elapsedMs >= PHASES[i].atMs) index = i;
+  }
+  return index;
+}
+
+export default function useElapsedPhase(startedAt) {
+  const [phaseIndex, setPhaseIndex] = useState(() =>
+    typeof startedAt === 'number' ? phaseIndexForElapsed(Date.now() - startedAt) : 0
+  );
+
+  useEffect(() => {
+    if (typeof startedAt !== 'number') return undefined;
+
+    const now = Date.now();
+    const elapsed = now - startedAt;
+    setPhaseIndex(phaseIndexForElapsed(elapsed));
+
+    const timeouts = [];
+    for (let i = 0; i < PHASES.length; i++) {
+      const fireIn = PHASES[i].atMs - elapsed;
+      if (fireIn <= 0) continue;
+      const id = setTimeout(() => setPhaseIndex(i), fireIn);
+      timeouts.push(id);
+    }
+
+    return () => {
+      for (const id of timeouts) clearTimeout(id);
+    };
+  }, [startedAt]);
+
+  return {
+    phaseIndex,
+    label: PHASES[phaseIndex].label,
+  };
+}
+
+export { PHASES };

--- a/src/components/ImageGenerationPlaceholder/useElapsedPhase.test.js
+++ b/src/components/ImageGenerationPlaceholder/useElapsedPhase.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useElapsedPhase, { PHASES } from './useElapsedPhase';
+
+describe('useElapsedPhase', () => {
+  let nowMs;
+
+  beforeEach(() => {
+    nowMs = 1_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(nowMs);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts at phase 0 with the first label', () => {
+    const { result } = renderHook(() => useElapsedPhase(nowMs));
+    expect(result.current.phaseIndex).toBe(0);
+    expect(result.current.label).toBe(PHASES[0].label);
+  });
+
+  it('advances through phases as time passes', () => {
+    const { result } = renderHook(() => useElapsedPhase(nowMs));
+
+    act(() => {
+      vi.advanceTimersByTime(PHASES[1].atMs - 1);
+    });
+    expect(result.current.phaseIndex).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.phaseIndex).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(PHASES[2].atMs - PHASES[1].atMs);
+    });
+    expect(result.current.phaseIndex).toBe(2);
+
+    act(() => {
+      vi.advanceTimersByTime(PHASES[3].atMs - PHASES[2].atMs);
+    });
+    expect(result.current.phaseIndex).toBe(3);
+
+    act(() => {
+      vi.advanceTimersByTime(PHASES[4].atMs - PHASES[3].atMs);
+    });
+    expect(result.current.phaseIndex).toBe(4);
+  });
+
+  it('snaps to the correct phase when mounted after a delay', () => {
+    const startedAt = nowMs - PHASES[2].atMs - 100;
+    const { result } = renderHook(() => useElapsedPhase(startedAt));
+    expect(result.current.phaseIndex).toBe(2);
+    expect(result.current.label).toBe(PHASES[2].label);
+  });
+
+  it('stays at the final phase forever after the last boundary', () => {
+    const startedAt = nowMs - PHASES[4].atMs - 60_000;
+    const { result } = renderHook(() => useElapsedPhase(startedAt));
+    expect(result.current.phaseIndex).toBe(PHASES.length - 1);
+
+    act(() => {
+      vi.advanceTimersByTime(120_000);
+    });
+    expect(result.current.phaseIndex).toBe(PHASES.length - 1);
+  });
+
+  it('returns phase 0 when startedAt is not provided', () => {
+    const { result } = renderHook(() => useElapsedPhase(undefined));
+    expect(result.current.phaseIndex).toBe(0);
+    expect(result.current.label).toBe(PHASES[0].label);
+  });
+
+  it('cleans up pending timeouts on unmount', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const { unmount } = renderHook(() => useElapsedPhase(nowMs));
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+
+  it('reschedules timeouts when startedAt changes', () => {
+    const { result, rerender } = renderHook(({ startedAt }) => useElapsedPhase(startedAt), {
+      initialProps: { startedAt: nowMs },
+    });
+
+    expect(result.current.phaseIndex).toBe(0);
+
+    rerender({ startedAt: nowMs - PHASES[3].atMs });
+    expect(result.current.phaseIndex).toBe(3);
+  });
+});

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -1100,13 +1100,16 @@ export default function MainContent() {
       // dots until the first token arrives; the `routing` SSE handler patches
       // in the real model info (and `done` patches in the final usage).
       const placeholderAssistantId = `pending-${Date.now()}`;
+      const placeholderCreatedAt = Date.now();
       dispatch(
         addMessage({
           id: placeholderAssistantId,
           role: 'assistant',
           content: '',
-          timestamp: Date.now(),
+          timestamp: placeholderCreatedAt,
           isPlaceholder: true,
+          ...(options.modality === 'image' ? { requestedModality: 'image' } : {}),
+          generationStartedAt: placeholderCreatedAt,
         })
       );
 

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -5,7 +5,14 @@ import { selectEffectiveTheme } from '../../store/slices/themeSlice';
 import { setInputValue, dismissMessageError } from '../../store/slices/chatSlice';
 import { selectSidebarCollapsed } from '../../store/slices/sidebarSlice';
 import { getProviderLogo } from '../getProviderLogo';
-import { PROVIDERS, MODELS, SPEED_TIERS, formatTokens } from '../../data/models';
+import {
+  PROVIDERS,
+  MODELS,
+  SPEED_TIERS,
+  formatTokens,
+  isImageGenerationModel,
+} from '../../data/models';
+import ImageGenerationPlaceholder from '../ImageGenerationPlaceholder';
 import {
   createSubConversation,
   fetchSubConversations,
@@ -5510,6 +5517,11 @@ function Message({
 }) {
   const isUser = message.role === 'user';
   const displayText = isStreaming ? streamedText : message.content;
+  const isImageGenerationTurn =
+    !isUser &&
+    (message.requestedModality === 'image' ||
+      message.analysis?.intent === 'image_generation' ||
+      isImageGenerationModel(message.modelId));
   const provider = message.provider;
   const providerData = provider ? PROVIDERS[provider] : null;
   const LogoComponent = provider ? getProviderLogo(provider) : null;
@@ -6076,13 +6088,17 @@ function Message({
               message.citations || message.sources,
               panelOpenerContext
             )}
-            {isStreaming && !renderText && (
-              <span className={styles.typingDots} aria-label="Thinking">
-                <span className={styles.typingDot} />
-                <span className={styles.typingDot} />
-                <span className={styles.typingDot} />
-              </span>
-            )}
+            {isStreaming &&
+              !renderText &&
+              (isImageGenerationTurn ? (
+                <ImageGenerationPlaceholder startedAt={message.generationStartedAt} />
+              ) : (
+                <span className={styles.typingDots} aria-label="Thinking">
+                  <span className={styles.typingDot} />
+                  <span className={styles.typingDot} />
+                  <span className={styles.typingDot} />
+                </span>
+              ))}
             {isStreaming && renderText && <span className={styles.cursor} />}
           </div>
         )}


### PR DESCRIPTION
## Summary

Image-generation turns used to share the same three pulsing dots as text replies, so users couldn't tell the request was alive — image gen can take 5–30s with zero token stream to watch. This adds a dedicated shimmering placeholder that makes the wait feel intentional and never stuck.

Builds the exact spec we locked in conversation: dot-grid card + drift + breathe + conversational phased status + radial vignette + accessibility/perf guards.

### The card

- Rounded 16px, theme-aware surface background.
- `aspect-ratio: 1 / 1` locked → the placeholder occupies the exact slot the final image will land in. Zero layout jump on arrival.
- Single overlay div with two stacked CSS background images:
  1. `radial-gradient` dot at `background-size: 18px 18px` → uniform grid of clean dots.
  2. `mask-image: radial-gradient(closest-side, #000 55%, transparent 100%)` → vignette that fades dots toward the edges.
- **Drift:** `dotDrift` animates `background-position 0 0 → 18px 18px` over 14s linear infinite — seamless loop because one tile-shift = identical grid.
- **Breathe:** `dotBreathe` animates opacity `0.65 → 1 → 0.65` over 2.8s ease-in-out infinite.
- Dot color is theme-aware (`rgba(0,0,0,0.18)` light, `rgba(255,255,255,0.13)` dark).

### Conversational status text (above the card)

A `useElapsedPhase(startedAt)` hook drives a single line that swaps through 5 phases at: 0s, 6s, 14s, 26s, 45s. It uses **one setTimeout per phase boundary** — not per-second polling — so the entire wait costs at most 5 renders, with zero work after the final phase.

| Window | Text |
|---|---|
| 0–6 s | Thinking through your image… |
| 6–14 s | Composing the scene… |
| 14–26 s | Mixing the palette… |
| 26–45 s | Adding the final touches… |
| 45 s+ | Almost there — sometimes the best ones take a moment… |

Each new phase fades the new line in (180 ms `statusFadeIn`).

### Stability guarantees

| Concern | How it's handled |
|---|---|
| CPU when offscreen | `IntersectionObserver` toggles `data-paused="true"` on the card → both animations get `animation-play-state: paused`. Pure CSS pause, no JS in the animation loop. |
| Layout shift on arrival | `aspect-ratio: 1 / 1` lock means the real `<img>` replaces the placeholder at identical dimensions. |
| Low-end devices | Only GPU-friendly properties animate (`background-position`, `opacity`). No filter, no blur, no shadow. |
| `prefers-reduced-motion` | Drift + breathe disabled; static dots stay; phased text still rotates. |
| Phase text leaks | Hook clears all pending timeouts on unmount (unit-tested). |
| Theme switches mid-stream | Colors come from theme tokens / `[data-theme='dark']`; switching repaints instantly with zero re-render. |
| Race with retry | Detection lives in render — when streaming stops, the placeholder unmounts via the existing `isStreaming && !renderText` gate. |
| SSR / hydration | All clocks start in `useEffect`. No mismatch. |

### Trigger (lives inside `Message`)

The placeholder renders only when the message is the streaming assistant turn with no text yet (`isStreaming && !renderText`) AND one of:

1. `message.requestedModality === 'image'` (set by `MainContent` on the placeholder bubble at submit time so we detect image gen instantly, before the routing SSE arrives),
2. `message.analysis?.intent === 'image_generation'` (ADE classifier),
3. `isImageGenerationModel(message.modelId)` (after the routing event patches the real model in).

Otherwise the existing pulsing-dots indicator stays for every text reply.

### Files

- `src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.jsx` — the component (~50 lines)
- `src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.module.css` — dot grid + keyframes + reduced-motion + mobile (~105 lines)
- `src/components/ImageGenerationPlaceholder/useElapsedPhase.js` — phased status hook (~50 lines)
- `src/components/ImageGenerationPlaceholder/useElapsedPhase.test.js` — 7 unit tests
- `src/components/ImageGenerationPlaceholder/index.js`
- `src/components/MainContent/MainContent.jsx` — placeholder bubble now carries `requestedModality` + `generationStartedAt`
- `src/components/MessageList/MessageList.jsx` — one conditional swap; nothing else touched

No backend changes. No new dependencies.

## Test plan

- [x] `npm test -- --run src/components/ImageGenerationPlaceholder/useElapsedPhase.test.js` — 7 tests covering: start at phase 0, phase transitions at every boundary, mid-stream mount snaps to correct phase, stays at final phase forever, undefined startedAt, timeout cleanup on unmount, reschedule on startedAt change
- [x] `npm test -- --run` — full suite green (one pre-existing `authSlice` failure unrelated)
- [x] `npm run build` — production build succeeds
- [x] `npx eslint` on touched files — no new warnings
- [ ] Manual: trigger image gen with a chat model → dots stay (only image-gen models / `modality=image` get the placeholder)
- [ ] Manual: trigger explicit image-gen request → placeholder shows immediately on submit (before routing SSE arrives)
- [ ] Manual: image arrives → cross-fade replaces the placeholder, no layout shift
- [ ] Manual: scroll the placeholder offscreen → animations pause (verify via DevTools `animation-play-state`)
- [ ] Manual: enable system-level `prefers-reduced-motion` → animations stop, status text still cycles
- [ ] Manual: toggle theme mid-stream → dot color updates, no flicker
- [ ] Manual: mobile (≤480 px) → card fills the bubble width, status text reads at the smaller size

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_