### PR TITLE
feat(routing): make route progress bar track real in-flight requests

### DIFF
--- a/src/components/RouteProgressBar/RouteProgressBar.jsx
+++ b/src/components/RouteProgressBar/RouteProgressBar.jsx
@@ -1,17 +1,28 @@
 import { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { subscribeToInflight } from '../../lib/apiClient';
 import styles from './RouteProgressBar.module.css';
 
 const START_DELAY_MS = 20;
-const LOADING_HOLD_MS = 500;
+const FETCH_GRACE_MS = 150;
+const SETTLE_DEBOUNCE_MS = 80;
 const COMPLETE_FADE_MS = 300;
+const SAFETY_TIMEOUT_MS = 10000;
 
 /**
- * Slim top-of-viewport progress bar that animates on route changes. Pure
- * UI affordance — runs on a fixed timeline (~800ms total) rather than
- * tracking actual data-load completion. Quick navigations still benefit
- * from the perceived-progress feedback. The bar is hidden in `idle` and
- * skips the very first render so a cold load doesn't flash.
+ * Slim top-of-viewport progress bar that animates on route changes and
+ * tracks actual in-flight `apiFetch` calls.
+ *
+ * Timeline per navigation:
+ *   1. pathname changes → bar appears (`start`)
+ *   2. ~20ms later → slow climb to ~90% (`loading`)
+ *   3. After a short grace period, watch the in-flight counter
+ *   4. When the counter settles at 0 → snap to 100% + fade (`complete`)
+ *   5. → `idle`
+ *
+ * The grace period lets the new route mount and kick off its fetches before
+ * we start watching; otherwise we'd settle immediately on routes whose data
+ * is already cached. A safety timeout guarantees the bar never sticks.
  */
 export default function RouteProgressBar() {
   const { pathname } = useLocation();
@@ -24,15 +35,47 @@ export default function RouteProgressBar() {
       return undefined;
     }
 
+    let cancelled = false;
+    let settleTimer = null;
+    let unsubscribe = null;
+    let settled = false;
+
+    const finish = () => {
+      if (cancelled || settled) return;
+      settled = true;
+      if (unsubscribe) unsubscribe();
+      setPhase('complete');
+      const idle = setTimeout(() => {
+        if (!cancelled) setPhase('idle');
+      }, COMPLETE_FADE_MS);
+      settleTimer = idle;
+    };
+
     setPhase('start');
-    const loadingTimer = setTimeout(() => setPhase('loading'), START_DELAY_MS);
-    const completeTimer = setTimeout(() => setPhase('complete'), LOADING_HOLD_MS);
-    const idleTimer = setTimeout(() => setPhase('idle'), LOADING_HOLD_MS + COMPLETE_FADE_MS);
+    const loadingTimer = setTimeout(() => {
+      if (!cancelled) setPhase('loading');
+    }, START_DELAY_MS);
+
+    const watchTimer = setTimeout(() => {
+      if (cancelled) return;
+      unsubscribe = subscribeToInflight((count) => {
+        if (cancelled) return;
+        if (settleTimer) clearTimeout(settleTimer);
+        if (count === 0) {
+          settleTimer = setTimeout(finish, SETTLE_DEBOUNCE_MS);
+        }
+      });
+    }, FETCH_GRACE_MS);
+
+    const safetyTimer = setTimeout(finish, SAFETY_TIMEOUT_MS);
 
     return () => {
+      cancelled = true;
       clearTimeout(loadingTimer);
-      clearTimeout(completeTimer);
-      clearTimeout(idleTimer);
+      clearTimeout(watchTimer);
+      clearTimeout(safetyTimer);
+      if (settleTimer) clearTimeout(settleTimer);
+      if (unsubscribe) unsubscribe();
     };
   }, [pathname]);
 

--- a/src/components/RouteProgressBar/RouteProgressBar.module.css
+++ b/src/components/RouteProgressBar/RouteProgressBar.module.css
@@ -20,9 +20,9 @@
 }
 
 .loading {
-  transform: scaleX(0.7);
+  transform: scaleX(0.9);
   opacity: 1;
-  transition: transform 0.5s cubic-bezier(0.1, 0.7, 0.1, 1), opacity 0.1s linear;
+  transition: transform 8s cubic-bezier(0, 0.4, 0.2, 1), opacity 0.1s linear;
 }
 
 .complete {

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -23,6 +23,27 @@ const API_BASE =
   import.meta.env.VITE_ARAVIEL_API_BASE ||
   (import.meta.env.DEV ? '' : 'https://araviel-api.vercel.app');
 
+const inflightSubscribers = new Set();
+let inflightCount = 0;
+
+function notifyInflight() {
+  for (const fn of inflightSubscribers) fn(inflightCount);
+}
+
+/**
+ * Subscribe to the global `apiFetch` in-flight counter. The callback is
+ * invoked immediately with the current count and again on every change.
+ * Returns an unsubscribe function.
+ *
+ * @param {(count: number) => void} callback
+ * @returns {() => void}
+ */
+export function subscribeToInflight(callback) {
+  inflightSubscribers.add(callback);
+  callback(inflightCount);
+  return () => inflightSubscribers.delete(callback);
+}
+
 /**
  * Resolve the full URL for an API path. Relative paths are mounted under the
  * configured API base; absolute URLs are used as-is so callers can point at
@@ -97,70 +118,78 @@ export async function apiFetch(path, options = {}) {
     errorContext,
   } = options;
 
-  const requestId = generateRequestId();
-  const url = resolveUrl(path);
-  const headers = await buildHeaders({ auth, headers: extraHeaders, body, json });
-  headers.set('X-Request-Id', requestId);
+  inflightCount += 1;
+  notifyInflight();
 
-  const init = {
-    method,
-    headers,
-    signal,
-  };
-  if (json !== undefined) {
-    init.body = JSON.stringify(json);
-  } else if (body !== undefined) {
-    init.body = body;
-  }
-
-  let response;
   try {
-    response = await fetch(url, init);
-  } catch (cause) {
-    if (cause?.name === 'AbortError') throw cause;
-    const err = new NetworkError({ cause });
-    err.requestId = requestId;
-    logger.error('API request failed (network)', err, {
-      route: errorContext || path,
-      method,
-      requestId,
-    });
-    throw err;
-  }
+    const requestId = generateRequestId();
+    const url = resolveUrl(path);
+    const headers = await buildHeaders({ auth, headers: extraHeaders, body, json });
+    headers.set('X-Request-Id', requestId);
 
-  if (!response.ok) {
-    const { technicalMessage, userMessage } = await readErrorBody(response);
-    const serverRequestId = response.headers.get('x-request-id') || requestId;
-    const err = errorFromResponse(response, technicalMessage, serverRequestId);
-    if (userMessage) err.userMessage = userMessage;
-    logger.error('API request failed', err, {
-      route: errorContext || path,
+    const init = {
       method,
-      status: response.status,
-      requestId: serverRequestId,
-    });
-    throw err;
-  }
+      headers,
+      signal,
+    };
+    if (json !== undefined) {
+      init.body = JSON.stringify(json);
+    } else if (body !== undefined) {
+      init.body = body;
+    }
 
-  if (!parse) return response;
+    let response;
+    try {
+      response = await fetch(url, init);
+    } catch (cause) {
+      if (cause?.name === 'AbortError') throw cause;
+      const err = new NetworkError({ cause });
+      err.requestId = requestId;
+      logger.error('API request failed (network)', err, {
+        route: errorContext || path,
+        method,
+        requestId,
+      });
+      throw err;
+    }
 
-  if (response.status === 204) return null;
-  try {
-    return await response.json();
-  } catch (cause) {
-    const err = new ServiceError({
-      userMessage: 'We received an unexpected response. Please try again.',
-      technicalMessage: cause instanceof Error ? cause.message : 'Invalid JSON response',
-      status: response.status,
-      requestId,
-      cause,
-    });
-    logger.error('API response parse failed', err, {
-      route: errorContext || path,
-      method,
-      requestId,
-    });
-    throw err;
+    if (!response.ok) {
+      const { technicalMessage, userMessage } = await readErrorBody(response);
+      const serverRequestId = response.headers.get('x-request-id') || requestId;
+      const err = errorFromResponse(response, technicalMessage, serverRequestId);
+      if (userMessage) err.userMessage = userMessage;
+      logger.error('API request failed', err, {
+        route: errorContext || path,
+        method,
+        status: response.status,
+        requestId: serverRequestId,
+      });
+      throw err;
+    }
+
+    if (!parse) return response;
+
+    if (response.status === 204) return null;
+    try {
+      return await response.json();
+    } catch (cause) {
+      const err = new ServiceError({
+        userMessage: 'We received an unexpected response. Please try again.',
+        technicalMessage: cause instanceof Error ? cause.message : 'Invalid JSON response',
+        status: response.status,
+        requestId,
+        cause,
+      });
+      logger.error('API response parse failed', err, {
+        route: errorContext || path,
+        method,
+        requestId,
+      });
+      throw err;
+    }
+  } finally {
+    inflightCount -= 1;
+    notifyInflight();
   }
 }
 


### PR DESCRIPTION
## Summary

The progress bar previously animated on a fixed ~800ms timeline regardless of whether data was still loading. Fast routes flashed before content arrived; slow routes finished mid-load. Both betray the affordance and make it feel like an "extra feature" rather than a real signal.

Now it tracks **actual** in-flight requests. Every API call in this app already goes through one helper (`apiFetch`) — wrapping that helper gives accurate coverage with zero view-side changes.

## How it works

```
pathname change ──▶ start (0% → 8%)
                       │
              20ms ──▶ loading (slow climb toward 90% over 8s)
                       │
             150ms ──▶ begin watching the in-flight counter
                       │
        count = 0 ──▶ 80ms debounce ──▶ complete (snap to 100% + fade)
                       │
              300ms ──▶ idle
```

- **150ms grace** before subscribing so the new route can mount and kick off its fetches; otherwise routes whose data is already cached would settle instantly and look like a flash.
- **80ms settle debounce** so a chained request (one fetch finishes, next one starts within 80ms) doesn't cause a flicker.
- **10s safety timeout** guarantees the bar never sticks if a request hangs indefinitely.
- **8s easing curve** on `loading`: fast loads still snap to 100% almost immediately, long loads keep visibly progressing instead of stalling at 70%.

## Counter implementation

```js
// src/lib/apiClient.js
const inflightSubscribers = new Set();
let inflightCount = 0;

export function subscribeToInflight(callback) {
  inflightSubscribers.add(callback);
  callback(inflightCount);
  return () => inflightSubscribers.delete(callback);
}

export async function apiFetch(path, options = {}) {
  inflightCount += 1;
  notifyInflight();
  try {
    // ... existing body
  } finally {
    inflightCount -= 1;
    notifyInflight();
  }
}
```

The whole function body sits inside `try/finally`, so the counter stays accurate across success, error, and abort paths.

## What's intentionally not tracked

- **SSE chat stream** (`sendMessage`) — bypasses `apiFetch` because it returns the raw Response. This is correct: the chat stream is its own UX (typing indicator), not a route-level signal. We don't want every message keystroke pulsing the route bar.
- **Image generation streaming** — same reason.

## Files

- `src/lib/apiClient.js` — counter + pub/sub + try/finally wrap. Existing logic untouched (just indented one level deeper inside the `try`).
- `src/components/RouteProgressBar/RouteProgressBar.jsx` — subscribes to the counter, four-phase state machine with grace/debounce/safety timers, full cleanup.
- `src/components/RouteProgressBar/RouteProgressBar.module.css` — extend the `loading` transition (500ms / 70% → 8s / 90%) so long loads keep visibly progressing.

## Test plan

- [ ] Navigate to a route with cached data — bar appears briefly and completes (no fake stall)
- [ ] Navigate to a route that fetches — bar holds until the response arrives, then snaps to 100%
- [ ] Slow network throttle (Network tab) — bar progresses smoothly toward 90% during the wait
- [ ] Hit a 500 error — bar still completes (finally block triggers on throw)
- [ ] Rapid back/forward — no stuck bar; each nav cancels previous timers
- [ ] Search/filter (query-string only) — no false trigger
- [ ] Chat stream sending a message — no false trigger
- [ ] Build, lint, tests — 603 pass, 1 pre-existing unrelated authSlice failure

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ha5ZuxPmpaGzzHH52fq6B)_