### PR TITLE
fix(sidebar): prevent mobile bleed by forcing collapsed state

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -252,13 +252,19 @@ export default function Sidebar() {
   }, [loadConversations, isAuthenticated]);
 
   useEffect(() => {
+    let wasMobile = window.innerWidth <= 768;
     const checkMobile = () => {
-      setIsMobile(window.innerWidth <= 768);
+      const nowMobile = window.innerWidth <= 768;
+      setIsMobile(nowMobile);
+      if (nowMobile && !wasMobile) {
+        dispatch(setCollapsed(true));
+      }
+      wasMobile = nowMobile;
     };
     checkMobile();
     window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
-  }, []);
+  }, [dispatch]);
 
   // Publish the sidebar's current rendered width as a CSS variable on
   // the root so position: fixed siblings (e.g. the landing page's

--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -1333,7 +1333,7 @@
     top: 0;
     left: 0;
     height: var(--app-height);
-    width: 300px;
+    width: min(85vw, 320px);
     margin: 0;
     padding: calc(16px + var(--safe-area-top)) 12px calc(16px + var(--safe-area-bottom));
     border-radius: 0 16px 16px 0;
@@ -1351,7 +1351,7 @@
   }
 
   .sidebar.collapsed {
-    width: 300px;
+    width: min(85vw, 320px);
     padding: 16px 12px;
     transform: translateX(-100%);
   }

--- a/src/store/slices/sidebarSlice.js
+++ b/src/store/slices/sidebarSlice.js
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 
 const getInitialCollapsed = () => {
+  if (typeof window !== 'undefined' && window.innerWidth <= 768) return true
   const saved = localStorage.getItem('araviel-sidebar-collapsed')
   if (saved === null) return true // Default to collapsed
   return saved === 'true'


### PR DESCRIPTION
## Summary

On mobile, the sidebar was bleeding over the chat/screen area. The `collapsed` state was persisted in `localStorage` and shared across breakpoints, so a user who had the sidebar open on desktop would land on mobile with the 300px panel slid in over the main content.

## Changes

- **`sidebarSlice.js`** — `getInitialCollapsed()` now returns `true` whenever `window.innerWidth <= 768`, regardless of `localStorage`. Desktop preference is still honored on desktop.
- **`Sidebar.jsx`** — the `checkMobile` effect now dispatches `setCollapsed(true)` when the viewport crosses from desktop to mobile, so resize doesn't strand the sidebar in an open state.
- **`Sidebar.module.css`** — mobile sidebar width changed from `300px` to `min(85vw, 320px)` so when the user does open it, it covers the visible strip and the existing overlay (z-index 1180) reads as a backdrop.

## Test plan

- [ ] Load app on a mobile viewport with `localStorage['araviel-sidebar-collapsed'] = 'false'` → sidebar stays hidden, no bleed
- [ ] Tap hamburger → sidebar slides in covering ~85% of width, overlay dims the rest
- [ ] Tap a conversation or the overlay → sidebar closes
- [ ] Resize desktop window down past 768px with sidebar open → sidebar collapses
- [ ] Desktop UX unchanged — sidebar respects localStorage preference

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQPB9YVWb8GGB4yXn1MJq)_