### PR TITLE
chore(models): drop presentation entries for catalog-absent image models

### DIFF
--- a/src/data/modelPresentation.js
+++ b/src/data/modelPresentation.js
@@ -184,26 +184,6 @@ export const MODEL_PRESENTATION = {
     bestFor: ['Image generation', 'Marketing assets', 'Infographics', 'Multi-image composition'],
     badge: 'New',
   },
-  'gemini-3.1-flash-image-preview': {
-    tagline: 'High-efficiency image generation and editing',
-    bestFor: ['Image generation', 'Image editing'],
-    badge: 'Image Gen',
-  },
-  'gemini-2.5-flash-image': {
-    tagline: 'Native image generation and editing',
-    bestFor: ['Budget image generation', 'Image editing'],
-    badge: 'Image Gen',
-  },
-  'imagen-4.0-fast-generate-001': {
-    tagline: 'Fast text-to-image with exceptional clarity',
-    bestFor: ['Fast image creation', 'High-clarity images'],
-    badge: 'Image Gen',
-  },
-  'imagen-4.0-generate-001': {
-    tagline: 'Best text rendering and highest quality images',
-    bestFor: ['Highest quality images', 'Text rendering', 'Visual content'],
-    badge: 'Image Gen',
-  },
   'veo-3.1-generate-preview': {
     tagline: 'Cinematic video generation with synced audio',
     bestFor: ['Video creation', 'Cinematic content', 'High-fidelity video'],


### PR DESCRIPTION
## Summary

Drops presentation entries for **four image model IDs that the catalog no longer exposes**, and triggers a fresh deploy so the prebuild step re-syncs `bundledModels.js` from the updated api catalog (which now reflects yesterday's Imagen 4 deprecation in `ade#81` and the earlier Nano Banana 2 preview retirement in `web#462`).

## What was stale

`modelPresentation.js` is web-owned, hand-maintained presentation copy (taglines, badges, `bestFor` chips) keyed by model ID. Entries are merged onto the canonical catalog at runtime; missing entries fall back to empty defaults. These four had no matching catalog entry anymore:

| ID | Status |
| --- | --- |
| `gemini-3.1-flash-image-preview` | Retired in `ade#80` / `web#462` |
| `gemini-2.5-flash-image` | Retired pre-audit |
| `imagen-4.0-fast-generate-001` | Deprecated in `ade#81` |
| `imagen-4.0-generate-001` | Deprecated in `ade#81` |

Zero runtime impact (the lookups for these IDs never fire), just removing dead documentation that made the file look like a richer image-model lineup was live than what users actually see in the picker.

After this deploys, the only Google image presentation entry is `gemini-3.1-flash-image` (Nano Banana 2 GA) — matching the catalog exactly.

## Deploy side-effect

The Vercel build runs the prebuild catalog sync, so this PR also brings `bundledModels.js` in line with the api catalog at deploy time — no other source change needed to surface yesterday's Imagen 4 deprecation in the production picker.

## Test plan

- [x] `git diff --stat` confirms 20-line deletion, no other touch
- [ ] After deploy, model picker shows Nano Banana 2 as the only premium Google image option
- [ ] No console warnings about missing model IDs (none expected — file removed FROM not added TO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_