### PR TITLE
Morphing-glow image placeholder, real-aspect inline image, side-panel lightbox

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -1681,10 +1681,7 @@ function GeneratedImageBlock({ imageData, allImages, imageIndex }) {
   const frameStyle = useMemo(() => {
     const dims = parseImageDimensions(imageData?.size);
     if (!dims) return undefined;
-    return {
-      aspectRatio: `${dims.width} / ${dims.height}`,
-      width: `min(100%, calc(75vh * ${dims.width} / ${dims.height}))`,
-    };
+    return { aspectRatio: `${dims.width} / ${dims.height}` };
   }, [imageData?.size]);
 
   if (!imageData || !imageData.url) return null;
@@ -1850,18 +1847,24 @@ function GeneratedImageLightbox({ images, initialIndex, onClose }) {
               className={styles.genLightboxImg}
             />
           </div>
-        </div>
 
-        <div className={styles.genLightboxFooter}>
-          {activeImage.prompt && <p className={styles.genLightboxPrompt}>{activeImage.prompt}</p>}
-          <div className={styles.genLightboxMeta}>
-            {activeImage.size && <span>{activeImage.size}</span>}
-            {images.length > 1 && (
-              <span>
-                {activeIndex + 1} of {images.length}
-              </span>
-            )}
-          </div>
+          {(activeImage.prompt || activeImage.size || images.length > 1) && (
+            <aside className={styles.genLightboxSidePanel}>
+              {activeImage.prompt && (
+                <p className={styles.genLightboxPrompt}>{activeImage.prompt}</p>
+              )}
+              {(activeImage.size || images.length > 1) && (
+                <div className={styles.genLightboxMeta}>
+                  {activeImage.size && <span>{activeImage.size}</span>}
+                  {images.length > 1 && (
+                    <span>
+                      {activeIndex + 1} of {images.length}
+                    </span>
+                  )}
+                </div>
+              )}
+            </aside>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1023,16 +1023,16 @@
 .generatedImageBlock {
   margin: 12px 0;
   width: 100%;
+  max-width: 360px;
 }
 
 .generatedImageFrame {
   position: relative;
   cursor: pointer;
   overflow: hidden;
-  border-radius: 18px;
+  border-radius: 16px;
   background: var(--bg-secondary);
   width: 100%;
-  max-width: 100%;
   aspect-ratio: 1 / 1;
   border: 1px solid rgba(0, 0, 0, 0.06);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 10px 28px rgba(0, 0, 0, 0.06);
@@ -1401,12 +1401,12 @@
   justify-content: center;
   min-height: 0;
   min-width: 0;
-  padding: 0 40px;
+  padding: 0 32px 24px;
 }
 
 .genLightboxImg {
-  max-width: 80vw;
-  max-height: calc(var(--app-height) - 220px);
+  max-width: 100%;
+  max-height: calc(var(--app-height) - 140px);
   border-radius: 14px;
   object-fit: contain;
   box-shadow: 0 16px 56px rgba(0, 0, 0, 0.5);
@@ -1425,34 +1425,51 @@
   }
 }
 
-.genLightboxFooter {
+.genLightboxSidePanel {
   flex-shrink: 0;
-  padding: 16px 24px 24px;
-  text-align: center;
-  max-width: 640px;
-  margin: 0 auto;
-  width: 100%;
+  width: 320px;
+  padding: 8px 28px 24px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+}
+
+.genLightboxSidePanel::-webkit-scrollbar {
+  width: 6px;
+}
+.genLightboxSidePanel::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.18);
+  border-radius: 3px;
 }
 
 .genLightboxPrompt {
-  font-size: 13px;
-  line-height: 1.6;
-  color: rgba(255, 255, 255, 0.55);
-  margin: 0 0 8px;
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.78);
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .genLightboxMeta {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 16px;
+  gap: 14px;
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.42);
   font-weight: 500;
+  letter-spacing: 0.02em;
+  padding-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-/* Mobile: hide sidebar, show simpler layout */
-@media (max-width: 640px) {
+@media (max-width: 768px) {
+  .genLightboxMain {
+    flex-direction: column;
+  }
   .genLightboxSidebar {
     display: none;
   }
@@ -1460,7 +1477,13 @@
     padding: 0 16px;
   }
   .genLightboxImg {
-    max-width: 95vw;
+    max-width: 100%;
+    max-height: calc(var(--app-height) - 280px);
+  }
+  .genLightboxSidePanel {
+    width: 100%;
+    max-height: 30vh;
+    padding: 12px 20px 20px;
   }
 }
 


### PR DESCRIPTION
## Summary

Combines two follow-ups on the image-generation experience.

### 1. Morphing-glow image placeholder

The previous A-mark felt static because the silhouette never moved. This swaps it for a **constellation** effect: the whole card is filled by a faint, sparse dot field, with a single bright dot layer masked by a **soft radial glow that drifts around the card on Lissajous-like timings and morphs as it moves**.

The glow's `--gx`, `--gy`, `--gw`, `--gh`, and `--gFalloff` are CSS `@property` percentages animated on five different periods (9.4 s / 11.7 s / 5.3 s / 7.1 s / 6.2 s), so the mask ellipse never returns to the same shape at the same place at the same time. The visible effect reads as a single soft light wandering through a starfield — asymmetric, never repeating, never marching. The field also breathes on a separate 4.2 s opacity pulse so areas outside the glow are not flat.

All animation lives in CSS and only touches `@property` percentages, `opacity`, and `mask-image` — GPU-friendly, no JS in the animation loop. The existing `IntersectionObserver` pause and `prefers-reduced-motion` guard still apply. The component drops the SVG path-and-sample machinery; it is now two stacked divs.

### 2. Generated image display

- **Inline display stays compact** (capped at 360 px max-width) so the bubble feels intentional in the flow — the lightbox is for the full-resolution view.
- The SSE `image_generation` payload's `size` field is now piped through `MainContent` into the rendered message, so `GeneratedImageBlock` can parse the real width/height and lock `aspect-ratio` to the actual ratio. Portrait results stay portrait; landscape stays landscape.
- A subtle frame (border, soft drop shadow, 320 ms enter animation) makes the image feel like a deliverable rather than a thumbnail.
- The container stacks vertically when a turn contains multiple images.

### 3. Lightbox layout

The prompt + meta lived in a centered footer that **overlapped portrait images** on shorter viewports. They now live in a **320 px side panel to the right of the image**, with the prompt at top, a divider, and `size / "n of m"` meta beneath. The panel scrolls independently when the prompt is long (thin themed scrollbar).

Under 768 px viewports, the layout collapses to image-on-top / panel-below so phones keep working.

The old footer and its CSS are removed. Keyboard nav, save, close, and the thumbnail sidebar are unchanged.

## Test plan

- [x] `npm test -- --run src/components/ImageGenerationPlaceholder/` — 7 unit tests pass
- [x] `npm test -- --run` — full suite green (one pre-existing `authSlice` failure unrelated)
- [x] `npm run build` — production build succeeds
- [x] `npx eslint` on touched files — no new warnings
- [ ] Manual: trigger image generation → verify the morphing-glow placeholder drifts and breathes, dot field never marches
- [ ] Manual: scroll the placeholder out of view → animations pause
- [ ] Manual: `prefers-reduced-motion` enabled → animations stop, field still legible
- [ ] Manual: image arrives → frame uses actual aspect ratio, stays compact (≤360 px wide)
- [ ] Manual: open lightbox → prompt + meta on the right, image on the left, no overlap on portrait images
- [ ] Manual: open lightbox with a very long prompt → side panel scrolls independently
- [ ] Manual: mobile (≤768 px) → side panel falls below the image, scrollable
- [ ] Manual: toggle theme mid-stream → placeholder dot color updates instantly

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_