### PR TITLE
Fix mermaid diagram exports by re-rendering with HTML labels disabled

### DIFF
--- a/src/components/DiagramExportMenu/DiagramExportMenu.jsx
+++ b/src/components/DiagramExportMenu/DiagramExportMenu.jsx
@@ -3,10 +3,10 @@ import useDiagramExport from '../../hooks/useDiagramExport';
 import { DownloadIcon } from '../Icons';
 import styles from './DiagramExportMenu.module.css';
 
-export default function DiagramExportMenu({ svgGetter, disabled = false }) {
+export default function DiagramExportMenu({ code, displayTheme, disabled = false }) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef(null);
-  const { exportPng, exportPdf, isExporting } = useDiagramExport(svgGetter);
+  const { exportPng, exportPdf, isExporting } = useDiagramExport({ code, displayTheme });
 
   useEffect(() => {
     if (!open) return undefined;

--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -620,7 +620,6 @@ function CodeBlock({ lang, code }) {
  */
 function MermaidBlock({ code }) {
   const containerRef = useRef(null);
-  const svgRef = useRef('');
   const [svgContent, setSvgContent] = useState('');
   const [error, setError] = useState(null);
   const [showCode, setShowCode] = useState(false);
@@ -639,14 +638,12 @@ function MermaidBlock({ code }) {
         });
         const { svg } = await mermaid.render(idRef.current, code.trim());
         if (!cancelled) {
-          svgRef.current = svg;
           setSvgContent(svg);
           setError(null);
         }
       } catch (err) {
         if (!cancelled) {
           setError(err.message || 'Failed to render diagram');
-          svgRef.current = '';
           setSvgContent('');
         }
       }
@@ -657,8 +654,6 @@ function MermaidBlock({ code }) {
     };
   }, [code, effectiveTheme]);
 
-  const getSvgForExport = useCallback(() => svgRef.current, []);
-
   if (error) {
     return <CodeBlock lang="mermaid" code={code} />;
   }
@@ -668,7 +663,11 @@ function MermaidBlock({ code }) {
       <div className={styles.mermaidHeader}>
         <span className={styles.mermaidLabel}>Diagram</span>
         <div className={styles.mermaidHeaderActions}>
-          <DiagramExportMenu svgGetter={getSvgForExport} disabled={!svgContent || showCode} />
+          <DiagramExportMenu
+            code={code}
+            displayTheme={effectiveTheme}
+            disabled={!svgContent || showCode}
+          />
           <button className={styles.mermaidToggleCode} onClick={() => setShowCode(!showCode)}>
             {showCode ? 'Preview' : 'Code'}
           </button>

--- a/src/hooks/useDiagramExport.js
+++ b/src/hooks/useDiagramExport.js
@@ -9,6 +9,30 @@ const PDF_PAGE_MARGIN_PT = 40;
 const FALLBACK_DIAGRAM_WIDTH = 800;
 const FALLBACK_DIAGRAM_HEIGHT = 600;
 
+const EXPORT_MERMAID_CONFIG = {
+  startOnLoad: false,
+  theme: 'default',
+  securityLevel: 'loose',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  flowchart: { htmlLabels: false, useMaxWidth: false },
+  sequence: { useMaxWidth: false },
+  classDiagram: { useMaxWidth: false },
+  stateDiagram: { useMaxWidth: false },
+  er: { useMaxWidth: false },
+  pie: { useMaxWidth: false },
+  journey: { useMaxWidth: false },
+  gantt: { useMaxWidth: false },
+  mindmap: { useMaxWidth: false },
+  quadrantChart: { useMaxWidth: false },
+};
+
+const DISPLAY_MERMAID_CONFIG = {
+  startOnLoad: false,
+  theme: 'default',
+  securityLevel: 'loose',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+};
+
 export function buildExportFilename(extension, now = new Date()) {
   const pad = (n) => String(n).padStart(2, '0');
   const stamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(
@@ -38,12 +62,35 @@ export function readSvgDimensions(svgElement) {
   return { width: FALLBACK_DIAGRAM_WIDTH, height: FALLBACK_DIAGRAM_HEIGHT };
 }
 
-async function rasterizeSvg(svgString) {
+async function renderExportSafeSvg(code, displayTheme) {
+  const mermaidModule = await import('mermaid');
+  const mermaid = mermaidModule.default ?? mermaidModule;
+  mermaid.initialize(EXPORT_MERMAID_CONFIG);
+  const renderId = `mermaid-export-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  try {
+    const { svg } = await mermaid.render(renderId, code.trim());
+    return svg;
+  } finally {
+    mermaid.initialize({
+      ...DISPLAY_MERMAID_CONFIG,
+      theme: displayTheme === 'dark' ? 'dark' : 'default',
+    });
+  }
+}
+
+async function rasterizeSvgString(svgString) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(svgString, 'image/svg+xml');
   const svg = doc.documentElement;
-  if (!svg || svg.nodeName === 'parsererror') {
+  if (!svg || svg.nodeName === 'parsererror' || svg.nodeName.toLowerCase() !== 'svg') {
     throw new Error('Could not parse diagram SVG');
+  }
+
+  if (!svg.getAttribute('xmlns')) {
+    svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  }
+  if (!svg.getAttribute('xmlns:xlink')) {
+    svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
   }
 
   const { width, height } = readSvgDimensions(svg);
@@ -51,28 +98,23 @@ async function rasterizeSvg(svgString) {
   svg.setAttribute('height', String(height));
 
   const serialized = new XMLSerializer().serializeToString(svg);
-  const svgBlob = new Blob([serialized], { type: 'image/svg+xml;charset=utf-8' });
-  const objectUrl = URL.createObjectURL(svgBlob);
+  const dataUri = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(serialized)}`;
 
-  try {
-    const image = await new Promise((resolve, reject) => {
-      const img = new Image();
-      img.onload = () => resolve(img);
-      img.onerror = () => reject(new Error('Failed to load diagram image'));
-      img.src = objectUrl;
-    });
+  const image = await new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load diagram image'));
+    img.src = dataUri;
+  });
 
-    const canvas = document.createElement('canvas');
-    canvas.width = Math.round(width * EXPORT_PIXEL_SCALE);
-    canvas.height = Math.round(height * EXPORT_PIXEL_SCALE);
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
-    return { canvas, width, height };
-  } finally {
-    URL.revokeObjectURL(objectUrl);
-  }
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(width * EXPORT_PIXEL_SCALE);
+  canvas.height = Math.round(height * EXPORT_PIXEL_SCALE);
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+  return { canvas, width, height };
 }
 
 async function canvasToPngBlob(canvas) {
@@ -103,43 +145,38 @@ function fitToPage(width, height) {
   return { width: Math.round(width * scale), height: Math.round(height * scale) };
 }
 
-function readSvgString(svgGetter) {
-  if (typeof svgGetter === 'function') return svgGetter();
-  if (typeof svgGetter === 'string') return svgGetter;
-  return null;
-}
-
-export default function useDiagramExport(svgGetter) {
+export default function useDiagramExport({ code, displayTheme }) {
   const [isExporting, setIsExporting] = useState(false);
   const { showError } = useToast();
 
   const exportPng = useCallback(async () => {
-    const svgString = readSvgString(svgGetter);
-    if (!svgString) {
+    if (!code) {
       showError('No diagram to export yet.');
       return;
     }
     setIsExporting(true);
     try {
-      const { canvas } = await rasterizeSvg(svgString);
+      const svgString = await renderExportSafeSvg(code, displayTheme);
+      const { canvas } = await rasterizeSvgString(svgString);
       const blob = await canvasToPngBlob(canvas);
       saveAs(blob, buildExportFilename('png'));
-    } catch {
+    } catch (err) {
+      console.error('Diagram PNG export failed', err);
       showError('Could not export PNG. Please try again.');
     } finally {
       setIsExporting(false);
     }
-  }, [svgGetter, showError]);
+  }, [code, displayTheme, showError]);
 
   const exportPdf = useCallback(async () => {
-    const svgString = readSvgString(svgGetter);
-    if (!svgString) {
+    if (!code) {
       showError('No diagram to export yet.');
       return;
     }
     setIsExporting(true);
     try {
-      const { canvas, width, height } = await rasterizeSvg(svgString);
+      const svgString = await renderExportSafeSvg(code, displayTheme);
+      const { canvas, width, height } = await rasterizeSvgString(svgString);
       const dataUri = canvas.toDataURL('image/png');
       const pdfMake = await getPdfMake();
       const fitted = fitToPage(width, height);
@@ -172,16 +209,17 @@ export default function useDiagramExport(svgGetter) {
             saveAs(blob, buildExportFilename('pdf'));
             resolve();
           });
-        } catch (err) {
-          reject(err);
+        } catch (innerErr) {
+          reject(innerErr);
         }
       });
-    } catch {
+    } catch (err) {
+      console.error('Diagram PDF export failed', err);
       showError('Could not export PDF. Please try again.');
     } finally {
       setIsExporting(false);
     }
-  }, [svgGetter, showError]);
+  }, [code, displayTheme, showError]);
 
   return { exportPng, exportPdf, isExporting };
 }


### PR DESCRIPTION
## Summary

Both PNG and PDF exports were failing for every diagram. Root cause:

The displayed mermaid SVG uses `<foreignObject>` elements to host the HTML node labels (`flowchart.htmlLabels: true` is mermaid's default). Modern browsers refuse to load those SVGs through `new Image()` for security reasons — `img.onerror` fires, the rasterise step rejects, and both PNG and PDF (PDF wraps PNG) hit the same toast.

## Fix

`useDiagramExport` now takes the **raw mermaid code** instead of a getter that reaches into the displayed SVG. On each export it:

1. Dynamically imports `mermaid`.
2. Calls `mermaid.initialize` with a dedicated **export config**:
   - `theme: 'default'` (light background → exported file reads on Slack / Notion / decks regardless of the user's current theme),
   - `flowchart.htmlLabels: false` (pure-SVG `<text>` instead of `<foreignObject>`),
   - `useMaxWidth: false` for every diagram family,
3. Re-renders the diagram into a clean SVG string.
4. **Always** restores the original display config in a `finally` block, so the on-screen diagram is never affected.

Rasterisation also got hardened:

- switched from a `Blob:` URL to an inline `data:image/svg+xml` URI (more reliable across browsers for SVG→Image hand-off),
- asserts the parsed root is an actual `<svg>` element,
- defensively attaches `xmlns` and `xmlns:xlink` if missing,
- locks `width` / `height` on the cloned SVG so canvas sizing is deterministic.

Both export paths now `console.error` the underlying failure before the toast fires, so production issues are debuggable from a user's devtools without having to add logging later.

## API change

`DiagramExportMenu` and `MermaidBlock` now pass `{ code, displayTheme }` to the hook instead of an SVG getter. The displayed diagram's render loop is unchanged.

## Test plan

- [x] `npm test -- --run src/hooks/useDiagramExport.test.js` — 6 pure-helper tests still pass
- [x] `npm test -- --run` — full suite green (one pre-existing `authSlice` failure unrelated)
- [x] `npm run build` — production build succeeds
- [x] `npx eslint` on touched files — no new warnings
- [ ] Manual: any mermaid block (flowchart/sequence/class/state/pie/er/journey) → click download → PNG saves with crisp text, renders correctly in macOS Preview, pastes correctly into Slack and Notion
- [ ] Manual: click PDF → A4 PDF saves with the diagram centred and aspect-correct
- [ ] Manual: dark theme on screen → exported PNG/PDF are still light-backed
- [ ] Manual: switch to Code view, switch back to Preview → on-screen diagram still renders the user's preferred theme
- [ ] Manual: introduce a deliberately broken mermaid string in the code path → export fails with a clear toast and the cause logged to console (not a silent failure)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEB7KXX9EVXzjgYnVfwgkU)_