### PR TITLE
chore(models): sync bundle with corrected prices + drop retired haiku 3.5

### DIFF
--- a/src/data/bundledModels.js
+++ b/src/data/bundledModels.js
@@ -3,8 +3,8 @@
  * Do NOT edit by hand — run `npm run sync-models` to refresh.
  *
  * Source:  https://araviel-api.vercel.app/api/models/catalog
- * Synced:  2026-06-19T01:57:29.698Z
- * Models:  60
+ * Synced:  2026-06-19T11:38:01.501Z
+ * Models:  59
  */
 export const BUNDLED_MODELS = [
   {
@@ -209,35 +209,6 @@ export const BUNDLED_MODELS = [
     },
     accessTier: 'free',
     creditCost: 4,
-  },
-  {
-    id: 'claude-3-5-haiku-20241022',
-    name: 'Claude Haiku 3.5',
-    provider: 'anthropic',
-    description:
-      'Budget Claude for simple tasks and high-volume classification. 200K context, 8K output.',
-    speedTier: 'fast',
-    pricing: {
-      inputPerM: 0.8,
-      outputPerM: 4,
-    },
-    context: {
-      inputTokens: 200000,
-      outputTokens: 8192,
-    },
-    capabilities: {
-      vision: true,
-      audio: false,
-      extendedThinking: false,
-      webSearch: true,
-      functionCalling: true,
-      streaming: true,
-      imageGeneration: false,
-      tts: false,
-      stt: false,
-    },
-    accessTier: 'free',
-    creditCost: 2,
   },
   {
     id: 'gpt-5.5',
@@ -767,7 +738,7 @@ export const BUNDLED_MODELS = [
       'OpenAI flagship image generation. Near-perfect multilingual text rendering, complex compositions, reasoning-driven outputs. Supports transparent backgrounds and arbitrary sizes.',
     speedTier: 'powerful',
     pricing: {
-      inputPerM: 5,
+      inputPerM: 8,
       outputPerM: 30,
     },
     context: {
@@ -967,8 +938,8 @@ export const BUNDLED_MODELS = [
       'Latest Gemini flagship. Best reasoning and coding from Google. 1M context window.',
     speedTier: 'powerful',
     pricing: {
-      inputPerM: 1.25,
-      outputPerM: 10,
+      inputPerM: 2,
+      outputPerM: 12,
     },
     context: {
       inputTokens: 1000000,
@@ -1735,4 +1706,4 @@ export const BUNDLED_MODELS = [
   },
 ];
 
-export const BUNDLED_MODELS_SYNCED_AT = '2026-06-19T01:57:29.698Z';
+export const BUNDLED_MODELS_SYNCED_AT = '2026-06-19T11:38:01.501Z';

--- a/src/data/modelPresentation.js
+++ b/src/data/modelPresentation.js
@@ -53,11 +53,6 @@ export const MODEL_PRESENTATION = {
     bestFor: ['Real-time responses', 'High-volume tasks', 'Cost-efficient work'],
     badge: 'Fastest',
   },
-  'claude-3-5-haiku-20241022': {
-    tagline: 'Budget Claude for simple tasks and classification',
-    bestFor: ['Classification', 'Extraction', 'Cost-sensitive workloads'],
-    badge: 'Legacy',
-  },
   'gpt-5.4': {
     tagline: "OpenAI's most capable frontier model",
     bestFor: ['Coding', 'Reasoning', 'Math', 'Long-context analysis'],


### PR DESCRIPTION
## Summary

Closes the loop on samaig-araviel/ade#77 + samaig-araviel/araviel-api#165 by refreshing web's build-time snapshot.

## What changes in the picker

- **60 → 59 models.** `claude-3-5-haiku-20241022` no longer appears (api catalog now filters it out because ADE flipped its `available` flag). Old conversations using it still cost-display correctly because the cost-history entry stays in api's `MODEL_PRICING`.
- **`gpt-image-2` input price**: $5/M → **$8/M** (output stays $30).
- **`gemini-3.1-pro-preview`**: $1.25 / $10 → **$2 / $12** (≤200K tier).

## Other change

- `modelPresentation.js`: dropped the `claude-3-5-haiku-20241022` entry. Without a facts row in the bundle, the merge step has nothing to attach the copy to — keeping the entry would be dead code.

## Test plan

- [x] `npm run sync-models` against the corrected prod catalog writes 59 models, `gpt-image-2 inputPerM: 8`, `gemini-3.1-pro-preview inputPerM: 2`, no `claude-3-5-haiku-20241022`
- [x] `npx prettier --write` applied
- [x] `npx eslint` clean
- [ ] After deploy: Models page shows updated prices on the GPT Image 2 and Gemini 3.1 Pro Preview cards
- [ ] After deploy: Claude Haiku 3.5 card no longer renders in the Anthropic group

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_