### PR TITLE
fix(route-progress): smoother start and completion easings

### DIFF
--- a/src/components/RouteProgressBar/RouteProgressBar.jsx
+++ b/src/components/RouteProgressBar/RouteProgressBar.jsx
@@ -6,7 +6,7 @@ import styles from './RouteProgressBar.module.css';
 const START_DELAY_MS = 20;
 const FETCH_GRACE_MS = 150;
 const SETTLE_DEBOUNCE_MS = 80;
-const COMPLETE_FADE_MS = 300;
+const COMPLETE_FADE_MS = 800;
 const SAFETY_TIMEOUT_MS = 10000;
 
 /**

--- a/src/components/RouteProgressBar/RouteProgressBar.module.css
+++ b/src/components/RouteProgressBar/RouteProgressBar.module.css
@@ -16,19 +16,19 @@
 .start {
   transform: scaleX(0.08);
   opacity: 1;
-  transition: opacity 0.1s linear;
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.2s linear;
 }
 
 .loading {
   transform: scaleX(0.9);
   opacity: 1;
-  transition: transform 8s cubic-bezier(0, 0.4, 0.2, 1), opacity 0.1s linear;
+  transition: transform 8s cubic-bezier(0, 0.4, 0.2, 1), opacity 0.2s linear;
 }
 
 .complete {
   transform: scaleX(1);
   opacity: 0;
-  transition: transform 0.2s ease-out, opacity 0.3s ease-out 0.1s;
+  transition: transform 0.5s cubic-bezier(0.22, 0.61, 0.36, 1), opacity 0.55s ease-out 0.25s;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

The route progress bar still felt mechanical despite tracking real loads — two transitions were too snappy:

1. **Start**: `idle → start` had no `transform` transition, so the bar appeared at 8% width instantly (a "pop in")
2. **Complete**: the snap from 90% → 100% completed in 200ms, then opacity dropped over 300ms with only a 100ms delay — the eye barely saw the 100% before it began fading

Both transitions softened with longer durations and gentler easings:

| Phase | Before | After |
|---|---|---|
| `start` transform | none (instant 0 → 8%) | 250ms `cubic-bezier(0.16, 1, 0.3, 1)` — soft glide |
| `complete` transform | 200ms `ease-out` | 500ms `cubic-bezier(0.22, 0.61, 0.36, 1)` — smooth finish |
| `complete` opacity | 300ms, 100ms delay | 550ms `ease-out`, 250ms delay — user sees 100% before it fades |
| `COMPLETE_FADE_MS` (JS idle timer) | 300ms | 800ms — matches new fade window |

`loading` (the long 8s climb to 90%) is unchanged — it was already smooth. `prefers-reduced-motion` fallback is unchanged.

## Why these numbers

- `cubic-bezier(0.16, 1, 0.3, 1)` is a soft-bounce ease-out used by Material 3 and Tailwind's `ease-out-expo` — feels expensive without being slow
- `cubic-bezier(0.22, 0.61, 0.36, 1)` is `ease-out-quad` — gentle deceleration, no snap at the end
- 250ms opacity delay on complete lets the eye catch the 100% width before the fade starts; without it the bar disappears while still mid-climb

Net total animation budget per nav still tops out at ~1s — only the *finish* is more relaxed.

## Test plan

- [ ] Navigate — bar glides in from the left (no pop), holds steadily, then smoothly slides to 100% and fades
- [ ] Slow network — climb stays smooth, completion is calmer
- [ ] Rapid back/forward — no stuck frames; existing cleanup still cancels all timers
- [ ] `prefers-reduced-motion: reduce` — still fades only, no scale animation
- [ ] Build, lint, tests — 603 pass, 1 pre-existing unrelated authSlice failure

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ha5ZuxPmpaGzzHH52fq6B)_