### PR TITLE
fix(lightbox): theme-aware prompt sheet on mobile

### DIFF
--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1754,13 +1754,13 @@
   width: 100%;
   max-width: 640px;
   max-height: 72vh;
-  background: #161616;
+  background: var(--bg-primary);
   border-radius: 20px 20px 0 0;
   padding: 12px 22px max(24px, env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 -16px 48px rgba(0, 0, 0, 0.5);
+  border-top: 1px solid var(--border-color);
+  box-shadow: 0 -16px 48px rgba(0, 0, 0, 0.45);
   animation: genLightboxSheetUp 0.28s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -1777,14 +1777,14 @@
   width: 36px;
   height: 4px;
   border-radius: 2px;
-  background: rgba(255, 255, 255, 0.22);
+  background: var(--border-color);
   margin: 0 auto 14px;
 }
 
 .genLightboxPromptSheetTitle {
   font-size: 11px;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.1em;
   margin: 0 0 10px;
@@ -1795,17 +1795,17 @@
   flex: 1;
   font-size: 14px;
   line-height: 1.65;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--text-primary);
   word-break: break-word;
   scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+  scrollbar-color: var(--text-muted) transparent;
 }
 
 .genLightboxPromptSheetContent::-webkit-scrollbar {
   width: 6px;
 }
 .genLightboxPromptSheetContent::-webkit-scrollbar-thumb {
-  background-color: rgba(255, 255, 255, 0.18);
+  background-color: var(--text-muted);
   border-radius: 3px;
 }
 
@@ -1817,12 +1817,13 @@
 }
 
 .genLightboxPromptSheetContent strong {
-  color: #fff;
+  color: var(--text-primary);
   font-weight: 700;
 }
 
 .genLightboxPromptSheetContent code {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-hover);
+  color: var(--text-primary);
   padding: 1px 5px;
   border-radius: 4px;
   font-size: 12.5px;


### PR DESCRIPTION
## Summary

The mobile prompt bottom sheet (added in #465) had hardcoded dark colors. In light mode, the markdown blockquote inside the prompt rendered with the light theme's cream background while the sheet's text-color overrides forced white text on top of it — unreadable.

This switches the sheet, handle, title, scrollbar, and content text to use the Araveil CSS variables (`--bg-primary`, `--text-primary`, `--text-muted`, `--border-color`, `--bg-hover`). The sheet now adopts the active Araveil theme and the blockquote inside renders with matching contrast.

## Test plan

- [ ] In **light mode**, open a generated image and tap "Prompt" — sheet should use the warm cream tones with dark text; blockquote contents should be legible.
- [ ] In **dark mode**, same flow — sheet should use the charcoal tones with light text.
- [ ] Toggle theme in Settings while the sheet is open if possible (or close + reopen) to confirm both states render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK

---
_Generated by [Claude Code](https://claude.ai/code/session_018tFc26w6vZVTs5rkJ5MkyK)_