### PR TITLE
chore(models): re-sync bundle to inherit new ADE ordering

### DIFF
--- a/src/data/bundledModels.js
+++ b/src/data/bundledModels.js
@@ -3,10 +3,39 @@
  * Do NOT edit by hand — run `npm run sync-models` to refresh.
  *
  * Source:  https://araviel-api.vercel.app/api/models/catalog
- * Synced:  2026-06-18T23:51:37.451Z
+ * Synced:  2026-06-19T00:15:18.929Z
  * Models:  54
  */
 export const BUNDLED_MODELS = [
+  {
+    id: 'claude-opus-4-8',
+    name: 'Claude Opus 4.8',
+    provider: 'anthropic',
+    description:
+      'Anthropic top-of-stack Opus. Adaptive thinking, agentic coding, high-res vision. Successor to Opus 4.7.',
+    speedTier: 'powerful',
+    pricing: {
+      inputPerM: 5,
+      outputPerM: 25,
+    },
+    context: {
+      inputTokens: 1000000,
+      outputTokens: 128000,
+    },
+    capabilities: {
+      vision: true,
+      audio: false,
+      extendedThinking: true,
+      webSearch: true,
+      functionCalling: true,
+      streaming: true,
+      imageGeneration: false,
+      tts: false,
+      stt: false,
+    },
+    accessTier: 'pro',
+    creditCost: 22,
+  },
   {
     id: 'claude-opus-4-7',
     name: 'Claude Opus 4.7',
@@ -1530,35 +1559,6 @@ export const BUNDLED_MODELS = [
     accessTier: 'lite',
     creditCost: 2,
   },
-  {
-    id: 'claude-opus-4-8',
-    name: 'Claude Opus 4.8',
-    provider: 'anthropic',
-    description:
-      'Anthropic top-of-stack Opus. Adaptive thinking, agentic coding, high-res vision. Successor to Opus 4.7.',
-    speedTier: 'powerful',
-    pricing: {
-      inputPerM: 5,
-      outputPerM: 25,
-    },
-    context: {
-      inputTokens: 1000000,
-      outputTokens: 128000,
-    },
-    capabilities: {
-      vision: true,
-      audio: false,
-      extendedThinking: true,
-      webSearch: true,
-      functionCalling: true,
-      streaming: true,
-      imageGeneration: false,
-      tts: false,
-      stt: false,
-    },
-    accessTier: 'pro',
-    creditCost: 22,
-  },
 ];
 
-export const BUNDLED_MODELS_SYNCED_AT = '2026-06-18T23:51:37.451Z';
+export const BUNDLED_MODELS_SYNCED_AT = '2026-06-19T00:15:18.929Z';


### PR DESCRIPTION
## Summary

Pairs with samaig-araviel/ade#74. That PR moved `claude-opus-4-8` to position 1 in ADE's registry. The api catalog now reflects the new order. Web's bundle was still holding the previous sync (claude-opus-4-8 at position 54), so the picker and Models page would render it at the bottom of the Anthropic group until rebuilt.

This PR re-runs `scripts/sync-models.mjs` against the live catalog and commits the regenerated bundle. `claude-opus-4-8` is now position 1 of 54.

## Why two PRs (ADE order + web sync)

Build-time sync means the web bundle only refreshes when web itself deploys. Reordering models in ADE doesn't auto-propagate. Each ADE order change needs a corresponding web bundle refresh to surface — same pattern as enabling a new model.

## Test plan

- [x] `npm run sync-models` writes 54 models with `claude-opus-4-8` at index 0
- [x] `grep -c "claude-opus-4-8" src/data/bundledModels.js` returns `1` (no duplication)
- [ ] After deploy: web Models page → Claude Opus 4.8 is the first card in the Anthropic group
- [ ] After deploy: ModelSelector dropdown surfaces it at the top of Anthropic options

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_