### PR TITLE
fix(lightbox): strip chat blockquote card style from prompt panel

### DIFF
--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1552,10 +1552,37 @@
 .genLightboxPrompt em {
   color: rgba(255, 255, 255, 0.85);
 }
+/* Override the chat's boxy .blockquote (flex card with bg + rounded
+   corners) — in the side panel we want simple quoted text with a thin
+   left rule, not a callout card. */
 .genLightboxPrompt blockquote {
-  border-left: 2px solid rgba(255, 255, 255, 0.2);
+  display: block;
+  background: transparent;
+  border-radius: 0;
+  margin: 0 0 10px 0;
   padding: 2px 0 2px 12px;
-  color: rgba(255, 255, 255, 0.7);
+  border-left: 2px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.78);
+  font-size: inherit;
+  line-height: inherit;
+  gap: 0;
+}
+.genLightboxPrompt blockquote :global([class*='blockquoteIcon']) {
+  display: none;
+}
+.genLightboxPrompt blockquote :global([class*='blockquoteContent']) {
+  flex: none;
+  min-width: 0;
+  display: block;
+}
+.genLightboxPrompt blockquote p {
+  margin: 0 0 6px;
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+.genLightboxPrompt blockquote p:last-child {
+  margin-bottom: 0;
 }
 .genLightboxPrompt code {
   background: rgba(255, 255, 255, 0.08);


### PR DESCRIPTION
## Summary

Fixes a regression from #461. After enabling `renderMarkdown()` on the prompt panel, the user's quoted prompt (lines starting with `> `) rendered inside a `<blockquote class={styles.blockquote}>` — which inherited the chat's blockquote *card* style (flex layout, `bg-secondary` fill, rounded corners, 14×18px padding). In the narrow side panel that card looked like a tight "boxed-in" snippet and clipped the surrounding text against the column edge.

In the lightbox side panel we want **simple quoted text with a thin left rule**, not a callout card. This PR strips the chat-blockquote card styles within `.genLightboxPrompt`:

- Forces `display: block` on the blockquote (overriding the inherited `display: flex`)
- Removes `background`, `border-radius`, `gap`, large padding
- Resets the inner `.blockquoteContent` flex to a plain block so text wraps freely
- Hides the (unused) `.blockquoteIcon` element the chat uses for Note/Warning variants
- Resets paragraph margins so the blockquote contents flow with the rest of the prompt

## Note on prompt content

For images **generated before** the Stage A synthesizer-removal (`#171`), the stored `prompt` field is the gpt-4o-mini-synthesized 40-160-word polished version, not the user's full original text. Those images will always show that shorter prompt regardless of the lightbox rendering — there's no longer text to display because the synthesizer rewrote it before save. Images generated **after** `#171` deployed store the user's raw prompt verbatim and will show the full text.

If the test image you re-checked was generated before `#171` shipped, generate a fresh one to compare.

## Test plan

- [x] `npm run build` succeeds
- [ ] After deploy, generate a new image with the long ARAVEIL prompt — lightbox shows the full text with `**bold**`, blockquote-rule indentation, no boxed card
- [ ] Older images render with the (shorter) synthesized prompt, but no more truncation/clipping
- [ ] Side panel still scrolls when content exceeds `max-height`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_