### PR TITLE
Let users download mermaid diagrams as PNG or PDF

### DIFF
--- a/src/components/DiagramExportMenu/DiagramExportMenu.jsx
+++ b/src/components/DiagramExportMenu/DiagramExportMenu.jsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react';
+import useDiagramExport from '../../hooks/useDiagramExport';
+import { DownloadIcon } from '../Icons';
+import styles from './DiagramExportMenu.module.css';
+
+export default function DiagramExportMenu({ svgGetter, disabled = false }) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  const { exportPng, exportPdf, isExporting } = useDiagramExport(svgGetter);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleClick = (event) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (event) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  const runExport = (action) => async () => {
+    setOpen(false);
+    await action();
+  };
+
+  return (
+    <div className={styles.wrapper} ref={wrapperRef}>
+      <button
+        type="button"
+        className={styles.trigger}
+        onClick={() => setOpen((value) => !value)}
+        disabled={disabled || isExporting}
+        aria-label="Download diagram"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Download"
+      >
+        {isExporting ? <span className={styles.spinner} aria-hidden="true" /> : <DownloadIcon />}
+      </button>
+      {open && (
+        <ul className={styles.menu} role="menu">
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              className={styles.item}
+              onClick={runExport(exportPng)}
+            >
+              <span className={styles.itemLabel}>Download as PNG</span>
+              <span className={styles.itemHint}>High-res image</span>
+            </button>
+          </li>
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              className={styles.item}
+              onClick={runExport(exportPdf)}
+            >
+              <span className={styles.itemLabel}>Download as PDF</span>
+              <span className={styles.itemHint}>Single page, A4</span>
+            </button>
+          </li>
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/DiagramExportMenu/DiagramExportMenu.module.css
+++ b/src/components/DiagramExportMenu/DiagramExportMenu.module.css
@@ -1,0 +1,120 @@
+.wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.trigger:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.trigger:focus-visible {
+  outline: 2px solid var(--accent, #4a90e2);
+  outline-offset: 1px;
+}
+
+.trigger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  animation: diagramExportSpin 0.7s linear infinite;
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 20;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  min-width: 200px;
+  border-radius: 10px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 12px 28px rgba(0, 0, 0, 0.12);
+  animation: diagramExportMenuIn 0.14s ease-out;
+}
+
+[data-theme='dark'] .menu {
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4), 0 12px 28px rgba(0, 0, 0, 0.5);
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--text-primary);
+  transition: background-color 0.12s ease;
+}
+
+.item:hover,
+.item:focus-visible {
+  background: var(--bg-hover);
+  outline: none;
+}
+
+.itemLabel {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.1px;
+}
+
+.itemHint {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+@keyframes diagramExportSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes diagramExportMenuIn {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner,
+  .menu {
+    animation: none;
+  }
+}

--- a/src/components/DiagramExportMenu/index.js
+++ b/src/components/DiagramExportMenu/index.js
@@ -1,0 +1,1 @@
+export { default } from './DiagramExportMenu';

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -25,6 +25,7 @@ import {
   reportSubConversation,
 } from '../../services/api';
 import { useToast } from '../Toast/Toast';
+import DiagramExportMenu from '../DiagramExportMenu';
 import { logger } from '../../lib/logger';
 import { readBooleanSetting } from '../../lib/localSettings';
 import { getFriendlyError } from '../../lib/chatErrorMessages';
@@ -619,6 +620,7 @@ function CodeBlock({ lang, code }) {
  */
 function MermaidBlock({ code }) {
   const containerRef = useRef(null);
+  const svgRef = useRef('');
   const [svgContent, setSvgContent] = useState('');
   const [error, setError] = useState(null);
   const [showCode, setShowCode] = useState(false);
@@ -637,12 +639,14 @@ function MermaidBlock({ code }) {
         });
         const { svg } = await mermaid.render(idRef.current, code.trim());
         if (!cancelled) {
+          svgRef.current = svg;
           setSvgContent(svg);
           setError(null);
         }
       } catch (err) {
         if (!cancelled) {
           setError(err.message || 'Failed to render diagram');
+          svgRef.current = '';
           setSvgContent('');
         }
       }
@@ -653,6 +657,8 @@ function MermaidBlock({ code }) {
     };
   }, [code, effectiveTheme]);
 
+  const getSvgForExport = useCallback(() => svgRef.current, []);
+
   if (error) {
     return <CodeBlock lang="mermaid" code={code} />;
   }
@@ -661,9 +667,12 @@ function MermaidBlock({ code }) {
     <div className={styles.mermaidBlock}>
       <div className={styles.mermaidHeader}>
         <span className={styles.mermaidLabel}>Diagram</span>
-        <button className={styles.mermaidToggleCode} onClick={() => setShowCode(!showCode)}>
-          {showCode ? 'Preview' : 'Code'}
-        </button>
+        <div className={styles.mermaidHeaderActions}>
+          <DiagramExportMenu svgGetter={getSvgForExport} disabled={!svgContent || showCode} />
+          <button className={styles.mermaidToggleCode} onClick={() => setShowCode(!showCode)}>
+            {showCode ? 'Preview' : 'Code'}
+          </button>
+        </div>
       </div>
       {showCode ? (
         <CodeBlock lang="mermaid" code={code} />

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1609,6 +1609,12 @@
   letter-spacing: 0.01em;
 }
 
+.mermaidHeaderActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .mermaidToggleCode {
   font-size: 11.5px;
   font-weight: 550;

--- a/src/hooks/useDiagramExport.js
+++ b/src/hooks/useDiagramExport.js
@@ -1,0 +1,187 @@
+import { useCallback, useState } from 'react';
+import { saveAs } from 'file-saver';
+import { useToast } from '../components/Toast/Toast';
+
+const EXPORT_PIXEL_SCALE = 2;
+const PDF_PAGE_WIDTH_PT = 595.28;
+const PDF_PAGE_HEIGHT_PT = 841.89;
+const PDF_PAGE_MARGIN_PT = 40;
+const FALLBACK_DIAGRAM_WIDTH = 800;
+const FALLBACK_DIAGRAM_HEIGHT = 600;
+
+export function buildExportFilename(extension, now = new Date()) {
+  const pad = (n) => String(n).padStart(2, '0');
+  const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(
+    now.getHours()
+  )}${pad(now.getMinutes())}`;
+  return `diagram-${stamp}.${extension}`;
+}
+
+export function readSvgDimensions(svgElement) {
+  const widthAttr = parseFloat(svgElement.getAttribute('width'));
+  const heightAttr = parseFloat(svgElement.getAttribute('height'));
+  if (
+    Number.isFinite(widthAttr) &&
+    Number.isFinite(heightAttr) &&
+    widthAttr > 0 &&
+    heightAttr > 0
+  ) {
+    return { width: widthAttr, height: heightAttr };
+  }
+  const viewBox = svgElement.getAttribute('viewBox');
+  if (viewBox) {
+    const parts = viewBox.split(/\s+|,/).map(Number);
+    if (parts.length === 4 && parts[2] > 0 && parts[3] > 0) {
+      return { width: parts[2], height: parts[3] };
+    }
+  }
+  return { width: FALLBACK_DIAGRAM_WIDTH, height: FALLBACK_DIAGRAM_HEIGHT };
+}
+
+async function rasterizeSvg(svgString) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svgString, 'image/svg+xml');
+  const svg = doc.documentElement;
+  if (!svg || svg.nodeName === 'parsererror') {
+    throw new Error('Could not parse diagram SVG');
+  }
+
+  const { width, height } = readSvgDimensions(svg);
+  svg.setAttribute('width', String(width));
+  svg.setAttribute('height', String(height));
+
+  const serialized = new XMLSerializer().serializeToString(svg);
+  const svgBlob = new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' });
+  const objectUrl = URL.createObjectURL(svgBlob);
+
+  try {
+    const image = await new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error('Failed to load diagram image'));
+      img.src = objectUrl;
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.round(width * EXPORT_PIXEL_SCALE);
+    canvas.height = Math.round(height * EXPORT_PIXEL_SCALE);
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+    return { canvas, width, height };
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+async function canvasToPngBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error('PNG encoding failed'))),
+      'image/png'
+    );
+  });
+}
+
+async function getPdfMake() {
+  const pdfMakeModule = await import('pdfmake/build/pdfmake');
+  const pdfFontsModule = await import('pdfmake/build/vfs_fonts');
+  const pdfMake = pdfMakeModule.default ?? pdfMakeModule;
+  const fontVfs =
+    pdfFontsModule.pdfMake?.vfs ??
+    pdfFontsModule.default?.pdfMake?.vfs ??
+    pdfFontsModule.default?.vfs;
+  if (fontVfs) pdfMake.vfs = fontVfs;
+  return pdfMake;
+}
+
+function fitToPage(width, height) {
+  const maxWidth = PDF_PAGE_WIDTH_PT - PDF_PAGE_MARGIN_PT * 2;
+  const maxHeight = PDF_PAGE_HEIGHT_PT - PDF_PAGE_MARGIN_PT * 2;
+  const scale = Math.min(1, maxWidth / width, maxHeight / height);
+  return { width: Math.round(width * scale), height: Math.round(height * scale) };
+}
+
+function readSvgString(svgGetter) {
+  if (typeof svgGetter === 'function') return svgGetter();
+  if (typeof svgGetter === 'string') return svgGetter;
+  return null;
+}
+
+export default function useDiagramExport(svgGetter) {
+  const [isExporting, setIsExporting] = useState(false);
+  const { showError } = useToast();
+
+  const exportPng = useCallback(async () => {
+    const svgString = readSvgString(svgGetter);
+    if (!svgString) {
+      showError('No diagram to export yet.');
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const { canvas } = await rasterizeSvg(svgString);
+      const blob = await canvasToPngBlob(canvas);
+      saveAs(blob, buildExportFilename('png'));
+    } catch {
+      showError('Could not export PNG. Please try again.');
+    } finally {
+      setIsExporting(false);
+    }
+  }, [svgGetter, showError]);
+
+  const exportPdf = useCallback(async () => {
+    const svgString = readSvgString(svgGetter);
+    if (!svgString) {
+      showError('No diagram to export yet.');
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const { canvas, width, height } = await rasterizeSvg(svgString);
+      const dataUri = canvas.toDataURL('image/png');
+      const pdfMake = await getPdfMake();
+      const fitted = fitToPage(width, height);
+
+      const docDefinition = {
+        content: [
+          {
+            image: dataUri,
+            width: fitted.width,
+            height: fitted.height,
+            alignment: 'center',
+          },
+        ],
+        pageMargins: [
+          PDF_PAGE_MARGIN_PT,
+          PDF_PAGE_MARGIN_PT,
+          PDF_PAGE_MARGIN_PT,
+          PDF_PAGE_MARGIN_PT,
+        ],
+        info: { title: 'Diagram', creator: 'Araviel' },
+      };
+
+      await new Promise((resolve, reject) => {
+        try {
+          pdfMake.createPdf(docDefinition).getBlob((blob) => {
+            if (!blob) {
+              reject(new Error('PDF encoding failed'));
+              return;
+            }
+            saveAs(blob, buildExportFilename('pdf'));
+            resolve();
+          });
+        } catch (err) {
+          reject(err);
+        }
+      });
+    } catch {
+      showError('Could not export PDF. Please try again.');
+    } finally {
+      setIsExporting(false);
+    }
+  }, [svgGetter, showError]);
+
+  return { exportPng, exportPdf, isExporting };
+}

--- a/src/hooks/useDiagramExport.test.js
+++ b/src/hooks/useDiagramExport.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { buildExportFilename, readSvgDimensions } from './useDiagramExport';
+
+function svgElementFrom(markup) {
+  return new DOMParser().parseFromString(markup, 'image/svg+xml').documentElement;
+}
+
+describe('buildExportFilename', () => {
+  it('formats a stamp from the supplied date', () => {
+    const now = new Date(2025, 1, 7, 9, 4);
+    expect(buildExportFilename('png', now)).toBe('diagram-2025-02-07-0904.png');
+  });
+
+  it('preserves the requested extension', () => {
+    const now = new Date(2024, 11, 31, 23, 59);
+    expect(buildExportFilename('pdf', now)).toBe('diagram-2024-12-31-2359.pdf');
+  });
+});
+
+describe('readSvgDimensions', () => {
+  it('uses numeric width and height attributes when present', () => {
+    const svg = svgElementFrom('<svg width="200" height="120"></svg>');
+    expect(readSvgDimensions(svg)).toEqual({ width: 200, height: 120 });
+  });
+
+  it('falls back to viewBox when width/height are missing', () => {
+    const svg = svgElementFrom('<svg viewBox="0 0 320 180"></svg>');
+    expect(readSvgDimensions(svg)).toEqual({ width: 320, height: 180 });
+  });
+
+  it('returns a sensible default when nothing is set', () => {
+    const svg = svgElementFrom('<svg></svg>');
+    expect(readSvgDimensions(svg)).toEqual({ width: 800, height: 600 });
+  });
+
+  it('ignores width/height when they are not finite positives', () => {
+    const svg = svgElementFrom('<svg width="0" height="-10" viewBox="0 0 100 50"></svg>');
+    expect(readSvgDimensions(svg)).toEqual({ width: 100, height: 50 });
+  });
+});


### PR DESCRIPTION
## Summary

Diagram blocks rendered via mermaid had no way out — you couldn't paste them into Slack, email them to a client, or drop them into a deck. This adds a small **download** button next to the existing **Code / Preview** toggle on every diagram block. Clicking it opens a tiny menu with two options:

- **Download as PNG** — high-res image (2× scale)
- **Download as PDF** — single page, A4

## Implementation

- **`useDiagramExport(svgGetter)`** — owns both export paths. It serialises the rendered SVG, paints it onto a 2× canvas with a white backdrop (so the file reads in either light or dark mode), and either:
  - encodes to a PNG blob, or
  - wraps the PNG inside a fitted-to-page A4 `pdfmake` document.
- **`DiagramExportMenu`** — pure presentation. 28 px icon trigger, popover menu, role-correct (`menu` / `menuitem`), closes on outside click / Escape / after a successful export / after a failure. Trigger shows a small spinner while pdfmake bootstraps and renders. Disabled while the diagram is in Code view (nothing to rasterise) and while an export is in flight.
- **`MermaidBlock`** — now keeps a ref to the latest rendered SVG and exposes a stable getter to the menu, so re-renders never break the export target. A new header-actions row keeps the existing Code / Preview button untouched and just adds the export trigger to its left.

## Dependencies

**No new packages.** `pdfmake` and `file-saver` are already project dependencies, used by the existing `fileGenerator` service for conversation export. The hook lazy-loads pdfmake on first use so the chunk only ships when a user actually exports a PDF.

## Safety + UX

- **Theme-honest export** — both files always rasterise on a white backdrop, so the result reads in Slack, Notion, decks, etc.
- **Sensible filenames** — `diagram-YYYY-MM-DD-HHMM.png` / `.pdf`.
- **Error path** — every failure surfaces through the existing `useToast` `showError` pattern. Never a silent black hole.
- **Loading state** — trigger spinner while the PDF path bootstraps and renders. PNG is instant enough to skip a spinner.
- **Disabled state** — when the user has switched to the Code view or an export is mid-flight.
- **Accessibility** — `aria-haspopup`, `aria-expanded`, `:focus-visible` rings, role-correct menu/menuitems, keyboard close on Escape, `prefers-reduced-motion` disables menu + spinner animation.
- **Object URL lifecycle** — the SVG blob URL is revoked in a `finally` so even a failed image load never leaks.

## Test plan

- [x] `npm test -- --run src/hooks/useDiagramExport.test.js` — 6 unit tests covering `buildExportFilename` formatting and `readSvgDimensions` (numeric attrs, viewBox fallback, default, invalid attrs)
- [x] `npm test -- --run` — full suite green (one pre-existing `authSlice` failure unrelated)
- [x] `npm run build` — production build succeeds
- [x] `npx eslint` on touched files — no new warnings
- [ ] Manual: any mermaid block → click download → menu opens → PNG downloads instantly, file renders crisply in macOS Preview, Slack paste, Notion paste
- [ ] Manual: click PDF → spinner shows briefly → A4 PDF downloads with the diagram centred and aspect-correct
- [ ] Manual: toggle to Code view → button disabled
- [ ] Manual: open menu → click outside → menu closes
- [ ] Manual: open menu → Escape → menu closes
- [ ] Manual: tab through → focus rings visible, Enter triggers export
- [ ] Manual: dark theme → menu contrast looks intentional, exported PNG/PDF are still light-backed
- [ ] Manual: mobile / narrow viewport → menu still fits, items still tappable

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_