### PR TITLE
feat(picker): derive featured models from registry instead of hardcoded IDs

### DIFF
--- a/src/components/ModelSelector/ModelSelector.jsx
+++ b/src/components/ModelSelector/ModelSelector.jsx
@@ -11,17 +11,12 @@ import {
   MODELS,
   PROVIDERS,
   PROVIDER_ORDER,
-  ACCESS_TIERS,
   getModelsForTier,
   getModelsByProvider,
+  getFeaturedModelsForTier,
 } from '../../data/models';
 import { ChevronDownIcon, ChevronLeftIcon, CheckIcon, ChevronRightIcon } from '../Icons';
 import styles from './ModelSelector.module.css';
-
-// Featured models per tier — one per major provider
-const FEATURED_MODEL_IDS_PRO = ['claude-opus-4-6', 'gpt-5.2', 'gemini-2.5-pro'];
-
-const FEATURED_MODEL_IDS_FREE = ['claude-haiku-4-5-20251001', 'gpt-5-mini', 'gemini-2.5-flash'];
 
 // Routing strategies shown as top-level options
 const ROUTING_OPTIONS = [
@@ -54,9 +49,7 @@ export default function ModelSelector({ imageOnly = false }) {
 
   const featuredModels = useMemo(() => {
     if (imageOnly) return tierModels.slice(0, 3);
-    const featuredIds =
-      userTier === ACCESS_TIERS.pro ? FEATURED_MODEL_IDS_PRO : FEATURED_MODEL_IDS_FREE;
-    return featuredIds.map((id) => tierModels.find((m) => m.id === id)).filter(Boolean);
+    return getFeaturedModelsForTier(userTier, tierModels);
   }, [imageOnly, tierModels, userTier]);
 
   const activeProviders = PROVIDER_ORDER.filter((pid) => tierModelsByProvider[pid]?.length > 0);

--- a/src/data/models.js
+++ b/src/data/models.js
@@ -81,3 +81,12 @@ export function getUpgradeModels(currentTier) {
 }
 
 export const getProOnlyModels = () => getUpgradeModels(ACCESS_TIERS.free);
+
+const FEATURED_PROVIDERS = ['anthropic', 'openai', 'google'];
+
+export function getFeaturedModelsForTier(tier, fromList) {
+  const source = fromList ?? getModelsForTier(tier);
+  return FEATURED_PROVIDERS.map((providerId) =>
+    source.find((m) => m.provider === providerId)
+  ).filter(Boolean);
+}


### PR DESCRIPTION
## Summary

Replaces two hardcoded constants in `ModelSelector.jsx` with a single derivation from the registry. The picker's "featured" row now shows the newest accessible model per provider, automatically.

## The problem

The picker's "featured" row was driven by:
```js
const FEATURED_MODEL_IDS_PRO  = ['claude-opus-4-6', 'gpt-5.2', 'gemini-2.5-pro'];
const FEATURED_MODEL_IDS_FREE = ['claude-haiku-4-5-20251001', 'gpt-5-mini', 'gemini-2.5-flash'];
```

These were stale — Pro users were still being shown Opus **4.6**, GPT-**5.2**, Gemini **2.5 Pro** even after Opus 4.7, 4.8, GPT-5.5, Gemini 3.5 Flash all landed. Every model launch needed someone to remember to edit this file. `gpt-5.2` is also on the retirement list, which would have silently emptied a featured slot.

There was also no `LITE` list, so Lite users were falling into the Free branch.

## The fix

New helper in `src/data/models.js`:

```js
const FEATURED_PROVIDERS = ['anthropic', 'openai', 'google'];

export function getFeaturedModelsForTier(tier, fromList) {
  const source = fromList ?? getModelsForTier(tier);
  return FEATURED_PROVIDERS.map((p) => source.find((m) => m.provider === p)).filter(Boolean);
}
```

For each provider in `FEATURED_PROVIDERS`, returns the first match in the tier-accessible model list. Because the registry is already organised "newest at top" within each provider group (set as a convention in samaig-araviel/ade#74 and samaig-araviel/ade#75), the first hit is exactly the newest the user can access — no extra metadata, no flags.

ModelSelector replaces the inline lookup with `getFeaturedModelsForTier(userTier, tierModels)`. ImageOnly branch is unchanged (still `tierModels.slice(0, 3)`).

## Effect per tier (today)

| Tier | Anthropic | OpenAI | Google |
|---|---|---|---|
| Pro | claude-opus-4-8 | gpt-5.5 | gemini-3.5-flash |
| Lite | (same as Pro — first not-Pro accessible) | gpt-5.5 | gemini-3.5-flash |
| Free | claude-haiku-4-5-20251001 | gpt-5.4-mini | gemini-3.1-flash-lite |

Pro users now see the current flagships instead of last quarter's. Free users get the newest tier-appropriate models automatically.

## Test plan

- [x] `npx eslint` clean
- [x] `npx vitest run` — 603/604 pass (one pre-existing unrelated authSlice failure on main)
- [ ] After deploy: Pro picker shows Claude Opus 4.8, GPT-5.5, Gemini 3.5 Flash as the three featured cards
- [ ] After deploy: Free picker shows Claude Haiku 4.5, GPT-5.4 Mini, Gemini 3.1 Flash-Lite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_