### PR TITLE
refactor(top-nav): remove new-chat icon from top-right

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -17,7 +17,6 @@ import {
   addMessage,
   setIsProcessing,
   updateLastMessage,
-  createNewChat,
   setCurrentChat,
   removeLastAssistantMessage,
   setWebSearchEnabled,
@@ -58,7 +57,6 @@ import {
   ChartIcon,
   SparkleIcon,
   BookIcon,
-  NewChatIcon,
   PlusIcon,
   CameraIcon,
   FilePlusIcon,
@@ -1978,30 +1976,6 @@ export default function MainContent() {
     }
   };
 
-  const handleNewChat = () => {
-    requestIdRef.current++;
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-      abortControllerRef.current = null;
-    }
-    if (completeTimeoutRef.current) {
-      clearTimeout(completeTimeoutRef.current);
-      completeTimeoutRef.current = null;
-    }
-
-    dispatch(createNewChat());
-    dispatch(setInputValue(''));
-    clearAttachedFiles();
-    setActiveDropdown(null);
-    setPipelineStatus('idle');
-    setIsStreaming(false);
-    setStreamedText('');
-    setRouteResult(null);
-    setIsManualRequest(false);
-    setShowThinkingUI(false);
-    navigate('/');
-  };
-
   /**
    * Retry handler.
    */
@@ -2602,14 +2576,6 @@ export default function MainContent() {
                   </button>
                 );
               })()}
-              <button
-                className={styles.newChatNavBtn}
-                onClick={handleNewChat}
-                title="New Chat"
-                aria-label="Start new chat"
-              >
-                <NewChatIcon />
-              </button>
             </>
           ) : (
             <>

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -579,34 +579,6 @@
   height: 16px;
 }
 
-.newChatNavBtn {
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
-  border-radius: 10px;
-  color: var(--text-muted);
-  transition: all 0.15s ease;
-  cursor: pointer;
-}
-
-.newChatNavBtn:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.newChatNavBtn:active {
-  transform: scale(0.95);
-}
-
-.newChatNavBtn svg {
-  width: 18px;
-  height: 18px;
-}
-
 /* Upgrade CTA — sits to the left of the New Chat button when the user is on a
    non-Pro plan. Shows "Upgrade" for free users, "Go Pro" for Lite users. */
 .upgradeNavBtn {
@@ -651,7 +623,7 @@
   line-height: 1;
 }
 
-/* Guest sign-up CTA — replaces .newChatNavBtn in the top-right when not authenticated */
+/* Guest sign-up CTA in the top-right */
 .signUpNavBtn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

The major AI chat apps (ChatGPT, Claude, Perplexity) have all moved away from the always-visible "new chat" icon in the top-right. Starting a new chat now lives in the sidebar (opened via the hamburger), with the home screen itself being the new-chat entry state. The top-right icon was redundant.

## Changes

- `MainContent.jsx` — drop the `<button class="newChatNavBtn">` from the authenticated top-nav fragment
- `MainContent.jsx` — remove the now-unused `handleNewChat` handler and the `createNewChat` / `NewChatIcon` imports
- `MainContent.module.css` — remove the `.newChatNavBtn` CSS block and clean up the stale comment on `.signUpNavBtn`

Applies to all viewports (mobile and desktop).

## Test plan

- [ ] Authenticated user on home or in a conversation: no new-chat icon at top-right.
- [ ] Open hamburger sidebar → "New chat" button still works as the primary way to start a new conversation.
- [ ] Guest sign-up CTA in top-right still renders for unauthenticated users.
- [ ] Upgrade CTA (when applicable) still renders correctly.
- [ ] No console errors or lint warnings about unused imports.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQPB9YVWb8GGB4yXn1MJq)_