### PR TITLE
Center lightbox image and prompt panel as one unit

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -1838,33 +1838,34 @@ function GeneratedImageLightbox({ images, initialIndex, onClose }) {
             </div>
           )}
 
-          {/* Main image area */}
-          <div className={styles.genLightboxBody}>
-            <img
-              key={activeIndex}
-              src={activeImage.url}
-              alt={activeImage.prompt || activeImage.model || 'Generated image'}
-              className={styles.genLightboxImg}
-            />
-          </div>
+          <div className={styles.genLightboxStage}>
+            <div className={styles.genLightboxBody}>
+              <img
+                key={activeIndex}
+                src={activeImage.url}
+                alt={activeImage.prompt || activeImage.model || 'Generated image'}
+                className={styles.genLightboxImg}
+              />
+            </div>
 
-          {(activeImage.prompt || activeImage.size || images.length > 1) && (
-            <aside className={styles.genLightboxSidePanel}>
-              {activeImage.prompt && (
-                <p className={styles.genLightboxPrompt}>{activeImage.prompt}</p>
-              )}
-              {(activeImage.size || images.length > 1) && (
-                <div className={styles.genLightboxMeta}>
-                  {activeImage.size && <span>{activeImage.size}</span>}
-                  {images.length > 1 && (
-                    <span>
-                      {activeIndex + 1} of {images.length}
-                    </span>
-                  )}
-                </div>
-              )}
-            </aside>
-          )}
+            {(activeImage.prompt || activeImage.size || images.length > 1) && (
+              <aside className={styles.genLightboxSidePanel}>
+                {activeImage.prompt && (
+                  <p className={styles.genLightboxPrompt}>{activeImage.prompt}</p>
+                )}
+                {(activeImage.size || images.length > 1) && (
+                  <div className={styles.genLightboxMeta}>
+                    {activeImage.size && <span>{activeImage.size}</span>}
+                    {images.length > 1 && (
+                      <span>
+                        {activeIndex + 1} of {images.length}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </aside>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1394,19 +1394,32 @@
   transform: scale(1.12);
 }
 
-.genLightboxBody {
+.genLightboxStage {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 0;
-  min-width: 0;
+  gap: 28px;
   padding: 0 32px 24px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.genLightboxBody {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  min-height: 0;
+  flex-shrink: 1;
 }
 
 .genLightboxImg {
+  display: block;
   max-width: 100%;
   max-height: calc(var(--app-height) - 140px);
+  width: auto;
+  height: auto;
   border-radius: 14px;
   object-fit: contain;
   box-shadow: 0 16px 56px rgba(0, 0, 0, 0.5);
@@ -1427,8 +1440,10 @@
 
 .genLightboxSidePanel {
   flex-shrink: 0;
-  width: 320px;
-  padding: 8px 28px 24px 4px;
+  width: clamp(240px, 22vw, 340px);
+  align-self: center;
+  max-height: calc(var(--app-height) - 140px);
+  padding: 4px 4px 4px 0;
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -1462,28 +1477,37 @@
   color: rgba(255, 255, 255, 0.42);
   font-weight: 500;
   letter-spacing: 0.02em;
-  padding-top: 4px;
+  padding-top: 10px;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-@media (max-width: 768px) {
-  .genLightboxMain {
+@media (max-width: 900px) {
+  .genLightboxStage {
     flex-direction: column;
-  }
-  .genLightboxSidebar {
-    display: none;
-  }
-  .genLightboxBody {
-    padding: 0 16px;
-  }
-  .genLightboxImg {
-    max-width: 100%;
-    max-height: calc(var(--app-height) - 280px);
+    gap: 16px;
+    padding: 0 20px 16px;
   }
   .genLightboxSidePanel {
     width: 100%;
-    max-height: 30vh;
-    padding: 12px 20px 20px;
+    max-width: min(640px, 92vw);
+    max-height: 28vh;
+    align-self: stretch;
+    padding: 0;
+  }
+  .genLightboxImg {
+    max-height: calc(var(--app-height) - 260px);
+  }
+}
+
+@media (max-width: 640px) {
+  .genLightboxSidebar {
+    display: none;
+  }
+  .genLightboxStage {
+    padding: 0 14px 14px;
+  }
+  .genLightboxPrompt {
+    font-size: 13px;
   }
 }
 


### PR DESCRIPTION
## Summary

Yes — I see it. The side panel was anchored to the right viewport edge while the image was centred inside its `flex: 1` body, so the prompt visually drifted off to the far right with empty space between it and the image. The panel was also a fixed 320 px, which clipped on narrower screens and felt oversized on very wide ones.

## Fix

A new `.genLightboxStage` wraps both the image body and the side panel as a single centered unit. The image keeps its natural size capped by viewport height + available stage width; the panel uses `width: clamp(240px, 22vw, 340px)` so it scales with the viewport instead of sitting in a fixed slot. The pair sits centred horizontally in the remaining lightbox area (after the optional thumbnail sidebar) — so the prompt always reads as the image's caption, never as a separate floating column at the edge.

The meta line also gets a touch more breathing room above its divider so it reads as a footer to the prompt, not a continuation of it.

## Responsive

Two breakpoints replace the previous single one:

| Viewport | Layout |
|---|---|
| ≥ 900 px | Image on the left, panel on the right, centred as a pair, sidebar (if multi-image) on the far left |
| < 900 px | Stage stacks → image on top, panel below (max-height 28vh, scrolls if long) |
| < 640 px | Thumbnail sidebar hides, stage padding tightens, prompt font scales down 0.5 px |

## Test plan

- [x] `npm run build` — production build succeeds
- [x] `npx eslint` on touched files — no new warnings
- [ ] Manual: open lightbox on wide desktop → image + prompt sit together, both visually centred
- [ ] Manual: long prompt → panel scrolls independently of image
- [ ] Manual: ultra-wide screen → panel doesn't bloat (capped at 340 px)
- [ ] Manual: 1024 px laptop → still side-by-side, balanced
- [ ] Manual: 800 px window → stage stacks, image on top, panel below
- [ ] Manual: 600 px window → thumbnail sidebar hides, layout still readable
- [ ] Manual: small phone → no overflow, prompt readable

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_