### PR TITLE
feat(lightbox): swipe between images on mobile, fix iOS notch overlap

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -1772,6 +1772,7 @@ function GeneratedImageLightbox({ images, initialIndex, onClose }) {
   const { downloading, handleDownload } = useImageDownload();
   const thumbListRef = useRef(null);
   const activeThumbRef = useRef(null);
+  const touchStartRef = useRef(null);
 
   const activeImage = images[activeIndex] || images[0];
   const providerData = activeImage?.provider ? PROVIDERS[activeImage.provider] : null;
@@ -1796,6 +1797,27 @@ function GeneratedImageLightbox({ images, initialIndex, onClose }) {
       activeThumbRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
   }, [activeIndex]);
+
+  const handleTouchStart = (e) => {
+    if (images.length <= 1) return;
+    const t = e.touches[0];
+    touchStartRef.current = { x: t.clientX, y: t.clientY };
+  };
+
+  const handleTouchEnd = (e) => {
+    if (!touchStartRef.current) return;
+    const t = e.changedTouches[0];
+    const dx = t.clientX - touchStartRef.current.x;
+    const dy = t.clientY - touchStartRef.current.y;
+    touchStartRef.current = null;
+    // Horizontal swipe only — must travel >50px and dominate any vertical motion
+    if (Math.abs(dx) < 50 || Math.abs(dx) <= Math.abs(dy)) return;
+    setActiveIndex((prev) => {
+      if (dx < 0 && prev < images.length - 1) return prev + 1;
+      if (dx > 0 && prev > 0) return prev - 1;
+      return prev;
+    });
+  };
 
   if (!activeImage) return null;
 
@@ -1856,7 +1878,11 @@ function GeneratedImageLightbox({ images, initialIndex, onClose }) {
           )}
 
           <div className={styles.genLightboxStage}>
-            <div className={styles.genLightboxBody}>
+            <div
+              className={styles.genLightboxBody}
+              onTouchStart={handleTouchStart}
+              onTouchEnd={handleTouchEnd}
+            >
               {images.length > 1 && (
                 <button
                   type="button"

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1244,7 +1244,10 @@
   align-items: center;
   justify-content: space-between;
   padding: 14px 20px;
+  padding-top: max(14px, env(safe-area-inset-top));
   flex-shrink: 0;
+  position: relative;
+  z-index: 5;
 }
 
 .genLightboxTopLeft {


### PR DESCRIPTION
## Summary

Two mobile UX fixes for the in-conversation image lightbox:

1. **iOS notch overlap.** On iPhones the Close (X) and Save buttons sat under the dynamic island/notch and could be hidden behind tall portrait images. The top bar now respects `env(safe-area-inset-top)` and gets `z-index: 5` so it always stays above the image stage.
2. **Swipe navigation.** Multi-image sets could only be navigated by tapping the small chevron buttons. Added `touchstart`/`touchend` handlers on the image body — a horizontal swipe of >50px that dominates any vertical motion moves to the next/previous image. Chevron buttons remain for tap fallback.

## Test plan

- [ ] Open a multi-image generation on iPhone Safari — verify Close (X) is fully visible and not under the dynamic island.
- [ ] Verify the Save button is no longer covered when the image is tall/portrait orientation.
- [ ] Swipe left/right on the image to navigate between images in the set.
- [ ] Confirm vertical scroll on the prompt panel still works (swipe gesture shouldn't hijack).
- [ ] Confirm desktop: arrow keys, Escape, click-outside, and chevron buttons all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_