### PR TITLE
Render image-gen placeholder as the araviel A mark shimmering in dots

### DIFF
--- a/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.jsx
+++ b/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.jsx
@@ -2,6 +2,34 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import useElapsedPhase from './useElapsedPhase';
 import styles from './ImageGenerationPlaceholder.module.css';
 
+const A_MARK_PATH =
+  'M 50 8 L 92 90 L 76 90 L 67 72 L 33 72 L 24 90 L 8 90 Z M 50 28 L 38 62 L 62 62 Z';
+const SAMPLE_STEP = 3.6;
+const SAMPLE_MIN = 4;
+const SAMPLE_MAX = 96;
+const SHIMMER_DURATION_S = 2.6;
+
+function computeMarkDots(pathElement) {
+  if (!pathElement || typeof pathElement.isPointInFill !== 'function') return [];
+  const dots = [];
+  for (let y = SAMPLE_MIN; y <= SAMPLE_MAX; y += SAMPLE_STEP) {
+    for (let x = SAMPLE_MIN; x <= SAMPLE_MAX; x += SAMPLE_STEP) {
+      try {
+        if (pathElement.isPointInFill({ x, y })) {
+          dots.push({
+            x,
+            y,
+            delay: Math.random() * SHIMMER_DURATION_S,
+          });
+        }
+      } catch {
+        return [];
+      }
+    }
+  }
+  return dots;
+}
+
 export default function ImageGenerationPlaceholder({ startedAt, aspectRatio = '1 / 1' }) {
   const safeStartedAt = useMemo(
     () => (typeof startedAt === 'number' ? startedAt : Date.now()),
@@ -9,7 +37,13 @@ export default function ImageGenerationPlaceholder({ startedAt, aspectRatio = '1
   );
   const { label } = useElapsedPhase(safeStartedAt);
   const cardRef = useRef(null);
+  const pathRef = useRef(null);
   const [isVisible, setIsVisible] = useState(true);
+  const [dots, setDots] = useState([]);
+
+  useEffect(() => {
+    setDots(computeMarkDots(pathRef.current));
+  }, []);
 
   useEffect(() => {
     const el = cardRef.current;
@@ -39,7 +73,24 @@ export default function ImageGenerationPlaceholder({ startedAt, aspectRatio = '1
         data-paused={isVisible ? undefined : 'true'}
         aria-hidden="true"
       >
-        <div className={styles.dots} />
+        <svg
+          className={styles.mark}
+          viewBox="0 0 100 100"
+          preserveAspectRatio="xMidYMid meet"
+          focusable="false"
+        >
+          <path ref={pathRef} d={A_MARK_PATH} fillRule="evenodd" className={styles.markHidden} />
+          {dots.map((dot, idx) => (
+            <circle
+              key={idx}
+              cx={dot.x}
+              cy={dot.y}
+              r="1.1"
+              className={styles.markDot}
+              style={{ animationDelay: `${dot.delay.toFixed(2)}s` }}
+            />
+          ))}
+        </svg>
       </div>
     </div>
   );

--- a/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.module.css
+++ b/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.module.css
@@ -33,50 +33,47 @@
   background-color: rgba(255, 255, 255, 0.04);
 }
 
-.dots {
+.mark {
   position: absolute;
   inset: 0;
-  background-image: radial-gradient(
-    circle 1.5px at center,
-    rgba(0, 0, 0, 0.18) 100%,
-    transparent 100%
-  );
-  background-size: 18px 18px;
-  background-repeat: repeat;
-  mask-image: radial-gradient(closest-side, #000 55%, transparent 100%);
-  -webkit-mask-image: radial-gradient(closest-side, #000 55%, transparent 100%);
-  animation: dotDrift 14s linear infinite, dotBreathe 2.8s ease-in-out infinite;
-  will-change: background-position, opacity;
+  width: 100%;
+  height: 100%;
+  padding: 10% 14%;
+  box-sizing: border-box;
+  display: block;
+  color: rgba(20, 20, 20, 0.62);
 }
 
-[data-theme='dark'] .dots {
-  background-image: radial-gradient(
-    circle 1.5px at center,
-    rgba(255, 255, 255, 0.13) 100%,
-    transparent 100%
-  );
+[data-theme='dark'] .mark {
+  color: rgba(255, 255, 255, 0.6);
 }
 
-.card[data-paused='true'] .dots {
+.markHidden {
+  fill: transparent;
+  pointer-events: none;
+}
+
+.markDot {
+  fill: currentColor;
+  animation: dotShimmer 2.6s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+  will-change: opacity, transform;
+}
+
+.card[data-paused='true'] .markDot {
   animation-play-state: paused;
 }
 
-@keyframes dotDrift {
-  from {
-    background-position: 0 0;
-  }
-  to {
-    background-position: 18px 18px;
-  }
-}
-
-@keyframes dotBreathe {
+@keyframes dotShimmer {
   0%,
   100% {
-    opacity: 0.65;
+    opacity: 0.15;
+    transform: scale(0.85);
   }
   50% {
     opacity: 1;
+    transform: scale(1.05);
   }
 }
 
@@ -92,9 +89,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .dots {
+  .markDot {
     animation: none;
-    opacity: 0.85;
+    opacity: 0.7;
+    transform: scale(1);
   }
   .statusLabel {
     animation: none;


### PR DESCRIPTION
## Summary

Follow-up to #437. The previous dot-grid card looked like ChatGPT's. This swaps the visual identity to **araviel's own "A" monogram, composed entirely of dots that shimmer independently** — random progressive fade so the mark is always legible but never frozen, never marching in formation.

### What it looks like

A bold "A" monogram is rendered as a single SVG path (with the inner triangle as a hole via `fill-rule="evenodd"`). On mount, the placeholder samples a fine grid across the path's viewBox and uses `SVGGeometryElement.isPointInFill` to keep only the points that fall inside the A. Each surviving point becomes a small circle. The dot field is computed once and memoized in state, so re-renders never re-shuffle the constellation.

Each dot animates on its own cycle:

- `opacity: 0.15 → 1 → 0.15`
- `transform: scale(0.85 → 1.05 → 0.85)`
- duration **2.6 s ease-in-out infinite**
- `animationDelay` is randomized uniformly across the full cycle

That stagger is what produces the "random progressive shimmer" — different dots peak at different moments, so the A is constantly twinkling in waves, instantly recognisable as araviel, never just a generic skeleton.

### Stability + performance

- **GPU-only**: animates `opacity` + `transform` only. No filter, no blur, no shadow.
- **One-time sampling**: `computeMarkDots` runs once on mount and memoizes the result. Re-renders, theme switches, and phase-text changes do not recompute or re-shuffle.
- **IntersectionObserver pause**: existing `data-paused` toggle still pauses every dot's animation when scrolled out of view.
- **`prefers-reduced-motion`**: animations disabled, dots settle at opacity 0.7 — the mark is still rendered legibly.
- **SSR-safe**: initial state is `[]`; the sampling runs in `useEffect` so server-rendered HTML has no spurious DOM.
- **Theme-aware**: dot color tracks `[data-theme='dark']`, switching repaints instantly via CSS — no re-render.

The conversational phased status text, `aspect-ratio` lock, and cross-fade arrival behavior from #437 are unchanged. Only the visual layer inside the card was swapped.

## Test plan

- [x] `npm test -- --run src/components/ImageGenerationPlaceholder/` — 7 unit tests still pass
- [x] `npm run build` — production build succeeds
- [x] `npx eslint` on touched files — no new warnings
- [ ] Manual: trigger image generation → verify the A monogram appears, made of shimmering dots, with random twinkling across the shape
- [ ] Manual: each dot fades independently, no marching/wave pattern
- [ ] Manual: scroll the placeholder out of view → all shimmer pauses
- [ ] Manual: enable system-level `prefers-reduced-motion` → dots settle, mark still visible
- [ ] Manual: toggle theme mid-stream → dot color updates instantly, no flicker
- [ ] Manual: mobile (≤480 px) → card fills the bubble width, mark remains centered and clear

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_