### PR TITLE
Fix password reset flow and reject duplicate-email signups

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -145,6 +145,11 @@ export default function AuthModal({ isOpen, onClose, initialTab = 'signin' }) {
       setLocalError(passwordError);
       return;
     }
+    const emailExistsError = location.state?.emailExistsError;
+    if (emailExistsError) {
+      setLocalError(emailExistsError);
+      return;
+    }
     const rejection = location.state?.ageRejection;
     if (rejection) {
       setLocalError(rejection);

--- a/src/components/Auth/ResetPasswordView.jsx
+++ b/src/components/Auth/ResetPasswordView.jsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  updatePassword,
+  selectAuthLoading,
+  selectAuthError,
+  selectIsAuthenticated,
+  setAuthError,
+} from '../../store/slices/authSlice';
+import {
+  PASSWORD_MIN_LENGTH,
+  getPasswordRuleViolations,
+  formatPasswordError,
+} from '../../utils/password';
+import authStyles from './AuthModal.module.css';
+import styles from './CheckEmailView.module.css';
+
+const ArrowLeftIcon = () => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <line x1="19" y1="12" x2="5" y2="12" />
+    <polyline points="12 19 5 12 12 5" />
+  </svg>
+);
+
+const LockIcon = () => (
+  <svg
+    width="28"
+    height="28"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="3" y="11" width="18" height="11" rx="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+  </svg>
+);
+
+/**
+ * ResetPasswordView — Mounted at /reset-password. Lands here from the
+ * password-reset email link, at which point Supabase has hydrated a
+ * recovery session into the client. The user picks a new password and
+ * we call updateUser({ password }) to persist it.
+ *
+ * If the user arrives without an active session (recovery link expired,
+ * direct visit, etc.) we send them back to /login so they can request a
+ * fresh email instead of being stuck on a form that can't possibly
+ * succeed.
+ */
+export default function ResetPasswordView() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const isLoading = useSelector(selectAuthLoading);
+  const authError = useSelector(selectAuthError);
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [localError, setLocalError] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+
+  // Give Supabase a brief moment to parse the recovery tokens out of
+  // the URL hash and fire the PASSWORD_RECOVERY auth event before we
+  // decide whether the user is "authenticated" enough to be here.
+  const [checkedSession, setCheckedSession] = useState(false);
+  useEffect(() => {
+    const timer = window.setTimeout(() => setCheckedSession(true), 400);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (!checkedSession) return;
+    if (!isAuthenticated) {
+      navigate('/login', {
+        replace: true,
+        state: {
+          passwordError:
+            'Your password reset link has expired or is no longer valid. Please request a new one.',
+        },
+      });
+    }
+  }, [checkedSession, isAuthenticated, navigate]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setLocalError('');
+    setSuccessMessage('');
+    dispatch(setAuthError(null));
+
+    const violations = getPasswordRuleViolations(password);
+    if (violations.length > 0) {
+      setLocalError(formatPasswordError(violations));
+      return;
+    }
+    if (password !== confirmPassword) {
+      setLocalError("Passwords don't match — re-enter to confirm.");
+      return;
+    }
+
+    const result = await dispatch(updatePassword({ password }));
+    if (result.meta.requestStatus === 'fulfilled') {
+      setSuccessMessage('Password updated. Taking you to the app…');
+      window.setTimeout(() => navigate('/', { replace: true }), 900);
+    }
+  };
+
+  if (!checkedSession) return null;
+  if (!isAuthenticated) return null;
+
+  const errorMessage = localError || authError;
+
+  return (
+    <div className={styles.container}>
+      <button
+        type="button"
+        className={authStyles.backBtn}
+        onClick={() => navigate('/login', { replace: true })}
+      >
+        <ArrowLeftIcon />
+        <span>Back to sign in</span>
+      </button>
+
+      <div className={styles.panel}>
+        <div className={styles.iconWrap} aria-hidden="true">
+          <LockIcon />
+        </div>
+        <h1 className={styles.heading}>Set a new password</h1>
+        <p className={styles.subtitle}>
+          Choose a new password for your account. You'll be signed in straight after.
+        </p>
+
+        <form className={authStyles.form} onSubmit={handleSubmit} noValidate>
+          <div className={authStyles.fieldGroup}>
+            <label className={authStyles.label} htmlFor="reset-password">
+              New password
+            </label>
+            <input
+              id="reset-password"
+              type="password"
+              className={authStyles.input}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder={`At least ${PASSWORD_MIN_LENGTH} characters`}
+              autoComplete="new-password"
+              minLength={PASSWORD_MIN_LENGTH}
+              required
+              disabled={isLoading}
+            />
+          </div>
+
+          <div className={authStyles.fieldGroup}>
+            <label className={authStyles.label} htmlFor="reset-password-confirm">
+              Confirm new password
+            </label>
+            <input
+              id="reset-password-confirm"
+              type="password"
+              className={authStyles.input}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="Re-enter your new password"
+              autoComplete="new-password"
+              minLength={PASSWORD_MIN_LENGTH}
+              required
+              disabled={isLoading}
+            />
+          </div>
+
+          {errorMessage && <div className={authStyles.error}>{errorMessage}</div>}
+          {successMessage && <div className={authStyles.success}>{successMessage}</div>}
+
+          <button className={authStyles.submitBtn} type="submit" disabled={isLoading}>
+            {isLoading ? <span className={authStyles.spinner} aria-hidden="true" /> : 'Update password'}
+          </button>
+        </form>
+
+        <p className={styles.footer}>
+          Remembered it after all?{' '}
+          <Link to="/login" className={styles.footerLink}>
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Auth/VerifyAgeView.jsx
+++ b/src/components/Auth/VerifyAgeView.jsx
@@ -246,6 +246,23 @@ export default function VerifyAgeView() {
       return;
     }
 
+    // Duplicate-email rejection from signUpWithEmail (Supabase returns
+    // success with an empty identities array when the address is already
+    // registered — see the thunk for the detection). Send the user back
+    // to /signup so they can switch to sign-in instead of being stuck
+    // on the age-verification screen.
+    if (raw === 'email_already_registered') {
+      navigate('/signup', {
+        replace: true,
+        state: {
+          ...location.state,
+          emailExistsError:
+            'An account with this email already exists. Try signing in instead.',
+        },
+      });
+      return;
+    }
+
     // If Supabase's password policy is stricter than our client-side
     // rules (or someone bypassed them), the server can still reject the
     // signUp with a password error after the user has already filled

--- a/src/components/Auth/index.js
+++ b/src/components/Auth/index.js
@@ -2,3 +2,4 @@ export { default as AuthModal } from './AuthModal';
 export { default as AuthRoute } from './AuthRoute';
 export { default as VerifyAgeView } from './VerifyAgeView';
 export { default as CheckEmailView } from './CheckEmailView';
+export { default as ResetPasswordView } from './ResetPasswordView';

--- a/src/hooks/useAuthListener.js
+++ b/src/hooks/useAuthListener.js
@@ -175,7 +175,11 @@ export default function useAuthListener() {
         case 'INITIAL_SESSION':
         case 'SIGNED_IN':
         case 'TOKEN_REFRESHED':
-        case 'USER_UPDATED': {
+        case 'USER_UPDATED':
+        // PASSWORD_RECOVERY fires when the user lands on /reset-password
+        // from a reset email — Supabase hydrates a recovery session and
+        // we need it in Redux so ResetPasswordView can render its form.
+        case 'PASSWORD_RECOVERY': {
           const user = mapUser(session?.user);
           setLoggerUser(user?.id || null);
           dispatch(

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -14,7 +14,7 @@ import SharedConversationView from './components/SharedConversationView';
 import RouteErrorBoundary from './components/ErrorBoundary/RouteErrorBoundary';
 import NotFound from './components/ErrorBoundary/NotFound';
 import RouteShell from './components/RouteShell/RouteShell';
-import { AuthRoute, VerifyAgeView, CheckEmailView } from './components/Auth';
+import { AuthRoute, VerifyAgeView, CheckEmailView, ResetPasswordView } from './components/Auth';
 import { WEB_APPLICATION_JSON_LD, ORGANIZATION_JSON_LD } from './lib/seo';
 
 const router = createBrowserRouter([
@@ -119,6 +119,21 @@ const router = createBrowserRouter([
             }}
           >
             <CheckEmailView />
+          </RouteShell>
+        ),
+      },
+      {
+        path: 'reset-password',
+        element: (
+          <RouteShell
+            feature="reset-password"
+            seo={{
+              title: 'Set a new password',
+              description: 'Choose a new password for your Araviel account.',
+              noindex: true,
+            }}
+          >
+            <ResetPasswordView />
           </RouteShell>
         ),
       },

--- a/src/store/slices/authSlice.js
+++ b/src/store/slices/authSlice.js
@@ -155,6 +155,18 @@ export const signUpWithEmail = createAsyncThunk(
         },
       });
       if (error) return rejectWithValue(error.message);
+      // Supabase's anti-enumeration behaviour: when email confirmation is
+      // ON and the address is already registered, signUp succeeds with an
+      // obfuscated user and an empty `identities` array (rather than
+      // returning a clear error). Surface that as a structured rejection
+      // so the UI can show "this email is already registered".
+      if (
+        data?.user &&
+        Array.isArray(data.user.identities) &&
+        data.user.identities.length === 0
+      ) {
+        return rejectWithValue('email_already_registered');
+      }
       return {
         user: mapUser(data.user),
         session: mapSession(data.session),
@@ -217,14 +229,36 @@ export const signOut = createAsyncThunk('auth/signOut', async (_, { rejectWithVa
   }
 });
 
-/** Send a password-reset email. */
+/** Send a password-reset email. The redirectTo is required so the link
+ *  in the email lands on /reset-password where the user can set a new
+ *  password — without it, Supabase falls back to the project's Site URL
+ *  and the recovery session has nowhere to be handled. */
 export const resetPassword = createAsyncThunk(
   'auth/resetPassword',
   async ({ email }, { rejectWithValue }) => {
     try {
-      const { error } = await supabase.auth.resetPasswordForEmail(email);
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo:
+          typeof window !== 'undefined' ? `${window.location.origin}/reset-password` : undefined,
+      });
       if (error) return rejectWithValue(error.message);
       return null;
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+/** Update the signed-in user's password. Used by ResetPasswordView after
+ *  the user clicks the recovery email link and Supabase hydrates a
+ *  recovery session into the client. */
+export const updatePassword = createAsyncThunk(
+  'auth/updatePassword',
+  async ({ password }, { rejectWithValue }) => {
+    try {
+      const { data, error } = await supabase.auth.updateUser({ password });
+      if (error) return rejectWithValue(error.message);
+      return { user: mapUser(data.user) };
     } catch (err) {
       return rejectWithValue(err.message);
     }
@@ -387,6 +421,21 @@ const authSlice = createSlice({
       .addCase(resetPassword.rejected, (state, action) => {
         state.isLoading = false;
         state.error = action.payload || 'Password reset failed';
+      });
+
+    // updatePassword
+    builder
+      .addCase(updatePassword.pending, (state) => {
+        state.isLoading = true;
+        state.error = null;
+      })
+      .addCase(updatePassword.fulfilled, (state, action) => {
+        state.isLoading = false;
+        if (action.payload?.user) state.user = action.payload.user;
+      })
+      .addCase(updatePassword.rejected, (state, action) => {
+        state.isLoading = false;
+        state.error = action.payload || 'Password update failed';
       });
   },
 });


### PR DESCRIPTION
## Summary
Two related auth fixes.

### 1. Reset password didn't actually work end-to-end
- `resetPassword` was calling `supabase.auth.resetPasswordForEmail(email)` with **no `redirectTo`**, so the email link (when delivered) had nowhere to land.
- There was no `/reset-password` route to handle the recovery session.
- `useAuthListener` didn't handle the `PASSWORD_RECOVERY` auth event, so the recovery session never made it into Redux even if the user did land somewhere usable.

Changes:
- `resetPassword` now sends `redirectTo: ${origin}/reset-password`.
- New `ResetPasswordView` mounted at `/reset-password`. Renders a new-password form (same complexity rules as signup, with confirm-password) and calls a new `updatePassword` thunk (`supabase.auth.updateUser({ password })`).
- `useAuthListener` adds `PASSWORD_RECOVERY` to the existing `setAuth` switch case so the recovery session populates Redux and the form can render (auth-gated).

> **Supabase config requirement**: the `${origin}/reset-password` URL must be added to **Authentication → URL Configuration → Redirect URLs** for the production project. Without that allowlist entry the link in the reset email won't carry the recovery tokens.

### 2. Duplicate email registrations silently appeared to succeed
Supabase's `signUp` is anti-enumerative when email confirmation is on — for an already-registered address it returns success with an **empty `identities[]`** rather than an error. The app was treating that as a fresh signup and routing the user to "check your email" even when no email was actually sent.

- `signUpWithEmail` now detects `data.user.identities.length === 0` and rejects with `email_already_registered`.
- `VerifyAgeView` catches that rejection and navigates back to `/signup` with `emailExistsError` in `location.state`.
- `AuthModal` surfaces `emailExistsError` on its inline error row: *"An account with this email already exists. Try signing in instead."*

## Test plan
- [ ] On `/login`, click "Forgot password", submit a valid email — recovery email arrives with a link to `${origin}/reset-password`.
- [ ] Click the link → land on `/reset-password` → set a new password → land at `/` signed in with the new password.
- [ ] Direct visit to `/reset-password` without a recovery session redirects to `/login`.
- [ ] Sign up with an email that already exists → after age verification, bounced back to `/signup` with a clear "account already exists" message instead of the misleading "check your email" screen.

https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkUHZjJtghLyRqmRD7CSAv)_