### PR TITLE
chore(models): sync bundle with corrected Gemini 2.5 Flash prices

### DIFF
--- a/src/data/bundledModels.js
+++ b/src/data/bundledModels.js
@@ -3,7 +3,7 @@
  * Do NOT edit by hand — run `npm run sync-models` to refresh.
  *
  * Source:  https://araviel-api.vercel.app/api/models/catalog
- * Synced:  2026-06-19T01:29:02.238Z
+ * Synced:  2026-06-19T01:57:29.698Z
  * Models:  60
  */
 export const BUNDLED_MODELS = [
@@ -1053,8 +1053,8 @@ export const BUNDLED_MODELS = [
       'Fast workhorse with thinking and native image generation. 1M context. Great balance of speed and quality.',
     speedTier: 'fast',
     pricing: {
-      inputPerM: 0.075,
-      outputPerM: 0.3,
+      inputPerM: 0.3,
+      outputPerM: 2.5,
     },
     context: {
       inputTokens: 1000000,
@@ -1111,8 +1111,8 @@ export const BUNDLED_MODELS = [
       'Ultra-fast, cost-efficient Gemini. 1M context. Best for high-volume, latency-sensitive tasks.',
     speedTier: 'fast',
     pricing: {
-      inputPerM: 0.025,
-      outputPerM: 0.15,
+      inputPerM: 0.1,
+      outputPerM: 0.4,
     },
     context: {
       inputTokens: 1000000,
@@ -1735,4 +1735,4 @@ export const BUNDLED_MODELS = [
   },
 ];
 
-export const BUNDLED_MODELS_SYNCED_AT = '2026-06-19T01:29:02.238Z';
+export const BUNDLED_MODELS_SYNCED_AT = '2026-06-19T01:57:29.698Z';


### PR DESCRIPTION
## Summary

Pulls the price corrections from samaig-araviel/ade#76 + samaig-araviel/araviel-api#164 into web's build-time bundle so display prices match what the cost calculator now bills.

| Model | Was (per million) | Now |
|---|---|---|
| `gemini-2.5-flash` | $0.075 / $0.30 | **$0.30 / $2.50** |
| `gemini-2.5-flash-lite` | $0.025 / $0.10 | **$0.10 / $0.40** |

## What this closes

After this PR, the under-billing fix is end-to-end:

- ✅ ADE registry serves the corrected prices (#76)
- ✅ api cost calculator bills at the corrected rate (#164)
- ✅ Web picker/Models view shows the corrected prices (this PR)

## Test plan

- [x] `npm run sync-models` against prod api catalog wrote `inputPerM: 0.3, outputPerM: 2.5` for Flash and `0.1, 0.4` for Flash-Lite
- [x] `npx prettier --write` applied to the generated file
- [ ] After deploy: Models page Flash card shows $0.30 / $2.50, Flash-Lite shows $0.10 / $0.40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_