### PR TITLE
chore(models): sync bundle to 60 models + presentation copy for the 6 new

### DIFF
--- a/src/data/bundledModels.js
+++ b/src/data/bundledModels.js
@@ -3,8 +3,8 @@
  * Do NOT edit by hand — run `npm run sync-models` to refresh.
  *
  * Source:  https://araviel-api.vercel.app/api/models/catalog
- * Synced:  2026-06-19T00:15:18.929Z
- * Models:  54
+ * Synced:  2026-06-19T01:29:02.238Z
+ * Models:  60
  */
 export const BUNDLED_MODELS = [
   {
@@ -240,6 +240,64 @@ export const BUNDLED_MODELS = [
     creditCost: 2,
   },
   {
+    id: 'gpt-5.5',
+    name: 'GPT-5.5',
+    provider: 'openai',
+    description:
+      'OpenAI new-generation flagship. Successor to GPT-5.4. Five-level reasoning effort, native Computer Use, 1M+ context.',
+    speedTier: 'powerful',
+    pricing: {
+      inputPerM: 5,
+      outputPerM: 30,
+    },
+    context: {
+      inputTokens: 1000000,
+      outputTokens: 128000,
+    },
+    capabilities: {
+      vision: true,
+      audio: false,
+      extendedThinking: false,
+      webSearch: true,
+      functionCalling: true,
+      streaming: true,
+      imageGeneration: true,
+      tts: false,
+      stt: false,
+    },
+    accessTier: 'lite',
+    creditCost: 15,
+  },
+  {
+    id: 'gpt-5.5-pro',
+    name: 'GPT-5.5 Pro',
+    provider: 'openai',
+    description:
+      'Premium GPT-5.5 with more compute for the hardest problems. Responses API only; streaming not supported — routed through background polling.',
+    speedTier: 'powerful',
+    pricing: {
+      inputPerM: 30,
+      outputPerM: 180,
+    },
+    context: {
+      inputTokens: 1050000,
+      outputTokens: 128000,
+    },
+    capabilities: {
+      vision: true,
+      audio: false,
+      extendedThinking: false,
+      webSearch: true,
+      functionCalling: true,
+      streaming: false,
+      imageGeneration: true,
+      tts: false,
+      stt: false,
+    },
+    accessTier: 'pro',
+    creditCost: 60,
+  },
+  {
     id: 'gpt-5.4',
     name: 'GPT-5.4',
     provider: 'openai',
@@ -296,6 +354,64 @@ export const BUNDLED_MODELS = [
     },
     accessTier: 'pro',
     creditCost: 60,
+  },
+  {
+    id: 'gpt-5.4-mini',
+    name: 'GPT-5.4 Mini',
+    provider: 'openai',
+    description:
+      'Fast, cost-efficient reasoning in the GPT-5.4 family. Mid-tier between gpt-5-mini and gpt-5.4.',
+    speedTier: 'balanced',
+    pricing: {
+      inputPerM: 0.75,
+      outputPerM: 4.5,
+    },
+    context: {
+      inputTokens: 400000,
+      outputTokens: 128000,
+    },
+    capabilities: {
+      vision: true,
+      audio: false,
+      extendedThinking: false,
+      webSearch: true,
+      functionCalling: true,
+      streaming: true,
+      imageGeneration: false,
+      tts: false,
+      stt: false,
+    },
+    accessTier: 'free',
+    creditCost: 3,
+  },
+  {
+    id: 'gpt-5.4-nano',
+    name: 'GPT-5.4 Nano',
+    provider: 'openai',
+    description:
+      'Fastest, cheapest reasoning in the GPT-5.4 family. Summarisation, classification, extraction.',
+    speedTier: 'fast',
+    pricing: {
+      inputPerM: 0.2,
+      outputPerM: 1.25,
+    },
+    context: {
+      inputTokens: 400000,
+      outputTokens: 128000,
+    },
+    capabilities: {
+      vision: true,
+      audio: false,
+      extendedThinking: false,
+      webSearch: false,
+      functionCalling: true,
+      streaming: true,
+      imageGeneration: true,
+      tts: false,
+      stt: false,
+    },
+    accessTier: 'lite',
+    creditCost: 1,
   },
   {
     id: 'gpt-5.2',
@@ -815,6 +931,35 @@ export const BUNDLED_MODELS = [
     creditCost: 20,
   },
   {
+    id: 'gemini-3.5-flash',
+    name: 'Gemini 3.5 Flash',
+    provider: 'google',
+    description:
+      'Google new-generation Flash workhorse. Thinking with minimal-to-high effort, native image generation. 1M context.',
+    speedTier: 'fast',
+    pricing: {
+      inputPerM: 1.5,
+      outputPerM: 9,
+    },
+    context: {
+      inputTokens: 1000000,
+      outputTokens: 65536,
+    },
+    capabilities: {
+      vision: true,
+      audio: true,
+      extendedThinking: true,
+      webSearch: true,
+      functionCalling: true,
+      streaming: true,
+      imageGeneration: true,
+      tts: false,
+      stt: false,
+    },
+    accessTier: 'lite',
+    creditCost: 5,
+  },
+  {
     id: 'gemini-3.1-pro-preview',
     name: 'Gemini 3.1 Pro Preview',
     provider: 'google',
@@ -928,6 +1073,35 @@ export const BUNDLED_MODELS = [
     },
     accessTier: 'free',
     creditCost: 2,
+  },
+  {
+    id: 'gemini-3.1-flash-lite',
+    name: 'Gemini 3.1 Flash-Lite',
+    provider: 'google',
+    description:
+      'Frontier-class Gemini at budget tier. Thinking with minimal-to-high effort. Best for high-volume, latency-sensitive tasks.',
+    speedTier: 'fast',
+    pricing: {
+      inputPerM: 0.25,
+      outputPerM: 1.5,
+    },
+    context: {
+      inputTokens: 1000000,
+      outputTokens: 65536,
+    },
+    capabilities: {
+      vision: true,
+      audio: true,
+      extendedThinking: true,
+      webSearch: false,
+      functionCalling: true,
+      streaming: true,
+      imageGeneration: false,
+      tts: false,
+      stt: false,
+    },
+    accessTier: 'free',
+    creditCost: 1,
   },
   {
     id: 'gemini-2.5-flash-lite',
@@ -1561,4 +1735,4 @@ export const BUNDLED_MODELS = [
   },
 ];
 
-export const BUNDLED_MODELS_SYNCED_AT = '2026-06-19T00:15:18.929Z';
+export const BUNDLED_MODELS_SYNCED_AT = '2026-06-19T01:29:02.238Z';

--- a/src/data/modelPresentation.js
+++ b/src/data/modelPresentation.js
@@ -288,4 +288,34 @@ export const MODEL_PRESENTATION = {
     bestFor: ['Noise removal', 'Voice isolation', 'Audio processing'],
     badge: 'Audio',
   },
+  'gpt-5.5': {
+    tagline: "OpenAI's newest frontier model",
+    bestFor: ['Coding', 'Reasoning', 'Math', 'Agentic tasks'],
+    badge: 'New',
+  },
+  'gpt-5.5-pro': {
+    tagline: 'Maximum compute for the hardest problems',
+    bestFor: ['Research', 'Deep reasoning', 'Frontier problems'],
+    badge: 'Max Power',
+  },
+  'gpt-5.4-mini': {
+    tagline: 'Mid-tier reasoning in the GPT-5.4 family',
+    bestFor: ['Cost-efficient reasoning', 'Structured tasks', 'Quick responses'],
+    badge: null,
+  },
+  'gpt-5.4-nano': {
+    tagline: 'Fastest, cheapest reasoning in the 5.4 family',
+    bestFor: ['Summarization', 'Classification', 'High-throughput pipelines'],
+    badge: 'Most Affordable',
+  },
+  'gemini-3.5-flash': {
+    tagline: "Google's newest Flash workhorse",
+    bestFor: ['Fast responses', 'Multimodal tasks', 'Reasoning'],
+    badge: 'New',
+  },
+  'gemini-3.1-flash-lite': {
+    tagline: 'Frontier-class Gemini at budget tier',
+    bestFor: ['High-volume pipelines', 'Cost optimization', 'Quick reasoning'],
+    badge: null,
+  },
 };


### PR DESCRIPTION
## Summary

Follow-up to samaig-araviel/ade#75 (enabled the six remaining new models). Refreshes web's build-time snapshot so the picker actually shows them.

## Changes

**`src/data/bundledModels.js`** (auto-generated by `npm run sync-models`)
- 54 → 60 models
- Order matches ADE's registry exactly via the sync script. After this PR:
  - Anthropic group leads with `claude-opus-4-8`
  - OpenAI group now leads with `gpt-5.5`
  - Google group now leads with `gemini-3.5-flash`

**`src/data/modelPresentation.js`** (hand-edited)
- Adds `tagline` + `bestFor` + `badge` for the six new models so the model cards render real marketing copy instead of the empty-string fallback (which would have looked like a dead state per #75's PR notes).
- Tone matches existing siblings (`Most Affordable` for the nano, `Max Power` for the Pro, `New` for new flagships, no badge for supporting tiers).
- Existing `Flagship` badges on `claude-opus-4-7`, `gpt-5.4`, `gemini-2.5-pro` etc. stay put — branding-transition decisions for whenever you want them. Current state: both an old Flagship and a new "New" exist side by side per provider.

## Test plan

- [x] `npm run sync-models` writes 60 models, top-of-array is `claude-opus-4-8`, the 6 new models appear in their expected positions
- [x] `npx eslint` clean
- [x] `npx prettier --write` applied
- [ ] After deploy: ModelSelector dropdown shows 6 new cards with real taglines and "New" / "Max Power" / "Most Affordable" / null badges as configured
- [ ] After deploy: Models page renders cards for all 60 models without empty marketing-copy gaps
- [ ] After deploy: clicking through to a new model and routing a prompt works (each model's capabilities + pricing are already wired in api from Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_