### PR TITLE
fix(routing): sync URL to state for new chats, projects, and image lightbox

### DIFF
--- a/src/components/ImageGalleryView/ImageGalleryView.jsx
+++ b/src/components/ImageGalleryView/ImageGalleryView.jsx
@@ -232,15 +232,18 @@ export default function ImageGalleryView() {
     setDisplayedCount(PAGE_SIZE);
   }, [filterModel]);
 
-  // Handle deep link to specific image via route param
+  // Sync lightbox with URL: opens on /images/:id, closes on /images.
   useEffect(() => {
-    if (routeImageId && images.length > 0) {
-      const idx = images.findIndex((img) => img.id === routeImageId);
-      if (idx !== -1) {
-        // Ensure the target image is within the currently displayed slice
-        setDisplayedCount((c) => (idx >= c ? Math.ceil((idx + 1) / PAGE_SIZE) * PAGE_SIZE : c));
-        setLightboxIdx(idx);
-      }
+    if (!routeImageId) {
+      setLightboxIdx(null);
+      return;
+    }
+    if (images.length === 0) return;
+    const idx = images.findIndex((img) => img.id === routeImageId);
+    if (idx !== -1) {
+      // Ensure the target image is within the currently displayed slice
+      setDisplayedCount((c) => (idx >= c ? Math.ceil((idx + 1) / PAGE_SIZE) * PAGE_SIZE : c));
+      setLightboxIdx(idx);
     }
   }, [routeImageId, images]);
 
@@ -692,7 +695,10 @@ export default function ImageGalleryView() {
                   return (
                     <div key={img.id} className={cardClassName} style={cardStyle}>
                       <div className={styles.cardImageWrapper}>
-                        <button className={styles.cardImage} onClick={() => setLightboxIdx(idx)}>
+                        <button
+                          className={styles.cardImage}
+                          onClick={() => navigate(`/images/${img.id}`)}
+                        >
                           <img
                             src={img.url}
                             alt={img.prompt || 'Generated image'}
@@ -712,7 +718,7 @@ export default function ImageGalleryView() {
                           <div className={styles.cardOverlayBottom}>
                             <button
                               className={styles.cardOverlayBtn}
-                              onClick={() => setLightboxIdx(idx)}
+                              onClick={() => navigate(`/images/${img.id}`)}
                               title="View full size"
                             >
                               <MaximizeIcon />
@@ -820,11 +826,11 @@ export default function ImageGalleryView() {
           <ImageDetailView
             images={visibleImages}
             startIndex={lightboxIdx}
-            onClose={() => setLightboxIdx(null)}
+            onClose={() => navigate('/images')}
             onDownload={handleDownload}
             onDelete={(id) => {
               handleDelete(id);
-              setLightboxIdx(null);
+              navigate('/images');
             }}
           />,
           document.body

--- a/src/components/MainContent/MainContent.jsx
+++ b/src/components/MainContent/MainContent.jsx
@@ -1176,6 +1176,17 @@ export default function MainContent() {
               // Save the conversationId from backend (may be newly created)
               if (data.conversationId) {
                 dispatch(setCurrentChat(data.conversationId));
+                // Sync the address bar so back/forward, refresh, and copy-link all
+                // work. replaceState (not navigate) because a real route change would
+                // remount MainContent and kill the in-flight stream — the router
+                // still picks up the new URL on refresh, share, and popstate.
+                const targetPath = `/conversations/${data.conversationId}`;
+                if (
+                  window.location.pathname !== targetPath &&
+                  window.location.pathname !== `/chat/${data.conversationId}`
+                ) {
+                  window.history.replaceState(null, '', targetPath);
+                }
                 // Notify sidebar to refresh conversations list immediately
                 window.dispatchEvent(new CustomEvent('araviel-conversation-updated'));
                 // Once the backend creates a native conversation, clear imported context

--- a/src/components/ProjectsView/ProjectsView.jsx
+++ b/src/components/ProjectsView/ProjectsView.jsx
@@ -905,6 +905,9 @@ export default function ProjectsView() {
     const result = await createProjectApi(data);
     const newProject = result.project || result;
     dispatch(addProject(newProject));
+    if (newProject?.id) {
+      navigate(`/projects/${newProject.id}`);
+    }
   };
 
   const handleEdit = async (data) => {


### PR DESCRIPTION
## Summary

The app's routing infrastructure was actually wired up correctly (real routes per page, deep links work, vercel SPA fallback in place), but several stateful actions never reflected in the address bar — so back/forward, refresh, and copy-link silently broke for the most common flows.

Three surgical fixes, all URL-sync, no other behavior changed:

- **New conversation** — `MainContent.jsx`: on the first SSE `routing` event of a fresh chat, the address bar now updates to `/conversations/:id`. Uses `window.history.replaceState` rather than `navigate()` because a real route change would remount `MainContent` mid-stream and tear down the in-flight SSE handler. The router still picks up the new URL on refresh, share, popstate, and subsequent navigations — exactly the pattern ChatGPT/Claude use.
- **New project** — `ProjectsView.jsx`: after `createProjectApi` resolves, `navigate('/projects/:id')` so the user lands inside the new project and the URL reflects it. Both routes already render the same element, so this is just a `useParams()` value change — no remount.
- **Image lightbox** — `ImageGalleryView.jsx`: clicking a card or maximize button pushes `/images/:id`; close/delete navigates back to `/images`. The existing URL→lightbox effect now also closes the lightbox when the route id disappears, so the browser back button closes it.

## What this fixes for users

- Refresh on a fresh chat keeps you in the chat (instead of bouncing to home)
- Copy/paste the URL of any chat, project, or image — works in a new tab
- Browser back closes the image lightbox naturally
- Creating a project lands you inside it instead of staying on the list

## What I deliberately left alone

Scroll restoration, in-lightbox arrow nav URL sync, filter persistence in `Conversations`/`Projects`, and a unified `<ProtectedRoute>` wrapper were all flagged in the audit but kept out of this PR. They're additive UX improvements rather than the "pages aren't real pages" bug, and per the brief I stayed surgical.

## Test plan

- [ ] Send a message from `/` — address bar updates to `/conversations/<id>` mid-stream; the stream completes without flicker; refresh keeps you in the conversation
- [ ] Send a follow-up from `/conversations/<id>` — URL unchanged, no extra history entry
- [ ] Create a new project from `/projects` and from `/projects/<otherId>` — both land on `/projects/<newId>`
- [ ] Click an image in the gallery — URL becomes `/images/<id>`, lightbox opens
- [ ] Hit browser back from the lightbox — closes the lightbox, returns to `/images`
- [ ] Open `/images/<id>` directly in a new tab — lightbox opens on load
- [ ] Delete the image from inside the lightbox — lightbox closes, URL returns to `/images`

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ha5ZuxPmpaGzzHH52fq6B)_