### PR TITLE
feat(top-nav): show Share label next to icon on desktop

### DIFF
--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -2555,6 +2555,7 @@ export default function MainContent() {
                 aria-label="Share conversation"
               >
                 <ShareIcon />
+                <span className={styles.shareBtnLabel}>Share</span>
               </button>
             </>
           )}

--- a/src/components/MainContent/MainContent.module.css
+++ b/src/components/MainContent/MainContent.module.css
@@ -552,15 +552,19 @@
 }
 
 .shareBtn {
-  width: 36px;
-  height: 36px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 6px;
+  height: 36px;
+  padding: 0 10px;
   background: transparent;
   border: none;
   border-radius: 10px;
   color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
   transition: all 0.15s ease;
   cursor: pointer;
 }
@@ -577,6 +581,11 @@
 .shareBtn svg {
   width: 16px;
   height: 16px;
+  flex-shrink: 0;
+}
+
+.shareBtnLabel {
+  line-height: 1;
 }
 
 /* Upgrade CTA — sits to the left of the New Chat button when the user is on a
@@ -2540,6 +2549,15 @@
 
   .breadcrumb {
     margin-left: 40px;
+  }
+
+  .shareBtn {
+    width: 36px;
+    padding: 0;
+  }
+
+  .shareBtnLabel {
+    display: none;
   }
 
   .breadcrumbProject {


### PR DESCRIPTION
## Summary

Show a "Share" text label next to the share icon on desktop while keeping mobile icon-only.

## Changes

- `MainContent.jsx` — add `<span class="shareBtnLabel">Share</span>` next to `<ShareIcon />` inside the share button.
- `MainContent.module.css` — change `.shareBtn` from a fixed 36×36 square to an inline-flex pill (`gap: 6px`, `padding: 0 10px`, `font-size: 13px`, `font-weight: 500`) that fits the icon + label.
- `MainContent.module.css` — inside the existing `@media (max-width: 768px)` block, collapse `.shareBtn` back to 36×36 and `display: none` the label so mobile is visually unchanged.

## Test plan

- [ ] Desktop conversation view: share button shows icon + "Share" text. Hover/active states unchanged.
- [ ] Mobile (≤768px): share button is icon-only at 36×36, same as before.
- [ ] aria-label still "Share conversation" — screen readers unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkQPB9YVWb8GGB4yXn1MJq)_