### PR TITLE
fix(message-list): show conversation trail from the first prompt

### DIFF
--- a/src/components/MessageList/ConversationTrail.jsx
+++ b/src/components/MessageList/ConversationTrail.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styles from './ConversationTrail.module.css';
 
-const MIN_MARKERS_TO_SHOW = 3;
+const MIN_MARKERS_TO_SHOW = 1;
 const ACTIVE_ANCHOR_RATIO = 0.32;
 const FLASH_DURATION_MS = 1100;
 const TOP_INSET_PX = 96;


### PR DESCRIPTION
## Summary

The right-edge dot-rail conversation scrubber (`ConversationTrail`) only appeared once a chat had **3 user prompts**, so short conversations had no visible affordance and the indicator felt inconsistent. Lower the threshold to **1** so the trail is visible from the very first message onwards.

```diff
- const MIN_MARKERS_TO_SHOW = 3;
+ const MIN_MARKERS_TO_SHOW = 1;
```

## What I deliberately didn't touch

- **`hidden` prop gate** — still hides the trail when a code / sources / sub-conversation panel is open. Those panels reclaim the right edge; showing the trail there would visually compete.
- **`@media (max-width: 900px)` rule** — mobile keeps the trail hidden; there isn't physical room for a fixed-position rail next to the messages on a narrow viewport.

Both gates exist for real layout reasons, not arbitrary thresholds.

## Test plan

- [ ] Open a brand-new conversation — trail appears with one dot after the first user prompt
- [ ] Send more messages — additional dots animate in, active one tracks scroll
- [ ] Open code/sources/sub-conv panel — trail disappears (existing behavior, unchanged)
- [ ] Resize browser below 900px — trail hides (existing behavior, unchanged)
- [ ] Build, lint, tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ha5ZuxPmpaGzzHH52fq6B)_