### PR TITLE
fix(lightbox): arrows outside image; render prompt as markdown

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -1858,28 +1858,15 @@ function GeneratedImageLightbox({ images, initialIndex, onClose }) {
           <div className={styles.genLightboxStage}>
             <div className={styles.genLightboxBody}>
               {images.length > 1 && (
-                <>
-                  <button
-                    type="button"
-                    className={`${styles.genLightboxNav} ${styles.genLightboxNavPrev}`}
-                    onClick={() => setActiveIndex((prev) => (prev > 0 ? prev - 1 : prev))}
-                    disabled={activeIndex === 0}
-                    aria-label="Previous image"
-                  >
-                    <ChevronLeftIcon />
-                  </button>
-                  <button
-                    type="button"
-                    className={`${styles.genLightboxNav} ${styles.genLightboxNavNext}`}
-                    onClick={() =>
-                      setActiveIndex((prev) => (prev < images.length - 1 ? prev + 1 : prev))
-                    }
-                    disabled={activeIndex === images.length - 1}
-                    aria-label="Next image"
-                  >
-                    <ChevronRightIcon />
-                  </button>
-                </>
+                <button
+                  type="button"
+                  className={`${styles.genLightboxNav} ${styles.genLightboxNavPrev}`}
+                  onClick={() => setActiveIndex((prev) => (prev > 0 ? prev - 1 : prev))}
+                  disabled={activeIndex === 0}
+                  aria-label="Previous image"
+                >
+                  <ChevronLeftIcon />
+                </button>
               )}
               <img
                 key={activeIndex}
@@ -1887,12 +1874,27 @@ function GeneratedImageLightbox({ images, initialIndex, onClose }) {
                 alt={activeImage.prompt || activeImage.model || 'Generated image'}
                 className={styles.genLightboxImg}
               />
+              {images.length > 1 && (
+                <button
+                  type="button"
+                  className={`${styles.genLightboxNav} ${styles.genLightboxNavNext}`}
+                  onClick={() =>
+                    setActiveIndex((prev) => (prev < images.length - 1 ? prev + 1 : prev))
+                  }
+                  disabled={activeIndex === images.length - 1}
+                  aria-label="Next image"
+                >
+                  <ChevronRightIcon />
+                </button>
+              )}
             </div>
 
             {(activeImage.prompt || activeImage.size || images.length > 1) && (
               <aside className={styles.genLightboxSidePanel}>
                 {activeImage.prompt && (
-                  <p className={styles.genLightboxPrompt}>{activeImage.prompt}</p>
+                  <div className={styles.genLightboxPrompt}>
+                    {renderMarkdown(activeImage.prompt)}
+                  </div>
                 )}
                 {(activeImage.size || images.length > 1) && (
                   <div className={styles.genLightboxMeta}>

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1406,19 +1406,17 @@
 }
 
 .genLightboxBody {
-  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 24px;
   min-width: 0;
   min-height: 0;
   flex-shrink: 1;
 }
 
 .genLightboxNav {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  flex-shrink: 0;
   width: 44px;
   height: 44px;
   border-radius: 50%;
@@ -1447,7 +1445,7 @@
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
   opacity: 1;
-  transform: translateY(-50%) scale(1.06);
+  transform: scale(1.06);
 }
 
 .genLightboxNav:focus-visible {
@@ -1459,18 +1457,12 @@
   opacity: 0.25;
   cursor: default;
   pointer-events: none;
-  transform: translateY(-50%);
-}
-
-.genLightboxNavPrev {
-  left: 12px;
-}
-
-.genLightboxNavNext {
-  right: 12px;
 }
 
 @media (max-width: 640px) {
+  .genLightboxBody {
+    gap: 14px;
+  }
   .genLightboxNav {
     width: 38px;
     height: 38px;
@@ -1478,12 +1470,6 @@
   .genLightboxNav svg {
     width: 18px;
     height: 18px;
-  }
-  .genLightboxNavPrev {
-    left: 8px;
-  }
-  .genLightboxNavNext {
-    right: 8px;
   }
 }
 
@@ -1537,9 +1523,61 @@
   font-size: 13.5px;
   line-height: 1.65;
   color: rgba(255, 255, 255, 0.78);
-  margin: 0;
-  white-space: pre-wrap;
   word-break: break-word;
+}
+
+.genLightboxPrompt > * {
+  margin: 0 0 10px;
+}
+.genLightboxPrompt > *:last-child {
+  margin-bottom: 0;
+}
+.genLightboxPrompt h1,
+.genLightboxPrompt h2,
+.genLightboxPrompt h3 {
+  font-size: 14px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+  margin-top: 14px;
+}
+.genLightboxPrompt h1:first-child,
+.genLightboxPrompt h2:first-child,
+.genLightboxPrompt h3:first-child {
+  margin-top: 0;
+}
+.genLightboxPrompt strong {
+  color: rgba(255, 255, 255, 0.95);
+  font-weight: 600;
+}
+.genLightboxPrompt em {
+  color: rgba(255, 255, 255, 0.85);
+}
+.genLightboxPrompt blockquote {
+  border-left: 2px solid rgba(255, 255, 255, 0.2);
+  padding: 2px 0 2px 12px;
+  color: rgba(255, 255, 255, 0.7);
+}
+.genLightboxPrompt code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 12.5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.genLightboxPrompt ul,
+.genLightboxPrompt ol {
+  padding-left: 20px;
+}
+.genLightboxPrompt li {
+  margin: 2px 0;
+}
+.genLightboxPrompt a {
+  color: rgba(160, 195, 255, 0.95);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.genLightboxPrompt a:hover {
+  color: rgba(190, 215, 255, 1);
 }
 
 .genLightboxMeta {


### PR DESCRIPTION
## Summary

PR 1 of the image-viewer polish work. Two visible fixes on the generated-image lightbox:

### 1. Nav arrows now sit outside the image
Before: arrows were `position: absolute; left/right: 12px` inside `.genLightboxBody`, sitting **on top** of the image and partially covering it. Hard to see what's rendered.

After: `.genLightboxBody` is a flex row with `gap: 24px`; the prev/next buttons are real flex siblings of the `<img>`. They occupy the negative space on either side — never overlapping the artwork. Standard gallery-viewer pattern (Notion, Linear, macOS Preview).

### 2. Prompt panel renders markdown properly
Before: the prompt panel rendered `activeImage.prompt` as raw text inside a `<p>` — so `**ARAVEIL**`, `> Create a premium…`, `> **Format:**` showed up as literal asterisks and angle brackets in the side panel.

After: uses the existing `renderMarkdown()` helper the rest of the chat already uses, wrapped in scoped styles for the dark side-panel theme:
- `**bold**` → proper bold with brighter white
- `>` → subtle blockquote with a left rule
- `# headings`, `*italic*`, `` `code` ``, lists, links all styled to fit the panel

## Test plan

- [x] `npm run build` succeeds
- [ ] After deploy, re-open the ARAVEIL image — the prompt panel shows formatted text (bold, blockquote rule, no raw `**` or `>`)
- [ ] Nav arrows sit beside the image, not on it; image is fully visible
- [ ] Single-image view (no nav buttons rendered) still centers correctly
- [ ] Mobile viewport (< 640px) gap collapses to 14px so the layout still fits

## What's next

PR 2 (separate) will replace the plain `<textarea>` composers across main chat and projects with a TipTap WYSIWYG editor so markdown formats live as you type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_