### PR TITLE
fix(sidebar): align mobile hamburger with top-nav icons

### DIFF
--- a/src/components/Sidebar/Sidebar.module.css
+++ b/src/components/Sidebar/Sidebar.module.css
@@ -2,23 +2,33 @@
 .mobileMenuBtn {
   display: none;
   position: fixed;
-  top: calc(16px + var(--safe-area-top));
+  top: calc(10px + var(--safe-area-top));
   left: calc(16px + var(--safe-area-left));
   z-index: 1001;
   width: 36px;
   height: 36px;
   align-items: center;
   justify-content: center;
-  background-color: var(--bg-button);
-  border: 1px solid var(--border-color);
+  background: transparent;
+  border: none;
   border-radius: 10px;
-  color: var(--text-secondary);
-  transition: background-color 0.15s ease, color 0.15s ease;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
 }
 
 .mobileMenuBtn:hover {
-  background-color: var(--bg-button-hover);
+  background-color: var(--bg-hover);
   color: var(--text-primary);
+}
+
+.mobileMenuBtn:active {
+  transform: scale(0.95);
+}
+
+.mobileMenuBtn svg {
+  width: 18px;
+  height: 18px;
 }
 
 /* Overlay for mobile */


### PR DESCRIPTION
## Summary

The mobile hamburger menu didn't match the other top-nav icons:
- It was a **bordered, filled button** while `.shareBtn`, `.chatMenuBtn`, etc. are ghost-style icons with no chrome.
- It sat **6px lower** than the centerline of the 56px mobile top nav, so it visibly dropped below the breadcrumb and other icons.

## Changes (all in `Sidebar.module.css`)

- Removed `background-color: var(--bg-button)` and the `1px solid` border — now `background: transparent; border: none;` to match the ghost-icon pattern used by every other top-nav action.
- Color moved from `--text-secondary` to `--text-muted`, hover moved from `--bg-button-hover` to `--bg-hover` and `--text-primary` — matches `.shareBtn` / `.chatMenuBtn` exactly.
- Added `:active { transform: scale(0.95); }` for consistent press feedback.
- Added explicit `svg { width: 18px; height: 18px; }` — slightly heavier than the 16px secondary actions because the hamburger is the primary nav affordance.
- Shifted `top` from `calc(16px + safe-area-top)` to `calc(10px + safe-area-top)` so a 36px button centers in the 56px nav, sitting on the same optical baseline as the breadcrumb and right-side icons.

## Test plan

- [ ] Mobile viewport, conversation view: hamburger now visually matches share/kebab icons — no border or background fill, same hover color.
- [ ] Hamburger sits on the same horizontal line as breadcrumb text and right-side icons.
- [ ] Tap feedback (scale) matches other top-nav buttons.
- [ ] Hover/active states match siblings.
- [ ] Desktop unchanged (mobileMenuBtn is `display: none` on desktop).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQPB9YVWb8GGB4yXn1MJq)_