### PR TITLE
Morphing-glow image placeholder and full-width image display

### DIFF
--- a/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.jsx
+++ b/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.jsx
@@ -2,34 +2,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import useElapsedPhase from './useElapsedPhase';
 import styles from './ImageGenerationPlaceholder.module.css';
 
-const A_MARK_PATH =
-  'M 50 8 L 92 90 L 76 90 L 67 72 L 33 72 L 24 90 L 8 90 Z M 50 28 L 38 62 L 62 62 Z';
-const SAMPLE_STEP = 3.6;
-const SAMPLE_MIN = 4;
-const SAMPLE_MAX = 96;
-const SHIMMER_DURATION_S = 2.6;
-
-function computeMarkDots(pathElement) {
-  if (!pathElement || typeof pathElement.isPointInFill !== 'function') return [];
-  const dots = [];
-  for (let y = SAMPLE_MIN; y <= SAMPLE_MAX; y += SAMPLE_STEP) {
-    for (let x = SAMPLE_MIN; x <= SAMPLE_MAX; x += SAMPLE_STEP) {
-      try {
-        if (pathElement.isPointInFill({ x, y })) {
-          dots.push({
-            x,
-            y,
-            delay: Math.random() * SHIMMER_DURATION_S,
-          });
-        }
-      } catch {
-        return [];
-      }
-    }
-  }
-  return dots;
-}
-
 export default function ImageGenerationPlaceholder({ startedAt, aspectRatio = '1 / 1' }) {
   const safeStartedAt = useMemo(
     () => (typeof startedAt === 'number' ? startedAt : Date.now()),
@@ -37,13 +9,7 @@ export default function ImageGenerationPlaceholder({ startedAt, aspectRatio = '1
   );
   const { label } = useElapsedPhase(safeStartedAt);
   const cardRef = useRef(null);
-  const pathRef = useRef(null);
   const [isVisible, setIsVisible] = useState(true);
-  const [dots, setDots] = useState([]);
-
-  useEffect(() => {
-    setDots(computeMarkDots(pathRef.current));
-  }, []);
 
   useEffect(() => {
     const el = cardRef.current;
@@ -73,24 +39,8 @@ export default function ImageGenerationPlaceholder({ startedAt, aspectRatio = '1
         data-paused={isVisible ? undefined : 'true'}
         aria-hidden="true"
       >
-        <svg
-          className={styles.mark}
-          viewBox="0 0 100 100"
-          preserveAspectRatio="xMidYMid meet"
-          focusable="false"
-        >
-          <path ref={pathRef} d={A_MARK_PATH} fillRule="evenodd" className={styles.markHidden} />
-          {dots.map((dot, idx) => (
-            <circle
-              key={idx}
-              cx={dot.x}
-              cy={dot.y}
-              r="1.1"
-              className={styles.markDot}
-              style={{ animationDelay: `${dot.delay.toFixed(2)}s` }}
-            />
-          ))}
-        </svg>
+        <div className={styles.field} />
+        <div className={styles.glow} />
       </div>
     </div>
   );

--- a/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.module.css
+++ b/src/components/ImageGenerationPlaceholder/ImageGenerationPlaceholder.module.css
@@ -1,3 +1,29 @@
+@property --gx {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 35%;
+}
+@property --gy {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 40%;
+}
+@property --gw {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 36%;
+}
+@property --gh {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 44%;
+}
+@property --gFalloff {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 55%;
+}
+
 .wrapper {
   display: flex;
   flex-direction: column;
@@ -24,56 +50,125 @@
   position: relative;
   width: 100%;
   border-radius: 16px;
-  background-color: var(--bg-hover, rgba(0, 0, 0, 0.04));
+  background-color: var(--bg-hover, rgba(0, 0, 0, 0.035));
   overflow: hidden;
   isolation: isolate;
 }
 
 [data-theme='dark'] .card {
-  background-color: rgba(255, 255, 255, 0.04);
+  background-color: rgba(255, 255, 255, 0.035);
 }
 
-.mark {
+.field,
+.glow {
   position: absolute;
   inset: 0;
-  width: 100%;
-  height: 100%;
-  padding: 10% 14%;
-  box-sizing: border-box;
-  display: block;
-  color: rgba(20, 20, 20, 0.62);
+  background-image: radial-gradient(
+    circle 1.1px at center,
+    rgba(20, 20, 20, 0.85) 100%,
+    transparent 100%
+  );
+  background-size: 20px 20px;
 }
 
-[data-theme='dark'] .mark {
-  color: rgba(255, 255, 255, 0.6);
+[data-theme='dark'] .field,
+[data-theme='dark'] .glow {
+  background-image: radial-gradient(
+    circle 1.1px at center,
+    rgba(255, 255, 255, 0.85) 100%,
+    transparent 100%
+  );
 }
 
-.markHidden {
-  fill: transparent;
-  pointer-events: none;
+.field {
+  opacity: 0.18;
+  animation: fieldBreathe 4.2s ease-in-out infinite;
+  mask-image: radial-gradient(closest-side, #000 70%, transparent 100%);
+  -webkit-mask-image: radial-gradient(closest-side, #000 70%, transparent 100%);
 }
 
-.markDot {
-  fill: currentColor;
-  animation: dotShimmer 2.6s ease-in-out infinite;
-  transform-box: fill-box;
-  transform-origin: center;
-  will-change: opacity, transform;
+.glow {
+  --gx: 35%;
+  --gy: 40%;
+  --gw: 36%;
+  --gh: 44%;
+  --gFalloff: 55%;
+  opacity: 0.95;
+  animation: glowX 9.4s ease-in-out infinite, glowY 11.7s ease-in-out infinite,
+    glowW 5.3s ease-in-out infinite, glowH 7.1s ease-in-out infinite,
+    glowFalloff 6.2s ease-in-out infinite;
+  mask-image: radial-gradient(
+    ellipse var(--gw) var(--gh) at var(--gx) var(--gy),
+    #000 0%,
+    rgba(0, 0, 0, 0.65) 30%,
+    transparent var(--gFalloff)
+  );
+  -webkit-mask-image: radial-gradient(
+    ellipse var(--gw) var(--gh) at var(--gx) var(--gy),
+    #000 0%,
+    rgba(0, 0, 0, 0.65) 30%,
+    transparent var(--gFalloff)
+  );
 }
 
-.card[data-paused='true'] .markDot {
+.card[data-paused='true'] .field,
+.card[data-paused='true'] .glow {
   animation-play-state: paused;
 }
 
-@keyframes dotShimmer {
+@keyframes glowX {
   0%,
   100% {
-    opacity: 0.15;
-    transform: scale(0.85);
+    --gx: 24%;
   }
   50% {
-    opacity: 1;
-    transform: scale(1.05);
+    --gx: 76%;
+  }
+}
+@keyframes glowY {
+  0%,
+  100% {
+    --gy: 30%;
+  }
+  50% {
+    --gy: 72%;
+  }
+}
+@keyframes glowW {
+  0%,
+  100% {
+    --gw: 28%;
+  }
+  50% {
+    --gw: 52%;
+  }
+}
+@keyframes glowH {
+  0%,
+  100% {
+    --gh: 42%;
+  }
+  50% {
+    --gh: 26%;
+  }
+}
+@keyframes glowFalloff {
+  0%,
+  100% {
+    --gFalloff: 48%;
+  }
+  50% {
+    --gFalloff: 62%;
+  }
+}
+
+@keyframes fieldBreathe {
+  0%,
+  100% {
+    opacity: 0.12;
+  }
+  50% {
+    opacity: 0.22;
   }
 }
 
@@ -89,10 +184,13 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .markDot {
+  .field {
+    animation: none;
+    opacity: 0.2;
+  }
+  .glow {
     animation: none;
     opacity: 0.7;
-    transform: scale(1);
   }
   .statusLabel {
     animation: none;

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -1355,6 +1355,7 @@ export default function MainContent() {
                     model: data.model || routeInfo?.modelName,
                     provider: data.provider || routeInfo?.provider,
                     id: imgEntry.id,
+                    size: data.size,
                   },
                 ];
                 dispatch(updateLastMessage({ generatedImages: newImages }));

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -1664,16 +1664,39 @@ function useImageDownload() {
   return { downloading, handleDownload };
 }
 
+function parseImageDimensions(size) {
+  if (!size || typeof size !== 'string') return null;
+  const match = size.match(/^\s*(\d+)\s*[xX×]\s*(\d+)\s*$/);
+  if (!match) return null;
+  const width = Number.parseInt(match[1], 10);
+  const height = Number.parseInt(match[2], 10);
+  if (!width || !height) return null;
+  return { width, height };
+}
+
 function GeneratedImageBlock({ imageData, allImages, imageIndex }) {
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const { downloading, handleDownload } = useImageDownload();
+
+  const frameStyle = useMemo(() => {
+    const dims = parseImageDimensions(imageData?.size);
+    if (!dims) return undefined;
+    return {
+      aspectRatio: `${dims.width} / ${dims.height}`,
+      width: `min(100%, calc(75vh * ${dims.width} / ${dims.height}))`,
+    };
+  }, [imageData?.size]);
 
   if (!imageData || !imageData.url) return null;
 
   return (
     <>
       <div className={styles.generatedImageBlock}>
-        <div className={styles.generatedImageFrame} onClick={() => setLightboxOpen(true)}>
+        <div
+          className={styles.generatedImageFrame}
+          style={frameStyle}
+          onClick={() => setLightboxOpen(true)}
+        >
           <img
             src={imageData.url}
             alt={imageData.prompt || imageData.model || 'Generated image'}

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1022,18 +1022,31 @@
 /* ===== Generated Image Block — ChatGPT-style ===== */
 .generatedImageBlock {
   margin: 12px 0;
-  border-radius: 16px;
-  overflow: hidden;
-  max-width: 340px;
+  width: 100%;
 }
 
 .generatedImageFrame {
   position: relative;
   cursor: pointer;
   overflow: hidden;
-  border-radius: 16px;
+  border-radius: 18px;
   background: var(--bg-secondary);
+  width: 100%;
+  max-width: 100%;
   aspect-ratio: 1 / 1;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 10px 28px rgba(0, 0, 0, 0.06);
+  animation: generatedImageEnter 320ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+[data-theme='dark'] .generatedImageFrame {
+  border-color: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25), 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.generatedImageFrame:hover {
+  transform: translateY(-1px);
 }
 
 .generatedImageImg {
@@ -1042,6 +1055,17 @@
   height: 100%;
   object-fit: cover;
   transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes generatedImageEnter {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .generatedImageFrame:hover .generatedImageImg {
@@ -1119,8 +1143,9 @@
 .generatedImagesSection {
   margin-top: 12px;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 12px;
+  width: 100%;
 }
 
 /* ===== Inline Images Row (replaces pill) ===== */


### PR DESCRIPTION
The A-shape placeholder felt static even with per-dot shimmer because the silhouette never moved. This swaps it for a constellation effect: the whole card is filled by a faint sparse dot field, with a single bright dot layer masked by a soft radial glow that drifts around the card on Lissajous-like timings and morphs its shape as it moves.

The glow's position, width, height, and falloff are all CSS @property custom percentages animated on five different periods, so the mask ellipse never returns to the same shape at the same place at the same time. The visible effect reads as a single soft light wandering through a starfield - asymmetric, never repeating, never marching. The whole field also breathes on a separate 4.2 s opacity pulse so areas outside the glow are not flat.

All animation lives in CSS and only touches @property percentages, opacity, and mask-image - GPU-friendly, no JS in the animation loop. The existing IntersectionObserver pause and prefers-reduced-motion guard still apply. The component drops the SVG path-and-sample machinery; it is now two stacked divs.

Generated images now use the full conversation column width. The SSE image_generation payload's size field is piped through MainContent so GeneratedImageBlock can parse the real width/height, lock the frame's aspect-ratio to that real ratio, and clamp the rendered width with min(100%, calc(75vh * w / h)) so portrait results never overflow the viewport. The 340 px max-width cap and the forced 1/1 aspect are gone. A subtle 18 px-radius frame, theme-aware border, soft drop shadow, and a 320 ms enter animation give the image room to feel like a deliverable rather than a thumbnail. The container also stacks vertically when a turn contains multiple images.