### PR TITLE
fix(sidebar): hide kebab dots bleeding at left edge on mobile

### DIFF
--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -1339,6 +1339,7 @@
     border-radius: 0 16px 16px 0;
     border-left: none;
     transform: translateX(-100%);
+    visibility: hidden;
     box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18), 0 4px 12px rgba(0, 0, 0, 0.08);
   }
 
@@ -1348,12 +1349,14 @@
 
   .sidebar:not(.collapsed) {
     transform: translateX(0);
+    visibility: visible;
   }
 
   .sidebar.collapsed {
     width: min(85vw, 320px);
     padding: 16px 12px;
     transform: translateX(-100%);
+    visibility: hidden;
   }
 
   /* Hide the in-header collapse chevron on mobile (mobile uses mobileCloseBtn) */


### PR DESCRIPTION
## Summary

Follow-up to #446. After identifying the source via DevTools, the bleeding column on the left edge was confirmed to be the `_recentItemMenu` (kebab) buttons on conversation rows. Even with `transform: translateX(-100%)`, the sidebar's right edge lands at exactly `x=0` in the viewport, and subpixel rendering surfaces the rightmost children (kebabs and the recents-section chevron).

## Change

Added `visibility: hidden` to the mobile collapsed sidebar (and `visibility: visible` to the open state). This guarantees that nothing inside the sidebar can render when it's collapsed on mobile, regardless of where its box lands at the viewport boundary.

## Test plan

- [ ] Load app on iPhone-size viewport (e.g. 430x932). No vertical column of dots/chevron at left edge.
- [ ] Tap hamburger → sidebar slides in normally.
- [ ] Close sidebar → no kebab dots visible.
- [ ] Desktop UX unchanged (rule is inside `@media (max-width: 768px)`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQPB9YVWb8GGB4yXn1MJq)_