### PR TITLE
fix(message): show image loader only when the turn actually generates an image

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -5,13 +5,7 @@ import { selectEffectiveTheme } from '../../store/slices/themeSlice';
 import { setInputValue, dismissMessageError } from '../../store/slices/chatSlice';
 import { selectSidebarCollapsed } from '../../store/slices/sidebarSlice';
 import { getProviderLogo } from '../getProviderLogo';
-import {
-  PROVIDERS,
-  MODELS,
-  SPEED_TIERS,
-  formatTokens,
-  isImageGenerationModel,
-} from '../../data/models';
+import { PROVIDERS, MODELS, SPEED_TIERS, formatTokens } from '../../data/models';
 import ImageGenerationPlaceholder from '../ImageGenerationPlaceholder';
 import {
   createSubConversation,
@@ -5671,9 +5665,7 @@ function Message({
   const displayText = isStreaming ? streamedText : message.content;
   const isImageGenerationTurn =
     !isUser &&
-    (message.requestedModality === 'image' ||
-      message.analysis?.intent === 'image_generation' ||
-      isImageGenerationModel(message.modelId));
+    (message.requestedModality === 'image' || message.analysis?.intent === 'image_generation');
   const provider = message.provider;
   const providerData = provider ? PROVIDERS[provider] : null;
   const LogoComponent = provider ? getProviderLogo(provider) : null;


### PR DESCRIPTION
## Summary

The streaming "Composing the scene…" image-generation placeholder fires the moment the routed model has `capabilities.imageGeneration === true` — even when the model is being used for a plain text reply. Hybrid text+image models (GPT-4o, Gemini, etc.) trigger it on any turn, including greetings like "good morning" in a text conversation. The user sees an image canvas loader and ends up with a text reply.

Frontend now mirrors the backend's actual gate exactly. `api/chat/route.ts:507` decides whether to generate an image with:

```ts
enableImageGeneration = !messageIsEmpty &&
  (adeResponse.analysis.intent === "image_generation" || chatReq.modality === "image");
```

After this change, `MessageList.jsx` uses the same two signals:

- `message.requestedModality === 'image'` — set on the placeholder iff the frontend sent `modality: 'image'` at submit (mirrors `chatReq.modality === 'image'`)
- `message.analysis?.intent === 'image_generation'` — set from the routing SSE event (mirrors `adeResponse.analysis.intent`)

The dropped `isImageGenerationModel(message.modelId)` check was a model-capability inference, not a turn-intent signal. It produced false positives for every hybrid model.

## Case coverage

| Scenario | Before | After |
|---|---|---|
| User picks Image mode → generates image | Loader | Loader |
| Text mode, "draw me a cat" → ADE auto-routes to image | Loader | Loader |
| Text mode, "good morning" → ADE picks hybrid model for text reply | **Loader (bug)** | Typing dots |
| Text mode, ADE picks dedicated text model | Typing dots | Typing dots |
| Loading historical conversation with past images | No placeholder (`isStreaming` is false) | Same |
| Refresh mid-image-stream | Real bubble on reconnect | Same |
| Image Gallery quick-prompt → auto-submit | Loader (via `requestedModality`) | Same |
| Stop / retry / regenerate | Fresh placeholder from `options.modality` | Same |

## Scope discipline

- One file, two edits: drop the capability-check clause, drop the now-unused import.
- `isImageGenerationModel()` itself is untouched and still used by its other three consumers in `MainContent.jsx` (submit-time credit/modality/route guards). Those decisions correctly need to know what a model is capable of — they're a different concern from "is this turn rendering an image?".
- No tests reference `isImageGenerationTurn` or `ImageGenerationPlaceholder`. The 8 tests on `isImageGenerationModel` cover the utility function itself and continue to pass.
- No new patterns, no new abstractions, no behavior change for real image generations.

## Test plan

- [ ] In Text mode, send "good morning" in a conversation that previously used a hybrid model — expect typing dots, then text reply
- [ ] In Text mode, send "draw me a cat" — expect "Composing the scene…" loader, then image
- [ ] In Image mode, send any prompt — expect loader, then image
- [ ] Stop a streaming image generation mid-flight — placeholder removed, no lingering state
- [ ] Regenerate an image reply — fresh loader, no flash of typing dots
- [ ] Open a historical conversation containing past images — images render, no placeholder shown
- [ ] `npm run build` succeeds, lint clean, tests pass (1 pre-existing unrelated authSlice failure on this branch)

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ha5ZuxPmpaGzzHH52fq6B)_