### PR TITLE
refactor(views): consolidate guest fallback behind &lt;RequireAuth&gt;

### DIFF
--- a/src/components/ConversationsView/ConversationsView.jsx
+++ b/src/components/ConversationsView/ConversationsView.jsx
@@ -17,7 +17,7 @@ import {
   createNewChat,
 } from '../../store/slices/chatSlice';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
-import { GuestGate } from '../GuestGate';
+import RequireAuth from '../RequireAuth';
 import {
   fetchConversations,
   fetchImportedConversations,
@@ -1707,530 +1707,530 @@ export default function ConversationsView() {
     ? filteredImportedConversations
     : filteredConversations;
 
-  if (!isAuthenticated) {
-    return (
-      <div ref={pageRef} className={styles.page}>
-        <div className={styles.inner}>
-          <div className={styles.header}>
-            <h1 className={styles.title}>Conversations</h1>
-          </div>
-          <GuestGate
-            icon={<ChatIcon />}
-            title="Your conversations live here"
-            description="Sign in to save your conversations, access conversation history, and pick up where you left off."
-            actionLabel="Sign in to view conversations"
-          />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div ref={pageRef} className={styles.page}>
       <div className={styles.inner}>
         {/* Header */}
         <div className={styles.header}>
           <h1 className={styles.title}>Conversations</h1>
-          <div className={styles.headerActions}>
-            <button className={styles.importBtn} onClick={() => setShowImportModal(true)}>
-              <ImportIcon />
-              <span>Import</span>
-            </button>
-            <button
-              className={styles.newChatBtn}
-              onClick={() => {
-                dispatch(createNewChat());
-                navigate('/');
-              }}
-            >
-              <PlusIcon />
-              <span>New conversation</span>
-            </button>
-          </div>
-        </div>
-
-        {/* Section switcher */}
-        <div className={styles.sectionSwitcher}>
-          <button
-            className={`${styles.sectionTab} ${
-              activeSection === 'my-chats' ? styles.sectionTabActive : ''
-            }`}
-            onClick={() => {
-              setActiveSection('my-chats');
-              exitSelectMode();
-              setSearchQuery('');
-            }}
-          >
-            <ChatIcon />
-            <span>My Conversations</span>
-          </button>
-          <button
-            className={`${styles.sectionTab} ${
-              activeSection === 'imported' ? styles.sectionTabActive : ''
-            }`}
-            onClick={() => {
-              setActiveSection('imported');
-              exitSelectMode();
-              setSearchQuery('');
-            }}
-          >
-            <ImportIcon />
-            <span>Imported Conversations</span>
-          </button>
-        </div>
-
-        {/* Search bar */}
-        <div className={styles.searchWrapper}>
-          <div className={styles.searchIcon}>
-            <SearchIcon />
-          </div>
-          <input
-            type="text"
-            className={styles.searchInput}
-            placeholder={
-              isImportedSection
-                ? 'Search imported conversations...'
-                : 'Search your conversations...'
-            }
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
-          {searchQuery && (
-            <button
-              className={styles.searchClear}
-              onClick={() => setSearchQuery('')}
-              aria-label="Clear search"
-            >
-              <CloseIcon />
-            </button>
+          {isAuthenticated && (
+            <div className={styles.headerActions}>
+              <button className={styles.importBtn} onClick={() => setShowImportModal(true)}>
+                <ImportIcon />
+                <span>Import</span>
+              </button>
+              <button
+                className={styles.newChatBtn}
+                onClick={() => {
+                  dispatch(createNewChat());
+                  navigate('/');
+                }}
+              >
+                <PlusIcon />
+                <span>New conversation</span>
+              </button>
+            </div>
           )}
         </div>
 
-        {/* My Chats Section */}
-        {!isImportedSection && (
-          <>
-            {/* Toolbar: Tabs + Select toggle */}
-            <div className={styles.toolbar}>
-              <div className={styles.tabs}>
-                {TABS.map((tab) => (
-                  <button
-                    key={tab.id}
-                    className={`${styles.tab} ${activeTab === tab.id ? styles.tabActive : ''}`}
-                    onClick={() => {
-                      setActiveTab(tab.id);
-                      exitSelectMode();
-                    }}
-                  >
-                    {tab.label}
-                    {tab.id === 'starred' && starredIds.size > 0 && (
-                      <span className={styles.tabBadge}>{starredIds.size}</span>
-                    )}
-                    {tab.id === 'archived' && archivedIds.size > 0 && (
-                      <span className={styles.tabBadge}>{archivedIds.size}</span>
-                    )}
-                    {tab.id === 'shared' && sharedChats.shares && sharedChats.shares.length > 0 && (
-                      <span className={styles.tabBadge}>{sharedChats.shares.length}</span>
-                    )}
-                  </button>
-                ))}
-              </div>
-              {activeTab !== 'shared' && (
-                <button
-                  className={`${styles.selectToggle} ${
-                    selectMode ? styles.selectToggleActive : ''
-                  }`}
-                  onClick={() => {
-                    if (selectMode) {
-                      exitSelectMode();
-                    } else {
-                      setSelectMode(true);
-                    }
-                  }}
-                >
-                  {selectMode ? 'Cancel' : 'Select'}
-                </button>
-              )}
+        <RequireAuth
+          icon={<ChatIcon />}
+          title="Your conversations live here"
+          description="Sign in to save your conversations, access conversation history, and pick up where you left off."
+          actionLabel="Sign in to view conversations"
+        >
+          {/* Section switcher */}
+          <div className={styles.sectionSwitcher}>
+            <button
+              className={`${styles.sectionTab} ${
+                activeSection === 'my-chats' ? styles.sectionTabActive : ''
+              }`}
+              onClick={() => {
+                setActiveSection('my-chats');
+                exitSelectMode();
+                setSearchQuery('');
+              }}
+            >
+              <ChatIcon />
+              <span>My Conversations</span>
+            </button>
+            <button
+              className={`${styles.sectionTab} ${
+                activeSection === 'imported' ? styles.sectionTabActive : ''
+              }`}
+              onClick={() => {
+                setActiveSection('imported');
+                exitSelectMode();
+                setSearchQuery('');
+              }}
+            >
+              <ImportIcon />
+              <span>Imported Conversations</span>
+            </button>
+          </div>
+
+          {/* Search bar */}
+          <div className={styles.searchWrapper}>
+            <div className={styles.searchIcon}>
+              <SearchIcon />
             </div>
-
-            {selectMode && (
-              <div className={styles.selectionBar}>
-                <div className={styles.selectionLeft}>
-                  <span className={styles.selectionCount}>{selectedIds.size} selected</span>
-                  {selectedIds.size < selectableCount && (
-                    <button className={styles.selectAllBtn} onClick={selectAll}>
-                      Select all
-                    </button>
-                  )}
-                </div>
-                <div className={styles.selectionActions}>
-                  {activeTab === 'trash' ? (
-                    <>
-                      <button
-                        className={styles.selectionAction}
-                        onClick={() => hasSelection && handleBulkRestore()}
-                        disabled={!hasSelection || bulkRestoring}
-                        title="Restore"
-                      >
-                        <RefreshIcon />
-                      </button>
-                      <button
-                        className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
-                        onClick={() => hasSelection && setPurgeTargetIds([...selectedIds])}
-                        disabled={!hasSelection || purging}
-                        title="Delete permanently"
-                      >
-                        <TrashIcon />
-                      </button>
-                    </>
-                  ) : (
-                    <>
-                      <button
-                        className={styles.selectionAction}
-                        onClick={() => hasSelection && handleBulkAddToProject()}
-                        disabled={!hasSelection}
-                        title="Add to project"
-                      >
-                        <ProjectsIcon />
-                      </button>
-                      <button
-                        className={styles.selectionAction}
-                        onClick={() => hasSelection && handleBulkRemoveFromProject()}
-                        disabled={!hasSelection}
-                        title="Remove from project"
-                      >
-                        <LinkIcon />
-                      </button>
-                      <button
-                        className={styles.selectionAction}
-                        onClick={() => hasSelection && toggleStar(selectedIds)}
-                        disabled={!hasSelection}
-                        title="Star"
-                      >
-                        <StarIcon />
-                      </button>
-                      <button
-                        className={styles.selectionAction}
-                        onClick={() => hasSelection && toggleArchive(selectedIds)}
-                        disabled={!hasSelection}
-                        title={activeTab === 'archived' ? 'Move to Conversations' : 'Archive'}
-                      >
-                        <ArchiveIcon />
-                      </button>
-                      <button
-                        className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
-                        onClick={() => hasSelection && handleBulkDelete()}
-                        disabled={!hasSelection}
-                        title="Delete"
-                      >
-                        <TrashIcon />
-                      </button>
-                    </>
-                  )}
-                </div>
-                <button
-                  className={styles.selectionClose}
-                  onClick={exitSelectMode}
-                  aria-label="Exit selection"
-                >
-                  <CloseIcon />
-                </button>
-              </div>
+            <input
+              type="text"
+              className={styles.searchInput}
+              placeholder={
+                isImportedSection
+                  ? 'Search imported conversations...'
+                  : 'Search your conversations...'
+              }
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            {searchQuery && (
+              <button
+                className={styles.searchClear}
+                onClick={() => setSearchQuery('')}
+                aria-label="Clear search"
+              >
+                <CloseIcon />
+              </button>
             )}
+          </div>
 
-            <div className={styles.list} ref={listRef}>
-              {activeTab === 'trash' ? (
-                <TrashList
-                  conversations={trashedConversations}
-                  total={trashedTotal}
-                  loading={trashLoading}
-                  error={trashError}
-                  restoringId={restoringId}
-                  onRestore={handleRestoreConversation}
-                  onPurgeRequest={setPurgeTargetIds}
-                  onRetry={() => loadTrash(0)}
-                  onLoadMore={handleLoadMoreTrash}
-                  selectMode={selectMode}
-                  selectedIds={selectedIds}
-                  onToggleSelect={toggleSelect}
-                />
-              ) : activeTab === 'shared' ? (
-                <SharedChatsTabPanel
-                  shares={sharedChats.shares}
-                  loading={sharedChats.loading}
-                  error={sharedChats.error}
-                  searchQuery={searchQuery}
-                  busyConversationId={sharedBusyConversationId}
-                  onRetry={sharedChats.refetch}
-                  onRowClick={handleSharedRowClick}
-                  onCopy={handleSharedCopy}
-                  onUnshare={setSharedUnshareTarget}
-                />
-              ) : conversationsLoading && conversations.length === 0 ? (
-                <div className={styles.skeleton}>
-                  {[1, 2, 3, 4, 5, 6].map((i) => (
-                    <div key={i} className={styles.skeletonItem}>
-                      <div className={styles.skeletonContent}>
-                        <div
-                          className={styles.skeletonTitle}
-                          style={{ width: `${45 + ((i * 11) % 30)}%` }}
-                        />
-                        <div
-                          className={styles.skeletonSub}
-                          style={{ width: `${25 + ((i * 7) % 20)}%` }}
-                        />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : groupedFilteredConversations.length > 0 ? (
-                <>
-                  {groupedFilteredConversations.map((group) => (
-                    <div key={group.label} className={styles.timeGroup}>
-                      <div className={styles.timeGroupLabel}>{group.label}</div>
-                      {group.items.map((chat) => renderConversationItem(chat))}
-                    </div>
-                  ))}
-                  {conversations.length < conversationsTotal && (
-                    <div className={styles.loadMoreWrapper}>
-                      {conversationsLoading ? (
-                        <div className={styles.loadingMore}>
-                          <div className={styles.loadingDots}>
-                            <span />
-                            <span />
-                            <span />
-                          </div>
-                        </div>
-                      ) : (
-                        <button className={styles.loadMoreBtn} onClick={handleLoadMore}>
-                          Load more conversations
-                        </button>
-                      )}
-                    </div>
-                  )}
-                </>
-              ) : (
-                <div className={styles.empty}>
-                  <div className={styles.emptyIcon}>
-                    <ChatIcon />
-                  </div>
-                  <h3 className={styles.emptyTitle}>
-                    {activeTab === 'starred'
-                      ? 'No starred conversations'
-                      : activeTab === 'archived'
-                      ? 'No archived conversations'
-                      : searchQuery
-                      ? 'No results found'
-                      : 'No conversations yet'}
-                  </h3>
-                  <p className={styles.emptyDesc}>
-                    {activeTab === 'starred'
-                      ? 'Star your important conversations to find them quickly.'
-                      : activeTab === 'archived'
-                      ? 'Archived conversations will appear here.'
-                      : searchQuery
-                      ? 'Try a different search term.'
-                      : 'Start a new conversation.'}
-                  </p>
-                  {!searchQuery && activeTab === 'all' && (
+          {/* My Chats Section */}
+          {!isImportedSection && (
+            <>
+              {/* Toolbar: Tabs + Select toggle */}
+              <div className={styles.toolbar}>
+                <div className={styles.tabs}>
+                  {TABS.map((tab) => (
                     <button
-                      className={styles.emptyAction}
+                      key={tab.id}
+                      className={`${styles.tab} ${activeTab === tab.id ? styles.tabActive : ''}`}
                       onClick={() => {
-                        dispatch(createNewChat());
-                        navigate('/');
+                        setActiveTab(tab.id);
+                        exitSelectMode();
                       }}
                     >
-                      <PlusIcon />
-                      <span>New conversation</span>
+                      {tab.label}
+                      {tab.id === 'starred' && starredIds.size > 0 && (
+                        <span className={styles.tabBadge}>{starredIds.size}</span>
+                      )}
+                      {tab.id === 'archived' && archivedIds.size > 0 && (
+                        <span className={styles.tabBadge}>{archivedIds.size}</span>
+                      )}
+                      {tab.id === 'shared' &&
+                        sharedChats.shares &&
+                        sharedChats.shares.length > 0 && (
+                          <span className={styles.tabBadge}>{sharedChats.shares.length}</span>
+                        )}
                     </button>
-                  )}
+                  ))}
                 </div>
-              )}
-            </div>
-          </>
-        )}
-
-        {/* Imported Chats Section */}
-        {isImportedSection && (
-          <>
-            {/* Provider filter tabs */}
-            {importedProviders.length > 0 && (
-              <div className={styles.toolbar}>
-                <div className={styles.providerFilters}>
+                {activeTab !== 'shared' && (
                   <button
-                    className={`${styles.tab} ${
-                      activeImportProvider === 'all' ? styles.tabActive : ''
+                    className={`${styles.selectToggle} ${
+                      selectMode ? styles.selectToggleActive : ''
                     }`}
                     onClick={() => {
-                      setActiveImportProvider('all');
-                      exitSelectMode();
+                      if (selectMode) {
+                        exitSelectMode();
+                      } else {
+                        setSelectMode(true);
+                      }
                     }}
                   >
-                    All
-                    <span className={styles.tabBadge}>{importedConversations.length}</span>
+                    {selectMode ? 'Cancel' : 'Select'}
                   </button>
-                  {importedProviders.map((p) => {
-                    const count = importedConversations.filter((c) => c.provider === p.id).length;
-                    const ProviderLogo = getProviderLogo(p.id);
-                    return (
-                      <button
-                        key={p.id}
-                        className={`${styles.tab} ${
-                          activeImportProvider === p.id ? styles.tabActive : ''
-                        }`}
-                        onClick={() => {
-                          setActiveImportProvider(p.id);
-                          exitSelectMode();
-                        }}
-                      >
-                        <span className={styles.tabProviderIcon}>
-                          <ProviderLogo size={14} />
-                        </span>
-                        {p.name}
-                        <span className={styles.tabBadge}>{count}</span>
+                )}
+              </div>
+
+              {selectMode && (
+                <div className={styles.selectionBar}>
+                  <div className={styles.selectionLeft}>
+                    <span className={styles.selectionCount}>{selectedIds.size} selected</span>
+                    {selectedIds.size < selectableCount && (
+                      <button className={styles.selectAllBtn} onClick={selectAll}>
+                        Select all
                       </button>
-                    );
-                  })}
-                </div>
-                <button
-                  className={`${styles.selectToggle} ${
-                    selectMode ? styles.selectToggleActive : ''
-                  }`}
-                  onClick={() => {
-                    if (selectMode) exitSelectMode();
-                    else setSelectMode(true);
-                  }}
-                >
-                  {selectMode ? 'Cancel' : 'Select'}
-                </button>
-              </div>
-            )}
-
-            {/* Compact context bar */}
-            {importedProviders.length > 0 && (
-              <div className={styles.contextBar}>
-                <span className={styles.contextBarLabel}>
-                  <svg
-                    width="13"
-                    height="13"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <circle cx="12" cy="12" r="3" />
-                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-                  </svg>
-                  <span>Context</span>
-                </span>
-                <div className={styles.contextBarDivider} />
-                <div className={styles.contextBarChips}>
-                  {(activeImportProvider === 'all'
-                    ? importedProviders
-                    : importedProviders.filter((p) => p.id === activeImportProvider)
-                  ).map((p) => {
-                    const ProviderLogo = getProviderLogo(p.id);
-                    const isEnabled = !!contextProviders[p.id];
-                    return (
-                      <button
-                        key={p.id}
-                        className={`${styles.contextChip} ${
-                          isEnabled ? styles.contextChipActive : ''
-                        }`}
-                        onClick={() => toggleProviderContext(p.id)}
-                        title={isEnabled ? `Disable ${p.name} context` : `Enable ${p.name} context`}
-                      >
-                        <ProviderLogo size={13} />
-                        <span>{p.name}</span>
-                        <span className={styles.contextChipDot} />
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-
-            {/* Selection action bar for imported */}
-            {selectMode && (
-              <div className={styles.selectionBar}>
-                <div className={styles.selectionLeft}>
-                  <span className={styles.selectionCount}>{selectedIds.size} selected</span>
-                  {selectedIds.size < filteredImportedConversations.length && (
-                    <button className={styles.selectAllBtn} onClick={selectAll}>
-                      Select all
-                    </button>
-                  )}
-                </div>
-                <div className={styles.selectionActions}>
-                  <button
-                    className={styles.selectionAction}
-                    onClick={() => hasSelection && toggleImportedStar(selectedIds)}
-                    disabled={!hasSelection}
-                    title="Star"
-                  >
-                    <StarIcon />
-                  </button>
-                  <button
-                    className={styles.selectionAction}
-                    onClick={() => hasSelection && toggleImportedArchive(selectedIds)}
-                    disabled={!hasSelection}
-                    title={activeTab === 'archived' ? 'Move to Conversations' : 'Archive'}
-                  >
-                    <ArchiveIcon />
-                  </button>
-                  <button
-                    className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
-                    onClick={() => hasSelection && handleBulkDelete()}
-                    disabled={!hasSelection}
-                    title="Delete"
-                  >
-                    <TrashIcon />
-                  </button>
-                </div>
-                <button
-                  className={styles.selectionClose}
-                  onClick={exitSelectMode}
-                  aria-label="Exit selection"
-                >
-                  <CloseIcon />
-                </button>
-              </div>
-            )}
-
-            {/* Imported conversations list */}
-            <div className={styles.list}>
-              {groupedImportedConversations.length > 0 ? (
-                groupedImportedConversations.map((group) => (
-                  <div key={group.label} className={styles.timeGroup}>
-                    <div className={styles.timeGroupLabel}>{group.label}</div>
-                    {group.items.map((chat) => renderConversationItem(chat, { isImported: true }))}
+                    )}
                   </div>
-                ))
-              ) : (
-                <div className={styles.empty}>
-                  <div className={styles.emptyIcon}>
-                    <ImportIcon />
+                  <div className={styles.selectionActions}>
+                    {activeTab === 'trash' ? (
+                      <>
+                        <button
+                          className={styles.selectionAction}
+                          onClick={() => hasSelection && handleBulkRestore()}
+                          disabled={!hasSelection || bulkRestoring}
+                          title="Restore"
+                        >
+                          <RefreshIcon />
+                        </button>
+                        <button
+                          className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
+                          onClick={() => hasSelection && setPurgeTargetIds([...selectedIds])}
+                          disabled={!hasSelection || purging}
+                          title="Delete permanently"
+                        >
+                          <TrashIcon />
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          className={styles.selectionAction}
+                          onClick={() => hasSelection && handleBulkAddToProject()}
+                          disabled={!hasSelection}
+                          title="Add to project"
+                        >
+                          <ProjectsIcon />
+                        </button>
+                        <button
+                          className={styles.selectionAction}
+                          onClick={() => hasSelection && handleBulkRemoveFromProject()}
+                          disabled={!hasSelection}
+                          title="Remove from project"
+                        >
+                          <LinkIcon />
+                        </button>
+                        <button
+                          className={styles.selectionAction}
+                          onClick={() => hasSelection && toggleStar(selectedIds)}
+                          disabled={!hasSelection}
+                          title="Star"
+                        >
+                          <StarIcon />
+                        </button>
+                        <button
+                          className={styles.selectionAction}
+                          onClick={() => hasSelection && toggleArchive(selectedIds)}
+                          disabled={!hasSelection}
+                          title={activeTab === 'archived' ? 'Move to Conversations' : 'Archive'}
+                        >
+                          <ArchiveIcon />
+                        </button>
+                        <button
+                          className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
+                          onClick={() => hasSelection && handleBulkDelete()}
+                          disabled={!hasSelection}
+                          title="Delete"
+                        >
+                          <TrashIcon />
+                        </button>
+                      </>
+                    )}
                   </div>
-                  <h3 className={styles.emptyTitle}>
-                    {searchQuery ? 'No results found' : 'No imported conversations yet'}
-                  </h3>
-                  <p className={styles.emptyDesc}>
-                    {searchQuery
-                      ? 'Try a different search term.'
-                      : 'Bring your conversations from ChatGPT, Claude, Gemini, and more.'}
-                  </p>
-                  {!searchQuery && (
-                    <button className={styles.emptyAction} onClick={() => setShowImportModal(true)}>
-                      <ImportIcon />
-                      <span>Import conversations</span>
-                    </button>
-                  )}
+                  <button
+                    className={styles.selectionClose}
+                    onClick={exitSelectMode}
+                    aria-label="Exit selection"
+                  >
+                    <CloseIcon />
+                  </button>
                 </div>
               )}
-            </div>
-          </>
-        )}
+
+              <div className={styles.list} ref={listRef}>
+                {activeTab === 'trash' ? (
+                  <TrashList
+                    conversations={trashedConversations}
+                    total={trashedTotal}
+                    loading={trashLoading}
+                    error={trashError}
+                    restoringId={restoringId}
+                    onRestore={handleRestoreConversation}
+                    onPurgeRequest={setPurgeTargetIds}
+                    onRetry={() => loadTrash(0)}
+                    onLoadMore={handleLoadMoreTrash}
+                    selectMode={selectMode}
+                    selectedIds={selectedIds}
+                    onToggleSelect={toggleSelect}
+                  />
+                ) : activeTab === 'shared' ? (
+                  <SharedChatsTabPanel
+                    shares={sharedChats.shares}
+                    loading={sharedChats.loading}
+                    error={sharedChats.error}
+                    searchQuery={searchQuery}
+                    busyConversationId={sharedBusyConversationId}
+                    onRetry={sharedChats.refetch}
+                    onRowClick={handleSharedRowClick}
+                    onCopy={handleSharedCopy}
+                    onUnshare={setSharedUnshareTarget}
+                  />
+                ) : conversationsLoading && conversations.length === 0 ? (
+                  <div className={styles.skeleton}>
+                    {[1, 2, 3, 4, 5, 6].map((i) => (
+                      <div key={i} className={styles.skeletonItem}>
+                        <div className={styles.skeletonContent}>
+                          <div
+                            className={styles.skeletonTitle}
+                            style={{ width: `${45 + ((i * 11) % 30)}%` }}
+                          />
+                          <div
+                            className={styles.skeletonSub}
+                            style={{ width: `${25 + ((i * 7) % 20)}%` }}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : groupedFilteredConversations.length > 0 ? (
+                  <>
+                    {groupedFilteredConversations.map((group) => (
+                      <div key={group.label} className={styles.timeGroup}>
+                        <div className={styles.timeGroupLabel}>{group.label}</div>
+                        {group.items.map((chat) => renderConversationItem(chat))}
+                      </div>
+                    ))}
+                    {conversations.length < conversationsTotal && (
+                      <div className={styles.loadMoreWrapper}>
+                        {conversationsLoading ? (
+                          <div className={styles.loadingMore}>
+                            <div className={styles.loadingDots}>
+                              <span />
+                              <span />
+                              <span />
+                            </div>
+                          </div>
+                        ) : (
+                          <button className={styles.loadMoreBtn} onClick={handleLoadMore}>
+                            Load more conversations
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div className={styles.empty}>
+                    <div className={styles.emptyIcon}>
+                      <ChatIcon />
+                    </div>
+                    <h3 className={styles.emptyTitle}>
+                      {activeTab === 'starred'
+                        ? 'No starred conversations'
+                        : activeTab === 'archived'
+                        ? 'No archived conversations'
+                        : searchQuery
+                        ? 'No results found'
+                        : 'No conversations yet'}
+                    </h3>
+                    <p className={styles.emptyDesc}>
+                      {activeTab === 'starred'
+                        ? 'Star your important conversations to find them quickly.'
+                        : activeTab === 'archived'
+                        ? 'Archived conversations will appear here.'
+                        : searchQuery
+                        ? 'Try a different search term.'
+                        : 'Start a new conversation.'}
+                    </p>
+                    {!searchQuery && activeTab === 'all' && (
+                      <button
+                        className={styles.emptyAction}
+                        onClick={() => {
+                          dispatch(createNewChat());
+                          navigate('/');
+                        }}
+                      >
+                        <PlusIcon />
+                        <span>New conversation</span>
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {/* Imported Chats Section */}
+          {isImportedSection && (
+            <>
+              {/* Provider filter tabs */}
+              {importedProviders.length > 0 && (
+                <div className={styles.toolbar}>
+                  <div className={styles.providerFilters}>
+                    <button
+                      className={`${styles.tab} ${
+                        activeImportProvider === 'all' ? styles.tabActive : ''
+                      }`}
+                      onClick={() => {
+                        setActiveImportProvider('all');
+                        exitSelectMode();
+                      }}
+                    >
+                      All
+                      <span className={styles.tabBadge}>{importedConversations.length}</span>
+                    </button>
+                    {importedProviders.map((p) => {
+                      const count = importedConversations.filter((c) => c.provider === p.id).length;
+                      const ProviderLogo = getProviderLogo(p.id);
+                      return (
+                        <button
+                          key={p.id}
+                          className={`${styles.tab} ${
+                            activeImportProvider === p.id ? styles.tabActive : ''
+                          }`}
+                          onClick={() => {
+                            setActiveImportProvider(p.id);
+                            exitSelectMode();
+                          }}
+                        >
+                          <span className={styles.tabProviderIcon}>
+                            <ProviderLogo size={14} />
+                          </span>
+                          {p.name}
+                          <span className={styles.tabBadge}>{count}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                  <button
+                    className={`${styles.selectToggle} ${
+                      selectMode ? styles.selectToggleActive : ''
+                    }`}
+                    onClick={() => {
+                      if (selectMode) exitSelectMode();
+                      else setSelectMode(true);
+                    }}
+                  >
+                    {selectMode ? 'Cancel' : 'Select'}
+                  </button>
+                </div>
+              )}
+
+              {/* Compact context bar */}
+              {importedProviders.length > 0 && (
+                <div className={styles.contextBar}>
+                  <span className={styles.contextBarLabel}>
+                    <svg
+                      width="13"
+                      height="13"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <circle cx="12" cy="12" r="3" />
+                      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                    </svg>
+                    <span>Context</span>
+                  </span>
+                  <div className={styles.contextBarDivider} />
+                  <div className={styles.contextBarChips}>
+                    {(activeImportProvider === 'all'
+                      ? importedProviders
+                      : importedProviders.filter((p) => p.id === activeImportProvider)
+                    ).map((p) => {
+                      const ProviderLogo = getProviderLogo(p.id);
+                      const isEnabled = !!contextProviders[p.id];
+                      return (
+                        <button
+                          key={p.id}
+                          className={`${styles.contextChip} ${
+                            isEnabled ? styles.contextChipActive : ''
+                          }`}
+                          onClick={() => toggleProviderContext(p.id)}
+                          title={
+                            isEnabled ? `Disable ${p.name} context` : `Enable ${p.name} context`
+                          }
+                        >
+                          <ProviderLogo size={13} />
+                          <span>{p.name}</span>
+                          <span className={styles.contextChipDot} />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Selection action bar for imported */}
+              {selectMode && (
+                <div className={styles.selectionBar}>
+                  <div className={styles.selectionLeft}>
+                    <span className={styles.selectionCount}>{selectedIds.size} selected</span>
+                    {selectedIds.size < filteredImportedConversations.length && (
+                      <button className={styles.selectAllBtn} onClick={selectAll}>
+                        Select all
+                      </button>
+                    )}
+                  </div>
+                  <div className={styles.selectionActions}>
+                    <button
+                      className={styles.selectionAction}
+                      onClick={() => hasSelection && toggleImportedStar(selectedIds)}
+                      disabled={!hasSelection}
+                      title="Star"
+                    >
+                      <StarIcon />
+                    </button>
+                    <button
+                      className={styles.selectionAction}
+                      onClick={() => hasSelection && toggleImportedArchive(selectedIds)}
+                      disabled={!hasSelection}
+                      title={activeTab === 'archived' ? 'Move to Conversations' : 'Archive'}
+                    >
+                      <ArchiveIcon />
+                    </button>
+                    <button
+                      className={`${styles.selectionAction} ${styles.selectionActionDanger}`}
+                      onClick={() => hasSelection && handleBulkDelete()}
+                      disabled={!hasSelection}
+                      title="Delete"
+                    >
+                      <TrashIcon />
+                    </button>
+                  </div>
+                  <button
+                    className={styles.selectionClose}
+                    onClick={exitSelectMode}
+                    aria-label="Exit selection"
+                  >
+                    <CloseIcon />
+                  </button>
+                </div>
+              )}
+
+              {/* Imported conversations list */}
+              <div className={styles.list}>
+                {groupedImportedConversations.length > 0 ? (
+                  groupedImportedConversations.map((group) => (
+                    <div key={group.label} className={styles.timeGroup}>
+                      <div className={styles.timeGroupLabel}>{group.label}</div>
+                      {group.items.map((chat) =>
+                        renderConversationItem(chat, { isImported: true })
+                      )}
+                    </div>
+                  ))
+                ) : (
+                  <div className={styles.empty}>
+                    <div className={styles.emptyIcon}>
+                      <ImportIcon />
+                    </div>
+                    <h3 className={styles.emptyTitle}>
+                      {searchQuery ? 'No results found' : 'No imported conversations yet'}
+                    </h3>
+                    <p className={styles.emptyDesc}>
+                      {searchQuery
+                        ? 'Try a different search term.'
+                        : 'Bring your conversations from ChatGPT, Claude, Gemini, and more.'}
+                    </p>
+                    {!searchQuery && (
+                      <button
+                        className={styles.emptyAction}
+                        onClick={() => setShowImportModal(true)}
+                      >
+                        <ImportIcon />
+                        <span>Import conversations</span>
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </RequireAuth>
       </div>
 
       {/* Floating action bar for selections */}

--- a/src/components/ProjectsView/ProjectsView.jsx
+++ b/src/components/ProjectsView/ProjectsView.jsx
@@ -13,7 +13,7 @@ import {
 } from '../../store/slices/projectsSlice';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import { showUpgradeModal } from '../../store/slices/subscriptionSlice';
-import { GuestGate } from '../GuestGate';
+import RequireAuth from '../RequireAuth';
 import { getProjectLimit, getNextTier } from '../../config/subscription';
 import { selectCurrentTier } from '../../store/slices/subscriptionSlice';
 import {
@@ -1106,27 +1106,6 @@ export default function ProjectsView() {
     );
   }
 
-  if (!isAuthenticated) {
-    return (
-      <div ref={pageRef} className={styles.page}>
-        <div className={styles.inner}>
-          <div className={styles.header}>
-            <div className={styles.headerLeft}>
-              <h1 className={styles.title}>Projects</h1>
-              <p className={styles.subtitle}>Organise your conversations with custom context</p>
-            </div>
-          </div>
-          <GuestGate
-            icon={<ProjectsIcon />}
-            title="Organise with Projects"
-            description="Sign in to create projects, group conversations, and add custom context to your chats."
-            actionLabel="Sign in to use Projects"
-          />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div ref={pageRef} className={styles.page}>
       <div className={styles.inner}>
@@ -1136,232 +1115,241 @@ export default function ProjectsView() {
             <h1 className={styles.title}>Projects</h1>
             <p className={styles.subtitle}>Organise your conversations with custom context</p>
           </div>
-          <button
-            className={styles.newProjectBtn}
-            onClick={() => {
-              setEditingProject(null);
-              setShowModal(true);
-            }}
-          >
-            <PlusIcon />
-            <span>New project</span>
-          </button>
-        </div>
-
-        {/* Search & Sort */}
-        <div className={styles.searchFilterBar}>
-          <div className={styles.searchWrapper}>
-            <div className={styles.searchIcon}>
-              <SearchIcon />
-            </div>
-            <input
-              className={styles.searchInput}
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search projects..."
-            />
-            {search && (
-              <button className={styles.searchClear} onClick={() => setSearch('')}>
-                <CloseIcon />
-              </button>
-            )}
-            {!search && (
-              <div className={styles.searchWebIcon} title="Web search">
-                <GlobeIcon />
-              </div>
-            )}
-          </div>
-
-          <div className={styles.sortWrapper} ref={sortRef}>
-            <button className={styles.sortBtn} onClick={() => setSortOpen(!sortOpen)}>
-              <span>Sort by</span>
-              <ChevronDownIcon />
-            </button>
-            {sortOpen && (
-              <div className={styles.sortDropdown}>
-                {SORT_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.id}
-                    className={`${styles.sortOption} ${
-                      sortBy === opt.id ? styles.sortOptionActive : ''
-                    }`}
-                    onClick={() => {
-                      setSortBy(opt.id);
-                      setSortOpen(false);
-                    }}
-                  >
-                    <span className={styles.sortCheck}>{sortBy === opt.id && <CheckIcon />}</span>
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Filter Tabs */}
-        <div className={styles.filterTabs}>
-          {FILTER_TABS.map((tab) => (
+          {isAuthenticated && (
             <button
-              key={tab.id}
-              className={`${styles.filterTab} ${filter === tab.id ? styles.filterTabActive : ''}`}
-              onClick={() => setFilter(tab.id)}
+              className={styles.newProjectBtn}
+              onClick={() => {
+                setEditingProject(null);
+                setShowModal(true);
+              }}
             >
-              <span>{tab.label}</span>
-              <span className={styles.filterTabBadge}>{counts[tab.id] || 0}</span>
+              <PlusIcon />
+              <span>New project</span>
             </button>
-          ))}
+          )}
         </div>
 
-        {/* Content */}
-        {loading && projects.length === 0 ? (
-          <div className={styles.skeleton}>
-            {[1, 2, 3, 4].map((i) => (
-              <div key={i} className={styles.skeletonCard}>
-                <div className={styles.skeletonIcon} />
-                <div className={styles.skeletonTitle} />
-                <div className={styles.skeletonDesc} />
-                <div className={styles.skeletonFooter} />
+        <RequireAuth
+          icon={<ProjectsIcon />}
+          title="Organise with Projects"
+          description="Sign in to create projects, group conversations, and add custom context to your chats."
+          actionLabel="Sign in to use Projects"
+        >
+          {/* Search & Sort */}
+          <div className={styles.searchFilterBar}>
+            <div className={styles.searchWrapper}>
+              <div className={styles.searchIcon}>
+                <SearchIcon />
               </div>
-            ))}
-          </div>
-        ) : filteredProjects.length > 0 ? (
-          <div className={styles.grid}>
-            {filteredProjects.map((project) => (
-              <div
-                key={project.id}
-                className={`${styles.card} ${project.is_starred ? styles.cardStarred : ''} ${
-                  menuOpenId === project.id ? styles.cardMenuOpen : ''
-                }`}
-                onClick={() => handleCardClick(project)}
-              >
-                <div className={styles.cardHeader}>
-                  <div className={styles.cardIcon}>
-                    <ProjectsIcon />
-                  </div>
-                  <button
-                    ref={menuOpenId === project.id ? menuRef : null}
-                    className={`${styles.cardMenu} ${
-                      menuOpenId === project.id ? styles.cardMenuVisible : ''
-                    }`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setMenuOpenId((prev) => (prev === project.id ? null : project.id));
-                    }}
-                  >
-                    <MoreVerticalIcon />
-                  </button>
+              <input
+                className={styles.searchInput}
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search projects..."
+              />
+              {search && (
+                <button className={styles.searchClear} onClick={() => setSearch('')}>
+                  <CloseIcon />
+                </button>
+              )}
+              {!search && (
+                <div className={styles.searchWebIcon} title="Web search">
+                  <GlobeIcon />
                 </div>
-
-                <div className={styles.cardName}>{project.name}</div>
-                <div className={styles.cardDesc}>{project.description || 'No description'}</div>
-
-                <div className={styles.cardFooter}>
-                  <span className={styles.cardTime}>
-                    Updated {formatRelativeTime(project.updated_at || project.created_at)}
-                  </span>
-                  <div className={styles.cardBadges}>
-                    {project.is_starred && (
-                      <span className={styles.cardStarBadge}>
-                        <StarIcon filled />
-                      </span>
-                    )}
-                    {project.instructions && (
-                      <span className={styles.cardInstructionsBadge}>
-                        <FileTextIcon />
-                        <span>Instructions</span>
-                      </span>
-                    )}
-                  </div>
-                </div>
-
-                {/* Card dropdown */}
-                {menuOpenId === project.id && (
-                  <div className={styles.cardDropdown} ref={dropdownRef}>
-                    <button
-                      className={styles.cardDropdownItem}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleToggleStar(project);
-                        setMenuOpenId(null);
-                      }}
-                    >
-                      <StarIcon filled={project.is_starred} />
-                      <span>{project.is_starred ? 'Unstar' : 'Star'}</span>
-                    </button>
-                    <button
-                      className={styles.cardDropdownItem}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        openEditModal(project);
-                      }}
-                    >
-                      <EditIcon />
-                      <span>Edit details</span>
-                    </button>
-                    <button
-                      className={styles.cardDropdownItem}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleToggleArchive(project);
-                      }}
-                    >
-                      <ArchiveIcon />
-                      <span>{project.is_archived ? 'Unarchive' : 'Archive'}</span>
-                    </button>
-                    <div className={styles.cardDropdownDivider} />
-                    <button
-                      className={`${styles.cardDropdownItem} ${styles.cardDropdownItemDanger}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        openDeleteConfirm(project);
-                      }}
-                    >
-                      <TrashIcon />
-                      <span>Delete</span>
-                    </button>
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className={styles.empty}>
-            <div className={styles.emptyVisual}>
-              <ProjectsIcon />
+              )}
             </div>
-            <h3 className={styles.emptyTitle}>
-              {search
-                ? 'No projects found'
-                : filter === 'starred'
-                ? 'No starred projects'
-                : filter === 'archived'
-                ? 'No archived projects'
-                : 'No projects yet'}
-            </h3>
-            <p className={styles.emptyDesc}>
-              {search
-                ? `No projects match "${search}". Try a different search term.`
-                : filter === 'starred'
-                ? 'Star your important projects to find them quickly here.'
-                : filter === 'archived'
-                ? 'Archived projects will appear here.'
-                : 'Create your first project to organise conversations with custom instructions and context.'}
-            </p>
-            {!search && filter === 'all' && (
-              <button
-                className={styles.emptyAction}
-                onClick={() => {
-                  setEditingProject(null);
-                  setShowModal(true);
-                }}
-              >
-                <PlusIcon />
-                <span>Create a project</span>
+
+            <div className={styles.sortWrapper} ref={sortRef}>
+              <button className={styles.sortBtn} onClick={() => setSortOpen(!sortOpen)}>
+                <span>Sort by</span>
+                <ChevronDownIcon />
               </button>
-            )}
+              {sortOpen && (
+                <div className={styles.sortDropdown}>
+                  {SORT_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.id}
+                      className={`${styles.sortOption} ${
+                        sortBy === opt.id ? styles.sortOptionActive : ''
+                      }`}
+                      onClick={() => {
+                        setSortBy(opt.id);
+                        setSortOpen(false);
+                      }}
+                    >
+                      <span className={styles.sortCheck}>{sortBy === opt.id && <CheckIcon />}</span>
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
-        )}
+
+          {/* Filter Tabs */}
+          <div className={styles.filterTabs}>
+            {FILTER_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                className={`${styles.filterTab} ${filter === tab.id ? styles.filterTabActive : ''}`}
+                onClick={() => setFilter(tab.id)}
+              >
+                <span>{tab.label}</span>
+                <span className={styles.filterTabBadge}>{counts[tab.id] || 0}</span>
+              </button>
+            ))}
+          </div>
+
+          {/* Content */}
+          {loading && projects.length === 0 ? (
+            <div className={styles.skeleton}>
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} className={styles.skeletonCard}>
+                  <div className={styles.skeletonIcon} />
+                  <div className={styles.skeletonTitle} />
+                  <div className={styles.skeletonDesc} />
+                  <div className={styles.skeletonFooter} />
+                </div>
+              ))}
+            </div>
+          ) : filteredProjects.length > 0 ? (
+            <div className={styles.grid}>
+              {filteredProjects.map((project) => (
+                <div
+                  key={project.id}
+                  className={`${styles.card} ${project.is_starred ? styles.cardStarred : ''} ${
+                    menuOpenId === project.id ? styles.cardMenuOpen : ''
+                  }`}
+                  onClick={() => handleCardClick(project)}
+                >
+                  <div className={styles.cardHeader}>
+                    <div className={styles.cardIcon}>
+                      <ProjectsIcon />
+                    </div>
+                    <button
+                      ref={menuOpenId === project.id ? menuRef : null}
+                      className={`${styles.cardMenu} ${
+                        menuOpenId === project.id ? styles.cardMenuVisible : ''
+                      }`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setMenuOpenId((prev) => (prev === project.id ? null : project.id));
+                      }}
+                    >
+                      <MoreVerticalIcon />
+                    </button>
+                  </div>
+
+                  <div className={styles.cardName}>{project.name}</div>
+                  <div className={styles.cardDesc}>{project.description || 'No description'}</div>
+
+                  <div className={styles.cardFooter}>
+                    <span className={styles.cardTime}>
+                      Updated {formatRelativeTime(project.updated_at || project.created_at)}
+                    </span>
+                    <div className={styles.cardBadges}>
+                      {project.is_starred && (
+                        <span className={styles.cardStarBadge}>
+                          <StarIcon filled />
+                        </span>
+                      )}
+                      {project.instructions && (
+                        <span className={styles.cardInstructionsBadge}>
+                          <FileTextIcon />
+                          <span>Instructions</span>
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Card dropdown */}
+                  {menuOpenId === project.id && (
+                    <div className={styles.cardDropdown} ref={dropdownRef}>
+                      <button
+                        className={styles.cardDropdownItem}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleToggleStar(project);
+                          setMenuOpenId(null);
+                        }}
+                      >
+                        <StarIcon filled={project.is_starred} />
+                        <span>{project.is_starred ? 'Unstar' : 'Star'}</span>
+                      </button>
+                      <button
+                        className={styles.cardDropdownItem}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openEditModal(project);
+                        }}
+                      >
+                        <EditIcon />
+                        <span>Edit details</span>
+                      </button>
+                      <button
+                        className={styles.cardDropdownItem}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleToggleArchive(project);
+                        }}
+                      >
+                        <ArchiveIcon />
+                        <span>{project.is_archived ? 'Unarchive' : 'Archive'}</span>
+                      </button>
+                      <div className={styles.cardDropdownDivider} />
+                      <button
+                        className={`${styles.cardDropdownItem} ${styles.cardDropdownItemDanger}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openDeleteConfirm(project);
+                        }}
+                      >
+                        <TrashIcon />
+                        <span>Delete</span>
+                      </button>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className={styles.empty}>
+              <div className={styles.emptyVisual}>
+                <ProjectsIcon />
+              </div>
+              <h3 className={styles.emptyTitle}>
+                {search
+                  ? 'No projects found'
+                  : filter === 'starred'
+                  ? 'No starred projects'
+                  : filter === 'archived'
+                  ? 'No archived projects'
+                  : 'No projects yet'}
+              </h3>
+              <p className={styles.emptyDesc}>
+                {search
+                  ? `No projects match "${search}". Try a different search term.`
+                  : filter === 'starred'
+                  ? 'Star your important projects to find them quickly here.'
+                  : filter === 'archived'
+                  ? 'Archived projects will appear here.'
+                  : 'Create your first project to organise conversations with custom instructions and context.'}
+              </p>
+              {!search && filter === 'all' && (
+                <button
+                  className={styles.emptyAction}
+                  onClick={() => {
+                    setEditingProject(null);
+                    setShowModal(true);
+                  }}
+                >
+                  <PlusIcon />
+                  <span>Create a project</span>
+                </button>
+              )}
+            </div>
+          )}
+        </RequireAuth>
       </div>
 
       {/* Create/Edit Modal */}

--- a/src/components/RequireAuth/RequireAuth.jsx
+++ b/src/components/RequireAuth/RequireAuth.jsx
@@ -1,0 +1,21 @@
+import { useSelector } from 'react-redux';
+import { selectIsAuthenticated } from '../../store/slices/authSlice';
+import GuestGate from '../GuestGate/GuestGate';
+
+/**
+ * Inline auth gate. Renders `children` when the user is signed in,
+ * otherwise renders a `GuestGate` prompt with the supplied copy.
+ *
+ * Designed to wrap the data-driven content of a view that still wants
+ * to render its own chrome (page background, header, hero) regardless
+ * of auth state. Header actions that only make sense for signed-in
+ * users should be gated by the view itself; this wrapper only owns the
+ * primary content swap.
+ */
+export default function RequireAuth({ children, icon, title, description, actionLabel }) {
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  if (isAuthenticated) return children;
+  return (
+    <GuestGate icon={icon} title={title} description={description} actionLabel={actionLabel} />
+  );
+}

--- a/src/components/RequireAuth/index.js
+++ b/src/components/RequireAuth/index.js
@@ -1,0 +1,1 @@
+export { default } from './RequireAuth';

--- a/src/components/SettingsView/SettingsView.jsx
+++ b/src/components/SettingsView/SettingsView.jsx
@@ -40,7 +40,7 @@ import useSharedChats from '../../hooks/useSharedChats';
 import { useToast } from '../Toast/Toast';
 import { logger } from '../../lib/logger';
 import ConfirmPackModal from '../ConfirmPackModal/ConfirmPackModal';
-import { GuestGate } from '../GuestGate';
+import RequireAuth from '../RequireAuth';
 import SubscriptionSummary from '../SubscriptionView/SubscriptionSummary';
 import {
   ChevronLeftIcon,
@@ -372,32 +372,7 @@ export default function SettingsView() {
     }
   };
 
-  if (!isAuthenticated) {
-    return (
-      <div ref={pageRef} className={styles.container}>
-        <div className={styles.inner}>
-          <div className={styles.header}>
-            <button className={styles.backBtn} onClick={handleBack}>
-              <ChevronLeftIcon />
-              <span>Back</span>
-            </button>
-            <div className={styles.headerTitle}>
-              <SettingsIcon />
-              <h1>Settings</h1>
-            </div>
-          </div>
-          <GuestGate
-            icon={<SettingsIcon />}
-            title="Your settings, your way"
-            description="Sign in to personalise your experience, manage your profile, and configure preferences."
-            actionLabel="Sign in to access Settings"
-          />
-        </div>
-      </div>
-    );
-  }
-
-  if (loading) {
+  if (isAuthenticated && loading) {
     return (
       <div ref={pageRef} className={styles.container}>
         <div className={styles.loadingState}>
@@ -422,1049 +397,1071 @@ export default function SettingsView() {
               <SettingsIcon />
               <h1>Settings</h1>
             </div>
-            <button
-              className={`${styles.saveBtn} ${saved ? styles.saveBtnSaved : ''}`}
-              onClick={handleSave}
-              disabled={saving}
-            >
-              {saved ? 'Saved!' : saving ? 'Saving...' : 'Save changes'}
-            </button>
+            {isAuthenticated && (
+              <button
+                className={`${styles.saveBtn} ${saved ? styles.saveBtnSaved : ''}`}
+                onClick={handleSave}
+                disabled={saving}
+              >
+                {saved ? 'Saved!' : saving ? 'Saving...' : 'Save changes'}
+              </button>
+            )}
           </div>
 
-          <div className={styles.layout}>
-            {/* Sidebar navigation */}
-            <nav className={styles.nav}>
-              {SECTIONS.map((section) => (
-                <button
-                  key={section.id}
-                  className={`${styles.navItem} ${
-                    activeSection === section.id ? styles.navItemActive : ''
-                  }`}
-                  onClick={() => navigate(`/settings/${section.id}`)}
-                >
-                  {section.label}
-                </button>
-              ))}
-            </nav>
+          <RequireAuth
+            icon={<SettingsIcon />}
+            title="Your settings, your way"
+            description="Sign in to personalise your experience, manage your profile, and configure preferences."
+            actionLabel="Sign in to access Settings"
+          >
+            <div className={styles.layout}>
+              {/* Sidebar navigation */}
+              <nav className={styles.nav}>
+                {SECTIONS.map((section) => (
+                  <button
+                    key={section.id}
+                    className={`${styles.navItem} ${
+                      activeSection === section.id ? styles.navItemActive : ''
+                    }`}
+                    onClick={() => navigate(`/settings/${section.id}`)}
+                  >
+                    {section.label}
+                  </button>
+                ))}
+              </nav>
 
-            {/* Content area */}
-            <div className={styles.content}>
-              {/* ═══ PROFILE ═══ */}
-              {activeSection === 'profile' && (
-                <section className={styles.section}>
-                  <div className={styles.sectionHeader}>
-                    <h2 className={styles.sectionTitle}>Profile</h2>
-                    <p className={styles.sectionDesc}>
-                      Manage your profile information and how you appear in the app.
-                    </p>
-                  </div>
+              {/* Content area */}
+              <div className={styles.content}>
+                {/* ═══ PROFILE ═══ */}
+                {activeSection === 'profile' && (
+                  <section className={styles.section}>
+                    <div className={styles.sectionHeader}>
+                      <h2 className={styles.sectionTitle}>Profile</h2>
+                      <p className={styles.sectionDesc}>
+                        Manage your profile information and how you appear in the app.
+                      </p>
+                    </div>
 
-                  {(() => {
-                    const resolvedAvatar = settings.avatarUrl || authUser?.avatarUrl;
-                    const resolvedName =
-                      settings.displayName && settings.displayName !== 'User'
-                        ? settings.displayName
-                        : authUser?.fullName || settings.displayName || 'User';
-                    return (
-                      <div className={styles.avatarRow}>
-                        <div
-                          className={`${styles.avatarLarge} ${
-                            avatarUploading ? styles.avatarUploading : ''
-                          }`}
-                        >
-                          {resolvedAvatar ? (
-                            <img
-                              src={resolvedAvatar}
-                              alt="Avatar"
-                              referrerPolicy="no-referrer"
-                              crossOrigin="anonymous"
-                              className={styles.avatarImage}
-                              onError={(e) => {
-                                e.target.style.display = 'none';
-                                e.target.nextSibling.style.display = '';
-                              }}
-                            />
-                          ) : null}
-                          <span style={{ display: resolvedAvatar ? 'none' : '' }}>
-                            <UserIcon />
-                          </span>
-                        </div>
-                        <div className={styles.avatarInfo}>
-                          <span className={styles.avatarName}>{resolvedName}</span>
-                          {authUser?.email && (
-                            <span className={styles.avatarPlan}>{authUser.email}</span>
-                          )}
-                          <button
-                            className={styles.avatarEditBtn}
-                            onClick={() => avatarInputRef.current?.click()}
-                            disabled={avatarUploading}
+                    {(() => {
+                      const resolvedAvatar = settings.avatarUrl || authUser?.avatarUrl;
+                      const resolvedName =
+                        settings.displayName && settings.displayName !== 'User'
+                          ? settings.displayName
+                          : authUser?.fullName || settings.displayName || 'User';
+                      return (
+                        <div className={styles.avatarRow}>
+                          <div
+                            className={`${styles.avatarLarge} ${
+                              avatarUploading ? styles.avatarUploading : ''
+                            }`}
                           >
-                            <EditIcon />
-                            <span>{avatarUploading ? 'Uploading...' : 'Change avatar'}</span>
-                          </button>
-                          <input
-                            ref={avatarInputRef}
-                            type="file"
-                            accept="image/png,image/jpeg,image/webp"
-                            style={{ display: 'none' }}
-                            onChange={handleAvatarChange}
-                          />
-                        </div>
-                      </div>
-                    );
-                  })()}
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Full name</label>
-                    <input
-                      className={styles.fieldInput}
-                      value={settings.fullName}
-                      onChange={(e) => updateSetting('fullName', e.target.value)}
-                      placeholder="Your full name"
-                    />
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Display name</label>
-                    <input
-                      className={styles.fieldInput}
-                      value={settings.displayName}
-                      onChange={(e) => updateSetting('displayName', e.target.value)}
-                      placeholder="What should Araviel call you?"
-                    />
-                    <span className={styles.fieldHint}>
-                      This is the name Araviel uses to address you.
-                    </span>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Email</label>
-                    <input
-                      className={styles.fieldInputReadonly}
-                      value={authUser?.email || ''}
-                      readOnly
-                    />
-                    <span className={styles.fieldHint}>
-                      Managed by your authentication provider.
-                    </span>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Bio</label>
-                    <textarea
-                      className={styles.fieldTextarea}
-                      value={settings.bio}
-                      onChange={(e) => updateSetting('bio', e.target.value)}
-                      placeholder="Tell us a little about yourself..."
-                      rows={3}
-                    />
-                    <span className={styles.fieldHint}>
-                      This helps personalize your experience.
-                    </span>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Occupation</label>
-                    <input
-                      className={styles.fieldInput}
-                      value={settings.occupation}
-                      onChange={(e) => updateSetting('occupation', e.target.value)}
-                      placeholder="e.g. Software Engineer, Designer, Student..."
-                    />
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Areas of expertise</label>
-                    <input
-                      className={styles.fieldInput}
-                      value={settings.expertise}
-                      onChange={(e) => updateSetting('expertise', e.target.value)}
-                      placeholder="e.g. Machine learning, Web development, Data analysis..."
-                    />
-                    <span className={styles.fieldHint}>
-                      Araviel will tailor responses to your expertise level.
-                    </span>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Phone</label>
-                    <input
-                      className={styles.fieldInput}
-                      type="tel"
-                      value={settings.phone}
-                      onChange={(e) => updateSetting('phone', e.target.value)}
-                      placeholder="e.g. +1 (555) 123-4567"
-                    />
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Website</label>
-                    <input
-                      className={styles.fieldInput}
-                      type="url"
-                      value={settings.website}
-                      onChange={(e) => updateSetting('website', e.target.value)}
-                      placeholder="e.g. https://yoursite.com"
-                    />
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Location</label>
-                    <input
-                      className={styles.fieldInput}
-                      value={settings.location}
-                      onChange={(e) => updateSetting('location', e.target.value)}
-                      placeholder="e.g. San Francisco, CA"
-                    />
-                  </div>
-                </section>
-              )}
-
-              {/* ═══ APPEARANCE ═══ */}
-              {activeSection === 'appearance' && (
-                <section className={styles.section}>
-                  <div className={styles.sectionHeader}>
-                    <h2 className={styles.sectionTitle}>Appearance</h2>
-                    <p className={styles.sectionDesc}>Customize how Araviel looks and feels.</p>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Theme</label>
-                    <div className={styles.themeCards}>
-                      <button
-                        className={`${styles.themeCard} ${
-                          themeMode === 'light' ? styles.themeCardActive : ''
-                        }`}
-                        onClick={() => dispatch(setTheme('light'))}
-                      >
-                        <div className={styles.themeCardPreview} data-theme-preview="light">
-                          <div className={styles.themePreviewBar} />
-                          <div className={styles.themePreviewContent}>
-                            <div className={styles.themePreviewLine} />
-                            <div className={styles.themePreviewLineShort} />
-                          </div>
-                        </div>
-                        <div className={styles.themeCardInfo}>
-                          <SunIcon />
-                          <span>Light</span>
-                        </div>
-                      </button>
-                      <button
-                        className={`${styles.themeCard} ${
-                          themeMode === 'dark' ? styles.themeCardActive : ''
-                        }`}
-                        onClick={() => dispatch(setTheme('dark'))}
-                      >
-                        <div className={`${styles.themeCardPreview} ${styles.themePreviewDark}`}>
-                          <div className={styles.themePreviewBar} />
-                          <div className={styles.themePreviewContent}>
-                            <div className={styles.themePreviewLine} />
-                            <div className={styles.themePreviewLineShort} />
-                          </div>
-                        </div>
-                        <div className={styles.themeCardInfo}>
-                          <MoonIcon />
-                          <span>Dark</span>
-                        </div>
-                      </button>
-                      <button
-                        className={`${styles.themeCard} ${
-                          themeMode === 'system' ? styles.themeCardActive : ''
-                        }`}
-                        onClick={() => dispatch(setTheme('system'))}
-                      >
-                        <div className={`${styles.themeCardPreview} ${styles.themePreviewSystem}`}>
-                          <div className={styles.themePreviewBar} />
-                          <div className={styles.themePreviewContent}>
-                            <div className={styles.themePreviewLine} />
-                            <div className={styles.themePreviewLineShort} />
-                          </div>
-                        </div>
-                        <div className={styles.themeCardInfo}>
-                          <MonitorIcon />
-                          <span>System</span>
-                        </div>
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Answer font style</label>
-                    <p className={styles.fieldLabelDesc}>Choose the font style for AI responses.</p>
-                    <div className={styles.segmentedControl}>
-                      {ANSWER_FONTS.map((font) => (
-                        <button
-                          key={font.id}
-                          className={`${styles.segmentedBtn} ${
-                            settings.answerFont === font.id ? styles.segmentedBtnActive : ''
-                          }`}
-                          onClick={() => {
-                            updateSetting('answerFont', font.id);
-                            // Apply immediately so the user sees the change
-                            // without having to hit "Save changes".
-                            const el = document.documentElement;
-                            if (font.id === 'system') {
-                              el.removeAttribute('data-answer-font');
-                            } else {
-                              el.setAttribute('data-answer-font', font.id);
-                            }
-                          }}
-                          style={{ fontFamily: font.sample }}
-                        >
-                          {font.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                </section>
-              )}
-
-              {/* ═══ PERSONALIZATION ═══ */}
-              {activeSection === 'personalization' && (
-                <section className={styles.section}>
-                  <div className={styles.sectionHeader}>
-                    <h2 className={styles.sectionTitle}>Personalization</h2>
-                    <p className={styles.sectionDesc}>
-                      Help Araviel understand you better for more relevant responses.
-                    </p>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Preferred response language</label>
-                    <p className={styles.fieldLabelDesc}>
-                      The language Araviel will use when responding to you.
-                    </p>
-                    <select
-                      className={styles.fieldSelect}
-                      value={settings.preferredLanguage}
-                      onChange={(e) => updateSetting('preferredLanguage', e.target.value)}
-                    >
-                      {LANGUAGES.map((lang) => (
-                        <option key={lang} value={lang}>
-                          {lang}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Response tone</label>
-                    <p className={styles.fieldLabelDesc}>
-                      Choose how Araviel communicates with you.
-                    </p>
-                    <div className={styles.toneGrid}>
-                      {TONES.map((tone) => (
-                        <button
-                          key={tone.id}
-                          className={`${styles.toneCard} ${
-                            settings.responseTone === tone.id ? styles.toneCardActive : ''
-                          }`}
-                          onClick={() => {
-                            updateSetting('responseTone', tone.id);
-                            dispatch(setTone(tone.id));
-                          }}
-                        >
-                          <span className={styles.toneCardLabel}>{tone.label}</span>
-                          <span className={styles.toneCardDesc}>{tone.description}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>
-                      What personal preferences should Araviel consider in responses?
-                    </label>
-                    <p className={styles.fieldLabelDesc}>
-                      Your preferences will apply to all conversations.
-                    </p>
-                    <textarea
-                      className={styles.fieldTextarea}
-                      value={settings.customInstructions}
-                      onChange={(e) => {
-                        if (e.target.value.length <= 2000) {
-                          updateSetting('customInstructions', e.target.value);
-                        }
-                      }}
-                      placeholder="e.g. When writing code, be very concise. Follow good coding principles and practices. Always adhere to good programming principles, OOP, DRY, SOLID, etc when writing code. All code must be written at top quality, clean, easy to read and understand..."
-                      rows={6}
-                    />
-                    <div className={styles.textareaFooter}>
-                      <span className={styles.fieldHint}>
-                        {settings.customInstructions.length} / 2,000 characters
-                      </span>
-                    </div>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <div className={styles.toggleRow}>
-                      <div className={styles.toggleInfo}>
-                        <span className={styles.toggleLabel}>Send message with Enter</span>
-                        <span className={styles.toggleDesc}>
-                          Use Enter to send messages. When off, use {modKey}+Enter instead.
-                        </span>
-                      </div>
-                      <ToggleSwitch
-                        value={settings.sendWithEnter}
-                        onChange={(v) => updateSetting('sendWithEnter', v)}
-                      />
-                    </div>
-                  </div>
-                </section>
-              )}
-
-              {/* ═══ MODEL PREFERENCES ═══ */}
-              {activeSection === 'models' && (
-                <section className={styles.section}>
-                  <div className={styles.sectionHeader}>
-                    <h2 className={styles.sectionTitle}>Model preferences</h2>
-                    <p className={styles.sectionDesc}>
-                      Configure how AI models are selected and behave.
-                    </p>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Web search</label>
-                    <p className={styles.fieldLabelDesc}>
-                      Control when Araviel searches the web for current information.
-                    </p>
-                    <div className={styles.segmentedControl}>
-                      {[
-                        { id: 'auto', label: 'Auto' },
-                        { id: 'always', label: 'Always' },
-                        { id: 'never', label: 'Never' },
-                      ].map((opt) => (
-                        <button
-                          key={opt.id}
-                          className={`${styles.segmentedBtn} ${
-                            settings.webSearchDefault === opt.id ? styles.segmentedBtnActive : ''
-                          }`}
-                          onClick={() => {
-                            updateSetting('webSearchDefault', opt.id);
-                            const val =
-                              opt.id === 'always' ? true : opt.id === 'never' ? false : null;
-                            dispatch(setWebSearchEnabled(val));
-                          }}
-                        >
-                          {opt.label}
-                        </button>
-                      ))}
-                    </div>
-                    <span className={styles.fieldHint}>
-                      {settings.webSearchDefault === 'auto' &&
-                        'Araviel decides when web search is needed based on your query.'}
-                      {settings.webSearchDefault === 'always' &&
-                        'Every query will include web search results.'}
-                      {settings.webSearchDefault === 'never' &&
-                        'Web search is disabled. Responses use model knowledge only.'}
-                    </span>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Default image quality</label>
-                    <p className={styles.fieldLabelDesc}>
-                      Set the default quality for AI-generated images.
-                    </p>
-                    <div className={styles.segmentedControl}>
-                      {[
-                        { id: 'standard', label: 'Standard (1 credit)' },
-                        { id: 'hd', label: 'HD (2 credits)' },
-                        { id: 'ultra', label: 'Ultra (4 credits)' },
-                      ].map((q) => (
-                        <button
-                          key={q.id}
-                          className={`${styles.segmentedBtn} ${
-                            settings.imageQualityDefault === q.id ? styles.segmentedBtnActive : ''
-                          }`}
-                          onClick={() => {
-                            updateSetting('imageQualityDefault', q.id);
-                            dispatch(setImageQuality(q.id));
-                          }}
-                        >
-                          {q.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <div className={styles.toggleRow}>
-                      <div className={styles.toggleInfo}>
-                        <span className={styles.toggleLabel}>Enable reasoning / thinking</span>
-                        <span className={styles.toggleDesc}>
-                          Enable deep chain-of-thought reasoning when available.
-                        </span>
-                      </div>
-                      <ToggleSwitch
-                        value={settings.enableReasoning}
-                        onChange={(v) => {
-                          updateSetting('enableReasoning', v);
-                          dispatch(setExtendedThinking(v));
-                        }}
-                      />
-                    </div>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <div className={styles.toggleRow}>
-                      <div className={styles.toggleInfo}>
-                        <span className={styles.toggleLabel}>Follow-up suggestions</span>
-                        <span className={styles.toggleDesc}>
-                          Show suggested follow-up questions after each response.
-                        </span>
-                      </div>
-                      <ToggleSwitch
-                        value={settings.enableFollowUps}
-                        onChange={(v) => updateSetting('enableFollowUps', v)}
-                      />
-                    </div>
-                  </div>
-                </section>
-              )}
-
-              {/* ═══ SUBSCRIPTION ═══ */}
-              {activeSection === 'subscription' && (
-                <section className={styles.section}>
-                  <div className={styles.sectionHeader}>
-                    <h2 className={styles.sectionTitle}>Subscription</h2>
-                    <p className={styles.sectionDesc}>
-                      Manage your plan, monitor credit usage, and access billing.
-                    </p>
-                  </div>
-                  <SubscriptionSummary />
-                </section>
-              )}
-
-              {/* ═══ USAGE & CREDITS ═══ */}
-              {activeSection === 'usage' && (
-                <section className={styles.section}>
-                  <div className={styles.sectionHeader}>
-                    <h2 className={styles.sectionTitle}>Usage & credits</h2>
-                    <p className={styles.sectionDesc}>
-                      Monitor your credit balance and manage your plan.
-                    </p>
-                  </div>
-
-                  {/* ── Subscription management ── */}
-                  {(() => {
-                    const tierInfo = getTierById(currentTier);
-                    const tierName =
-                      tierInfo?.name ||
-                      currentTier?.charAt(0).toUpperCase() + currentTier?.slice(1) ||
-                      'Free';
-                    const tierId = currentTier || 'free';
-                    const badgeClass =
-                      tierId === 'pro'
-                        ? styles.planBadgePro
-                        : tierId === 'lite'
-                        ? styles.planBadgeLite
-                        : styles.planBadgeFree;
-
-                    // Text credits
-                    const monthlyLimit = textCredits?.monthlyLimit || 0;
-                    const monthlyUsed = textCredits?.monthlyUsed || 0;
-                    const monthlyRemaining = Math.max(0, monthlyLimit - monthlyUsed);
-                    const monthlyPct =
-                      monthlyLimit > 0
-                        ? Math.min(100, Math.round((monthlyUsed / monthlyLimit) * 100))
-                        : 0;
-                    const monthlyRatio = monthlyLimit > 0 ? monthlyRemaining / monthlyLimit : 1;
-                    const monthlyColor =
-                      monthlyRatio > 0.5
-                        ? styles.creditProgressHealthy
-                        : monthlyRatio > 0.2
-                        ? styles.creditProgressLow
-                        : styles.creditProgressCritical;
-
-                    // 3-hour window
-                    const windowLimit = textCredits?.windowLimit || 0;
-                    const windowUsed = textCredits?.windowUsed || 0;
-                    const windowRemaining = Math.max(0, windowLimit - windowUsed);
-                    const windowPct =
-                      windowLimit > 0
-                        ? Math.min(100, Math.round((windowUsed / windowLimit) * 100))
-                        : 0;
-                    const windowRatio = windowLimit > 0 ? windowRemaining / windowLimit : 1;
-                    const windowColor =
-                      windowRatio > 0.5
-                        ? styles.creditProgressHealthy
-                        : windowRatio > 0.2
-                        ? styles.creditProgressLow
-                        : styles.creditProgressCritical;
-                    const windowResetAt = textCredits?.windowResetAt;
-
-                    // Image credits
-                    const imgRemaining = imageCredits?.remaining || 0;
-                    const imgLimit = imageCredits?.limit || 0;
-                    const imgUsed = Math.max(0, imgLimit - imgRemaining);
-                    const imgPct =
-                      imgLimit > 0 ? Math.min(100, Math.round((imgUsed / imgLimit) * 100)) : 0;
-                    const imgRatio = imgLimit > 0 ? imgRemaining / imgLimit : 1;
-                    const imgColor =
-                      imgRatio > 0.5
-                        ? styles.creditProgressHealthy
-                        : imgRatio > 0.2
-                        ? styles.creditProgressLow
-                        : styles.creditProgressCritical;
-                    const cycleResetsAt = imageCredits?.cycleResetsAt;
-
-                    return (
-                      <div className={styles.subscriptionSection}>
-                        <div className={styles.planRow}>
-                          <span className={`${styles.planBadge} ${badgeClass}`}>{tierName}</span>
-                        </div>
-
-                        {/* Text credits */}
-                        <div className={styles.creditProgressSection}>
-                          <div className={styles.creditProgressLabel}>
-                            <span>Text credits</span>
-                            <span>
-                              {monthlyUsed} of {monthlyLimit} used
+                            {resolvedAvatar ? (
+                              <img
+                                src={resolvedAvatar}
+                                alt="Avatar"
+                                referrerPolicy="no-referrer"
+                                crossOrigin="anonymous"
+                                className={styles.avatarImage}
+                                onError={(e) => {
+                                  e.target.style.display = 'none';
+                                  e.target.nextSibling.style.display = '';
+                                }}
+                              />
+                            ) : null}
+                            <span style={{ display: resolvedAvatar ? 'none' : '' }}>
+                              <UserIcon />
                             </span>
                           </div>
-                          <div className={styles.creditProgressBar}>
-                            <div
-                              className={`${styles.creditProgressFill} ${monthlyColor}`}
-                              style={{ width: `${monthlyPct}%` }}
+                          <div className={styles.avatarInfo}>
+                            <span className={styles.avatarName}>{resolvedName}</span>
+                            {authUser?.email && (
+                              <span className={styles.avatarPlan}>{authUser.email}</span>
+                            )}
+                            <button
+                              className={styles.avatarEditBtn}
+                              onClick={() => avatarInputRef.current?.click()}
+                              disabled={avatarUploading}
+                            >
+                              <EditIcon />
+                              <span>{avatarUploading ? 'Uploading...' : 'Change avatar'}</span>
+                            </button>
+                            <input
+                              ref={avatarInputRef}
+                              type="file"
+                              accept="image/png,image/jpeg,image/webp"
+                              style={{ display: 'none' }}
+                              onChange={handleAvatarChange}
                             />
                           </div>
                         </div>
+                      );
+                    })()}
 
-                        {/* Current session (3-hour window) */}
-                        {windowResetAt && (
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Full name</label>
+                      <input
+                        className={styles.fieldInput}
+                        value={settings.fullName}
+                        onChange={(e) => updateSetting('fullName', e.target.value)}
+                        placeholder="Your full name"
+                      />
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Display name</label>
+                      <input
+                        className={styles.fieldInput}
+                        value={settings.displayName}
+                        onChange={(e) => updateSetting('displayName', e.target.value)}
+                        placeholder="What should Araviel call you?"
+                      />
+                      <span className={styles.fieldHint}>
+                        This is the name Araviel uses to address you.
+                      </span>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Email</label>
+                      <input
+                        className={styles.fieldInputReadonly}
+                        value={authUser?.email || ''}
+                        readOnly
+                      />
+                      <span className={styles.fieldHint}>
+                        Managed by your authentication provider.
+                      </span>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Bio</label>
+                      <textarea
+                        className={styles.fieldTextarea}
+                        value={settings.bio}
+                        onChange={(e) => updateSetting('bio', e.target.value)}
+                        placeholder="Tell us a little about yourself..."
+                        rows={3}
+                      />
+                      <span className={styles.fieldHint}>
+                        This helps personalize your experience.
+                      </span>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Occupation</label>
+                      <input
+                        className={styles.fieldInput}
+                        value={settings.occupation}
+                        onChange={(e) => updateSetting('occupation', e.target.value)}
+                        placeholder="e.g. Software Engineer, Designer, Student..."
+                      />
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Areas of expertise</label>
+                      <input
+                        className={styles.fieldInput}
+                        value={settings.expertise}
+                        onChange={(e) => updateSetting('expertise', e.target.value)}
+                        placeholder="e.g. Machine learning, Web development, Data analysis..."
+                      />
+                      <span className={styles.fieldHint}>
+                        Araviel will tailor responses to your expertise level.
+                      </span>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Phone</label>
+                      <input
+                        className={styles.fieldInput}
+                        type="tel"
+                        value={settings.phone}
+                        onChange={(e) => updateSetting('phone', e.target.value)}
+                        placeholder="e.g. +1 (555) 123-4567"
+                      />
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Website</label>
+                      <input
+                        className={styles.fieldInput}
+                        type="url"
+                        value={settings.website}
+                        onChange={(e) => updateSetting('website', e.target.value)}
+                        placeholder="e.g. https://yoursite.com"
+                      />
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Location</label>
+                      <input
+                        className={styles.fieldInput}
+                        value={settings.location}
+                        onChange={(e) => updateSetting('location', e.target.value)}
+                        placeholder="e.g. San Francisco, CA"
+                      />
+                    </div>
+                  </section>
+                )}
+
+                {/* ═══ APPEARANCE ═══ */}
+                {activeSection === 'appearance' && (
+                  <section className={styles.section}>
+                    <div className={styles.sectionHeader}>
+                      <h2 className={styles.sectionTitle}>Appearance</h2>
+                      <p className={styles.sectionDesc}>Customize how Araviel looks and feels.</p>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Theme</label>
+                      <div className={styles.themeCards}>
+                        <button
+                          className={`${styles.themeCard} ${
+                            themeMode === 'light' ? styles.themeCardActive : ''
+                          }`}
+                          onClick={() => dispatch(setTheme('light'))}
+                        >
+                          <div className={styles.themeCardPreview} data-theme-preview="light">
+                            <div className={styles.themePreviewBar} />
+                            <div className={styles.themePreviewContent}>
+                              <div className={styles.themePreviewLine} />
+                              <div className={styles.themePreviewLineShort} />
+                            </div>
+                          </div>
+                          <div className={styles.themeCardInfo}>
+                            <SunIcon />
+                            <span>Light</span>
+                          </div>
+                        </button>
+                        <button
+                          className={`${styles.themeCard} ${
+                            themeMode === 'dark' ? styles.themeCardActive : ''
+                          }`}
+                          onClick={() => dispatch(setTheme('dark'))}
+                        >
+                          <div className={`${styles.themeCardPreview} ${styles.themePreviewDark}`}>
+                            <div className={styles.themePreviewBar} />
+                            <div className={styles.themePreviewContent}>
+                              <div className={styles.themePreviewLine} />
+                              <div className={styles.themePreviewLineShort} />
+                            </div>
+                          </div>
+                          <div className={styles.themeCardInfo}>
+                            <MoonIcon />
+                            <span>Dark</span>
+                          </div>
+                        </button>
+                        <button
+                          className={`${styles.themeCard} ${
+                            themeMode === 'system' ? styles.themeCardActive : ''
+                          }`}
+                          onClick={() => dispatch(setTheme('system'))}
+                        >
+                          <div
+                            className={`${styles.themeCardPreview} ${styles.themePreviewSystem}`}
+                          >
+                            <div className={styles.themePreviewBar} />
+                            <div className={styles.themePreviewContent}>
+                              <div className={styles.themePreviewLine} />
+                              <div className={styles.themePreviewLineShort} />
+                            </div>
+                          </div>
+                          <div className={styles.themeCardInfo}>
+                            <MonitorIcon />
+                            <span>System</span>
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Answer font style</label>
+                      <p className={styles.fieldLabelDesc}>
+                        Choose the font style for AI responses.
+                      </p>
+                      <div className={styles.segmentedControl}>
+                        {ANSWER_FONTS.map((font) => (
+                          <button
+                            key={font.id}
+                            className={`${styles.segmentedBtn} ${
+                              settings.answerFont === font.id ? styles.segmentedBtnActive : ''
+                            }`}
+                            onClick={() => {
+                              updateSetting('answerFont', font.id);
+                              // Apply immediately so the user sees the change
+                              // without having to hit "Save changes".
+                              const el = document.documentElement;
+                              if (font.id === 'system') {
+                                el.removeAttribute('data-answer-font');
+                              } else {
+                                el.setAttribute('data-answer-font', font.id);
+                              }
+                            }}
+                            style={{ fontFamily: font.sample }}
+                          >
+                            {font.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </section>
+                )}
+
+                {/* ═══ PERSONALIZATION ═══ */}
+                {activeSection === 'personalization' && (
+                  <section className={styles.section}>
+                    <div className={styles.sectionHeader}>
+                      <h2 className={styles.sectionTitle}>Personalization</h2>
+                      <p className={styles.sectionDesc}>
+                        Help Araviel understand you better for more relevant responses.
+                      </p>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Preferred response language</label>
+                      <p className={styles.fieldLabelDesc}>
+                        The language Araviel will use when responding to you.
+                      </p>
+                      <select
+                        className={styles.fieldSelect}
+                        value={settings.preferredLanguage}
+                        onChange={(e) => updateSetting('preferredLanguage', e.target.value)}
+                      >
+                        {LANGUAGES.map((lang) => (
+                          <option key={lang} value={lang}>
+                            {lang}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Response tone</label>
+                      <p className={styles.fieldLabelDesc}>
+                        Choose how Araviel communicates with you.
+                      </p>
+                      <div className={styles.toneGrid}>
+                        {TONES.map((tone) => (
+                          <button
+                            key={tone.id}
+                            className={`${styles.toneCard} ${
+                              settings.responseTone === tone.id ? styles.toneCardActive : ''
+                            }`}
+                            onClick={() => {
+                              updateSetting('responseTone', tone.id);
+                              dispatch(setTone(tone.id));
+                            }}
+                          >
+                            <span className={styles.toneCardLabel}>{tone.label}</span>
+                            <span className={styles.toneCardDesc}>{tone.description}</span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>
+                        What personal preferences should Araviel consider in responses?
+                      </label>
+                      <p className={styles.fieldLabelDesc}>
+                        Your preferences will apply to all conversations.
+                      </p>
+                      <textarea
+                        className={styles.fieldTextarea}
+                        value={settings.customInstructions}
+                        onChange={(e) => {
+                          if (e.target.value.length <= 2000) {
+                            updateSetting('customInstructions', e.target.value);
+                          }
+                        }}
+                        placeholder="e.g. When writing code, be very concise. Follow good coding principles and practices. Always adhere to good programming principles, OOP, DRY, SOLID, etc when writing code. All code must be written at top quality, clean, easy to read and understand..."
+                        rows={6}
+                      />
+                      <div className={styles.textareaFooter}>
+                        <span className={styles.fieldHint}>
+                          {settings.customInstructions.length} / 2,000 characters
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <div className={styles.toggleRow}>
+                        <div className={styles.toggleInfo}>
+                          <span className={styles.toggleLabel}>Send message with Enter</span>
+                          <span className={styles.toggleDesc}>
+                            Use Enter to send messages. When off, use {modKey}+Enter instead.
+                          </span>
+                        </div>
+                        <ToggleSwitch
+                          value={settings.sendWithEnter}
+                          onChange={(v) => updateSetting('sendWithEnter', v)}
+                        />
+                      </div>
+                    </div>
+                  </section>
+                )}
+
+                {/* ═══ MODEL PREFERENCES ═══ */}
+                {activeSection === 'models' && (
+                  <section className={styles.section}>
+                    <div className={styles.sectionHeader}>
+                      <h2 className={styles.sectionTitle}>Model preferences</h2>
+                      <p className={styles.sectionDesc}>
+                        Configure how AI models are selected and behave.
+                      </p>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Web search</label>
+                      <p className={styles.fieldLabelDesc}>
+                        Control when Araviel searches the web for current information.
+                      </p>
+                      <div className={styles.segmentedControl}>
+                        {[
+                          { id: 'auto', label: 'Auto' },
+                          { id: 'always', label: 'Always' },
+                          { id: 'never', label: 'Never' },
+                        ].map((opt) => (
+                          <button
+                            key={opt.id}
+                            className={`${styles.segmentedBtn} ${
+                              settings.webSearchDefault === opt.id ? styles.segmentedBtnActive : ''
+                            }`}
+                            onClick={() => {
+                              updateSetting('webSearchDefault', opt.id);
+                              const val =
+                                opt.id === 'always' ? true : opt.id === 'never' ? false : null;
+                              dispatch(setWebSearchEnabled(val));
+                            }}
+                          >
+                            {opt.label}
+                          </button>
+                        ))}
+                      </div>
+                      <span className={styles.fieldHint}>
+                        {settings.webSearchDefault === 'auto' &&
+                          'Araviel decides when web search is needed based on your query.'}
+                        {settings.webSearchDefault === 'always' &&
+                          'Every query will include web search results.'}
+                        {settings.webSearchDefault === 'never' &&
+                          'Web search is disabled. Responses use model knowledge only.'}
+                      </span>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Default image quality</label>
+                      <p className={styles.fieldLabelDesc}>
+                        Set the default quality for AI-generated images.
+                      </p>
+                      <div className={styles.segmentedControl}>
+                        {[
+                          { id: 'standard', label: 'Standard (1 credit)' },
+                          { id: 'hd', label: 'HD (2 credits)' },
+                          { id: 'ultra', label: 'Ultra (4 credits)' },
+                        ].map((q) => (
+                          <button
+                            key={q.id}
+                            className={`${styles.segmentedBtn} ${
+                              settings.imageQualityDefault === q.id ? styles.segmentedBtnActive : ''
+                            }`}
+                            onClick={() => {
+                              updateSetting('imageQualityDefault', q.id);
+                              dispatch(setImageQuality(q.id));
+                            }}
+                          >
+                            {q.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <div className={styles.toggleRow}>
+                        <div className={styles.toggleInfo}>
+                          <span className={styles.toggleLabel}>Enable reasoning / thinking</span>
+                          <span className={styles.toggleDesc}>
+                            Enable deep chain-of-thought reasoning when available.
+                          </span>
+                        </div>
+                        <ToggleSwitch
+                          value={settings.enableReasoning}
+                          onChange={(v) => {
+                            updateSetting('enableReasoning', v);
+                            dispatch(setExtendedThinking(v));
+                          }}
+                        />
+                      </div>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <div className={styles.toggleRow}>
+                        <div className={styles.toggleInfo}>
+                          <span className={styles.toggleLabel}>Follow-up suggestions</span>
+                          <span className={styles.toggleDesc}>
+                            Show suggested follow-up questions after each response.
+                          </span>
+                        </div>
+                        <ToggleSwitch
+                          value={settings.enableFollowUps}
+                          onChange={(v) => updateSetting('enableFollowUps', v)}
+                        />
+                      </div>
+                    </div>
+                  </section>
+                )}
+
+                {/* ═══ SUBSCRIPTION ═══ */}
+                {activeSection === 'subscription' && (
+                  <section className={styles.section}>
+                    <div className={styles.sectionHeader}>
+                      <h2 className={styles.sectionTitle}>Subscription</h2>
+                      <p className={styles.sectionDesc}>
+                        Manage your plan, monitor credit usage, and access billing.
+                      </p>
+                    </div>
+                    <SubscriptionSummary />
+                  </section>
+                )}
+
+                {/* ═══ USAGE & CREDITS ═══ */}
+                {activeSection === 'usage' && (
+                  <section className={styles.section}>
+                    <div className={styles.sectionHeader}>
+                      <h2 className={styles.sectionTitle}>Usage & credits</h2>
+                      <p className={styles.sectionDesc}>
+                        Monitor your credit balance and manage your plan.
+                      </p>
+                    </div>
+
+                    {/* ── Subscription management ── */}
+                    {(() => {
+                      const tierInfo = getTierById(currentTier);
+                      const tierName =
+                        tierInfo?.name ||
+                        currentTier?.charAt(0).toUpperCase() + currentTier?.slice(1) ||
+                        'Free';
+                      const tierId = currentTier || 'free';
+                      const badgeClass =
+                        tierId === 'pro'
+                          ? styles.planBadgePro
+                          : tierId === 'lite'
+                          ? styles.planBadgeLite
+                          : styles.planBadgeFree;
+
+                      // Text credits
+                      const monthlyLimit = textCredits?.monthlyLimit || 0;
+                      const monthlyUsed = textCredits?.monthlyUsed || 0;
+                      const monthlyRemaining = Math.max(0, monthlyLimit - monthlyUsed);
+                      const monthlyPct =
+                        monthlyLimit > 0
+                          ? Math.min(100, Math.round((monthlyUsed / monthlyLimit) * 100))
+                          : 0;
+                      const monthlyRatio = monthlyLimit > 0 ? monthlyRemaining / monthlyLimit : 1;
+                      const monthlyColor =
+                        monthlyRatio > 0.5
+                          ? styles.creditProgressHealthy
+                          : monthlyRatio > 0.2
+                          ? styles.creditProgressLow
+                          : styles.creditProgressCritical;
+
+                      // 3-hour window
+                      const windowLimit = textCredits?.windowLimit || 0;
+                      const windowUsed = textCredits?.windowUsed || 0;
+                      const windowRemaining = Math.max(0, windowLimit - windowUsed);
+                      const windowPct =
+                        windowLimit > 0
+                          ? Math.min(100, Math.round((windowUsed / windowLimit) * 100))
+                          : 0;
+                      const windowRatio = windowLimit > 0 ? windowRemaining / windowLimit : 1;
+                      const windowColor =
+                        windowRatio > 0.5
+                          ? styles.creditProgressHealthy
+                          : windowRatio > 0.2
+                          ? styles.creditProgressLow
+                          : styles.creditProgressCritical;
+                      const windowResetAt = textCredits?.windowResetAt;
+
+                      // Image credits
+                      const imgRemaining = imageCredits?.remaining || 0;
+                      const imgLimit = imageCredits?.limit || 0;
+                      const imgUsed = Math.max(0, imgLimit - imgRemaining);
+                      const imgPct =
+                        imgLimit > 0 ? Math.min(100, Math.round((imgUsed / imgLimit) * 100)) : 0;
+                      const imgRatio = imgLimit > 0 ? imgRemaining / imgLimit : 1;
+                      const imgColor =
+                        imgRatio > 0.5
+                          ? styles.creditProgressHealthy
+                          : imgRatio > 0.2
+                          ? styles.creditProgressLow
+                          : styles.creditProgressCritical;
+                      const cycleResetsAt = imageCredits?.cycleResetsAt;
+
+                      return (
+                        <div className={styles.subscriptionSection}>
+                          <div className={styles.planRow}>
+                            <span className={`${styles.planBadge} ${badgeClass}`}>{tierName}</span>
+                          </div>
+
+                          {/* Text credits */}
                           <div className={styles.creditProgressSection}>
                             <div className={styles.creditProgressLabel}>
-                              <span>Current session</span>
+                              <span>Text credits</span>
                               <span>
-                                {windowUsed} of {windowLimit} used
+                                {monthlyUsed} of {monthlyLimit} used
                               </span>
                             </div>
                             <div className={styles.creditProgressBar}>
                               <div
-                                className={`${styles.creditProgressFill} ${windowColor}`}
-                                style={{ width: `${windowPct}%` }}
+                                className={`${styles.creditProgressFill} ${monthlyColor}`}
+                                style={{ width: `${monthlyPct}%` }}
                               />
                             </div>
-                            <div className={styles.creditProgressLabel}>
-                              <span>
-                                Resets at{' '}
-                                {new Date(windowResetAt).toLocaleTimeString(undefined, {
-                                  hour: '2-digit',
-                                  minute: '2-digit',
-                                })}
-                              </span>
-                            </div>
                           </div>
-                        )}
 
-                        {/* Image credits */}
-                        <div className={styles.creditProgressSection}>
-                          <div className={styles.creditProgressLabel}>
-                            <span>Image credits</span>
-                            <span>{imgPct}% used</span>
-                          </div>
-                          <div className={styles.creditProgressBar}>
-                            <div
-                              className={`${styles.creditProgressFill} ${imgColor}`}
-                              style={{ width: `${imgPct}%` }}
-                            />
-                          </div>
-                          {cycleResetsAt && (
+                          {/* Current session (3-hour window) */}
+                          {windowResetAt && (
+                            <div className={styles.creditProgressSection}>
+                              <div className={styles.creditProgressLabel}>
+                                <span>Current session</span>
+                                <span>
+                                  {windowUsed} of {windowLimit} used
+                                </span>
+                              </div>
+                              <div className={styles.creditProgressBar}>
+                                <div
+                                  className={`${styles.creditProgressFill} ${windowColor}`}
+                                  style={{ width: `${windowPct}%` }}
+                                />
+                              </div>
+                              <div className={styles.creditProgressLabel}>
+                                <span>
+                                  Resets at{' '}
+                                  {new Date(windowResetAt).toLocaleTimeString(undefined, {
+                                    hour: '2-digit',
+                                    minute: '2-digit',
+                                  })}
+                                </span>
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Image credits */}
+                          <div className={styles.creditProgressSection}>
                             <div className={styles.creditProgressLabel}>
-                              <span>
-                                Resets{' '}
-                                {new Date(cycleResetsAt).toLocaleDateString(undefined, {
-                                  year: 'numeric',
-                                  month: 'long',
-                                  day: 'numeric',
-                                })}
-                              </span>
+                              <span>Image credits</span>
+                              <span>{imgPct}% used</span>
+                            </div>
+                            <div className={styles.creditProgressBar}>
+                              <div
+                                className={`${styles.creditProgressFill} ${imgColor}`}
+                                style={{ width: `${imgPct}%` }}
+                              />
+                            </div>
+                            {cycleResetsAt && (
+                              <div className={styles.creditProgressLabel}>
+                                <span>
+                                  Resets{' '}
+                                  {new Date(cycleResetsAt).toLocaleDateString(undefined, {
+                                    year: 'numeric',
+                                    month: 'long',
+                                    day: 'numeric',
+                                  })}
+                                </span>
+                              </div>
+                            )}
+                          </div>
+
+                          {periodEnd && (
+                            <div className={styles.billingInfo}>
+                              Next billing:{' '}
+                              {new Date(periodEnd).toLocaleDateString(undefined, {
+                                year: 'numeric',
+                                month: 'long',
+                                day: 'numeric',
+                              })}
+                            </div>
+                          )}
+
+                          {cancelAtPeriodEnd && (
+                            <div className={styles.cancelNotice}>
+                              Your plan will be cancelled at the end of the current period
+                            </div>
+                          )}
+
+                          {(tierId === 'free' || tierId === 'lite') && (
+                            <div className={styles.subscriptionActions}>
+                              <button
+                                className={styles.upgradeBtn}
+                                onClick={() => navigate('/plans')}
+                              >
+                                Upgrade Plan
+                              </button>
                             </div>
                           )}
                         </div>
+                      );
+                    })()}
 
-                        {periodEnd && (
-                          <div className={styles.billingInfo}>
-                            Next billing:{' '}
-                            {new Date(periodEnd).toLocaleDateString(undefined, {
-                              year: 'numeric',
-                              month: 'long',
-                              day: 'numeric',
+                    {creditsLoading ? (
+                      <div className={styles.usageLoading}>
+                        <div className={styles.loadingSpinner} />
+                        <span>Loading usage data...</span>
+                      </div>
+                    ) : creditBalance?.balance ? (
+                      <>
+                        {/* ── Current plan card ── */}
+                        {(() => {
+                          const tierInfo = getTierById(currentTier);
+                          const tier = currentTier || 'free';
+                          const tierLabel =
+                            tierInfo?.name || tier.charAt(0).toUpperCase() + tier.slice(1);
+                          const tierCredits = tierInfo?.monthlyImageCredits ?? 5;
+                          return (
+                            <div className={styles.planCard}>
+                              <div className={styles.planInfo}>
+                                <span className={styles.planName}>
+                                  <span
+                                    className={`${styles.tierBadge} ${
+                                      styles[`tierBadge${tierLabel}`] || ''
+                                    }`}
+                                  >
+                                    {tierLabel}
+                                  </span>
+                                  {tierLabel} plan
+                                </span>
+                                <span className={styles.planDesc}>
+                                  {tierCredits} image credits per month
+                                </span>
+                              </div>
+                              <button
+                                className={styles.planUpgradeBtn}
+                                onClick={() =>
+                                  tier === 'free'
+                                    ? navigate('/plans')
+                                    : dispatch(createPortalThunk())
+                                }
+                                disabled={tier !== 'free' && portalLoading}
+                              >
+                                {tier === 'free'
+                                  ? 'Upgrade plan'
+                                  : portalLoading
+                                  ? 'Opening...'
+                                  : 'Manage plan'}
+                              </button>
+                            </div>
+                          );
+                        })()}
+
+                        {/* ── Plan usage limits ── */}
+                        <div className={styles.fieldGroup}>
+                          <label className={styles.fieldLabel}>Plan usage limits</label>
+
+                          {/* Monthly image credits */}
+                          {(() => {
+                            const monthly = creditBalance.balance.monthly || {
+                              total: 0,
+                              used: 0,
+                              remaining: 0,
+                            };
+                            const pct = monthly.total
+                              ? Math.round((monthly.used / monthly.total) * 100)
+                              : 0;
+                            const resetDate = creditBalance.balance.cycleResetsAt
+                              ? new Date(creditBalance.balance.cycleResetsAt)
+                              : null;
+                            const daysUntilReset = resetDate
+                              ? Math.max(
+                                  0,
+                                  Math.ceil(
+                                    (resetDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+                                  )
+                                )
+                              : null;
+                            return (
+                              <div className={styles.usageRow}>
+                                <div className={styles.usageRowHeader}>
+                                  <span className={styles.usageRowLabel}>Image credits</span>
+                                  <span className={styles.usageRowValue}>{pct}% used</span>
+                                </div>
+                                <div className={styles.usageProgressBar}>
+                                  <div
+                                    className={`${styles.usageProgressFill} ${
+                                      pct > 80 ? styles.usageProgressFillWarn : ''
+                                    }`}
+                                    style={{ width: `${Math.min(100, pct)}%` }}
+                                  />
+                                </div>
+                                <div className={styles.usageRowFooter}>
+                                  <span>
+                                    {monthly.used} of {monthly.total} used
+                                  </span>
+                                  {daysUntilReset !== null && (
+                                    <span>
+                                      Resets in {daysUntilReset} day
+                                      {daysUntilReset !== 1 ? 's' : ''}
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                            );
+                          })()}
+
+                          {/* Pack credits */}
+                          {(() => {
+                            const packs = creditBalance.balance.packs || {
+                              total: 0,
+                              used: 0,
+                              remaining: 0,
+                            };
+                            const packPct = packs.total
+                              ? Math.round((packs.used / packs.total) * 100)
+                              : 0;
+                            return (
+                              <div className={styles.usageRow}>
+                                <div className={styles.usageRowHeader}>
+                                  <span className={styles.usageRowLabel}>Purchased credits</span>
+                                  <span className={styles.usageRowValue}>
+                                    {packs.remaining} remaining
+                                  </span>
+                                </div>
+                                <div className={styles.usageProgressBar}>
+                                  <div
+                                    className={`${styles.usageProgressFill} ${styles.usageProgressFillPack}`}
+                                    style={{
+                                      width: `${packs.total ? Math.min(100, packPct) : 0}%`,
+                                    }}
+                                  />
+                                </div>
+                                <div className={styles.usageRowFooter}>
+                                  <span>
+                                    {packs.used} of {packs.total} used
+                                  </span>
+                                  <span>Packs expire after 90 days</span>
+                                </div>
+                              </div>
+                            );
+                          })()}
+                        </div>
+
+                        {/* ── Total available ── */}
+                        <div className={styles.totalCreditsCard}>
+                          <div className={styles.totalCreditsLeft}>
+                            <span className={styles.totalCreditsValue}>
+                              {creditBalance.balance.combined ?? 0}
+                            </span>
+                            <span className={styles.totalCreditsLabel}>
+                              Total credits available
+                            </span>
+                          </div>
+                          <span className={styles.totalCreditsSub}>
+                            {creditBalance.balance.monthly?.remaining ?? 0} monthly +{' '}
+                            {creditBalance.balance.packs?.remaining ?? 0} pack
+                          </span>
+                        </div>
+
+                        {/* ── Credit costs ── */}
+                        <div className={styles.fieldGroup}>
+                          <label className={styles.fieldLabel}>Image generation costs</label>
+                          <div className={styles.costTable}>
+                            <div className={styles.costRow}>
+                              <span>Standard quality</span>
+                              <span className={styles.costValue}>
+                                {creditBalance.costs?.standard ?? 1} credit
+                              </span>
+                            </div>
+                            <div className={styles.costRow}>
+                              <span>HD quality</span>
+                              <span className={styles.costValue}>
+                                {creditBalance.costs?.hd ?? 2} credits
+                              </span>
+                            </div>
+                            <div className={styles.costRow}>
+                              <span>Ultra quality</span>
+                              <span className={styles.costValue}>
+                                {creditBalance.costs?.ultra ?? 4} credits
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+
+                        {/* ── Add more credits ── */}
+                        <div className={styles.fieldGroup}>
+                          <label className={styles.fieldLabel}>Add more credits</label>
+                          <p className={styles.fieldLabelDesc}>
+                            Purchase credit packs for additional image generations. Credits expire
+                            after 90 days.
+                          </p>
+                          <div className={styles.packCards}>
+                            {Object.entries(creditBalance.packs || {}).map(([key, pack]) => {
+                              const price = IMAGE_PACKS[key]?.price || pack.price;
+                              return (
+                                <div key={key} className={styles.packCard}>
+                                  <div className={styles.packCardBody}>
+                                    <span className={styles.packCardCredits}>{pack.credits}</span>
+                                    <span className={styles.packCardLabel}>{pack.label}</span>
+                                    {price && <span className={styles.packCardPrice}>{price}</span>}
+                                  </div>
+                                  <button
+                                    className={styles.packCardBtn}
+                                    onClick={() => handlePackSelect(key)}
+                                    disabled={packLoading}
+                                  >
+                                    Add credits
+                                  </button>
+                                </div>
+                              );
                             })}
                           </div>
-                        )}
-
-                        {cancelAtPeriodEnd && (
-                          <div className={styles.cancelNotice}>
-                            Your plan will be cancelled at the end of the current period
-                          </div>
-                        )}
-
-                        {(tierId === 'free' || tierId === 'lite') && (
-                          <div className={styles.subscriptionActions}>
-                            <button
-                              className={styles.upgradeBtn}
-                              onClick={() => navigate('/plans')}
-                            >
-                              Upgrade Plan
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })()}
-
-                  {creditsLoading ? (
-                    <div className={styles.usageLoading}>
-                      <div className={styles.loadingSpinner} />
-                      <span>Loading usage data...</span>
-                    </div>
-                  ) : creditBalance?.balance ? (
-                    <>
-                      {/* ── Current plan card ── */}
-                      {(() => {
-                        const tierInfo = getTierById(currentTier);
-                        const tier = currentTier || 'free';
-                        const tierLabel =
-                          tierInfo?.name || tier.charAt(0).toUpperCase() + tier.slice(1);
-                        const tierCredits = tierInfo?.monthlyImageCredits ?? 5;
-                        return (
-                          <div className={styles.planCard}>
-                            <div className={styles.planInfo}>
-                              <span className={styles.planName}>
-                                <span
-                                  className={`${styles.tierBadge} ${
-                                    styles[`tierBadge${tierLabel}`] || ''
-                                  }`}
-                                >
-                                  {tierLabel}
-                                </span>
-                                {tierLabel} plan
-                              </span>
-                              <span className={styles.planDesc}>
-                                {tierCredits} image credits per month
-                              </span>
-                            </div>
-                            <button
-                              className={styles.planUpgradeBtn}
-                              onClick={() =>
-                                tier === 'free' ? navigate('/plans') : dispatch(createPortalThunk())
-                              }
-                              disabled={tier !== 'free' && portalLoading}
-                            >
-                              {tier === 'free'
-                                ? 'Upgrade plan'
-                                : portalLoading
-                                ? 'Opening...'
-                                : 'Manage plan'}
-                            </button>
-                          </div>
-                        );
-                      })()}
-
-                      {/* ── Plan usage limits ── */}
-                      <div className={styles.fieldGroup}>
-                        <label className={styles.fieldLabel}>Plan usage limits</label>
-
-                        {/* Monthly image credits */}
-                        {(() => {
-                          const monthly = creditBalance.balance.monthly || {
-                            total: 0,
-                            used: 0,
-                            remaining: 0,
-                          };
-                          const pct = monthly.total
-                            ? Math.round((monthly.used / monthly.total) * 100)
-                            : 0;
-                          const resetDate = creditBalance.balance.cycleResetsAt
-                            ? new Date(creditBalance.balance.cycleResetsAt)
-                            : null;
-                          const daysUntilReset = resetDate
-                            ? Math.max(
-                                0,
-                                Math.ceil(
-                                  (resetDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)
-                                )
-                              )
-                            : null;
-                          return (
-                            <div className={styles.usageRow}>
-                              <div className={styles.usageRowHeader}>
-                                <span className={styles.usageRowLabel}>Image credits</span>
-                                <span className={styles.usageRowValue}>{pct}% used</span>
-                              </div>
-                              <div className={styles.usageProgressBar}>
-                                <div
-                                  className={`${styles.usageProgressFill} ${
-                                    pct > 80 ? styles.usageProgressFillWarn : ''
-                                  }`}
-                                  style={{ width: `${Math.min(100, pct)}%` }}
-                                />
-                              </div>
-                              <div className={styles.usageRowFooter}>
-                                <span>
-                                  {monthly.used} of {monthly.total} used
-                                </span>
-                                {daysUntilReset !== null && (
-                                  <span>
-                                    Resets in {daysUntilReset} day{daysUntilReset !== 1 ? 's' : ''}
-                                  </span>
-                                )}
-                              </div>
-                            </div>
-                          );
-                        })()}
-
-                        {/* Pack credits */}
-                        {(() => {
-                          const packs = creditBalance.balance.packs || {
-                            total: 0,
-                            used: 0,
-                            remaining: 0,
-                          };
-                          const packPct = packs.total
-                            ? Math.round((packs.used / packs.total) * 100)
-                            : 0;
-                          return (
-                            <div className={styles.usageRow}>
-                              <div className={styles.usageRowHeader}>
-                                <span className={styles.usageRowLabel}>Purchased credits</span>
-                                <span className={styles.usageRowValue}>
-                                  {packs.remaining} remaining
-                                </span>
-                              </div>
-                              <div className={styles.usageProgressBar}>
-                                <div
-                                  className={`${styles.usageProgressFill} ${styles.usageProgressFillPack}`}
-                                  style={{
-                                    width: `${packs.total ? Math.min(100, packPct) : 0}%`,
-                                  }}
-                                />
-                              </div>
-                              <div className={styles.usageRowFooter}>
-                                <span>
-                                  {packs.used} of {packs.total} used
-                                </span>
-                                <span>Packs expire after 90 days</span>
-                              </div>
-                            </div>
-                          );
-                        })()}
-                      </div>
-
-                      {/* ── Total available ── */}
-                      <div className={styles.totalCreditsCard}>
-                        <div className={styles.totalCreditsLeft}>
-                          <span className={styles.totalCreditsValue}>
-                            {creditBalance.balance.combined ?? 0}
-                          </span>
-                          <span className={styles.totalCreditsLabel}>Total credits available</span>
                         </div>
-                        <span className={styles.totalCreditsSub}>
-                          {creditBalance.balance.monthly?.remaining ?? 0} monthly +{' '}
-                          {creditBalance.balance.packs?.remaining ?? 0} pack
-                        </span>
-                      </div>
 
-                      {/* ── Credit costs ── */}
-                      <div className={styles.fieldGroup}>
-                        <label className={styles.fieldLabel}>Image generation costs</label>
-                        <div className={styles.costTable}>
-                          <div className={styles.costRow}>
-                            <span>Standard quality</span>
-                            <span className={styles.costValue}>
-                              {creditBalance.costs?.standard ?? 1} credit
-                            </span>
-                          </div>
-                          <div className={styles.costRow}>
-                            <span>HD quality</span>
-                            <span className={styles.costValue}>
-                              {creditBalance.costs?.hd ?? 2} credits
-                            </span>
-                          </div>
-                          <div className={styles.costRow}>
-                            <span>Ultra quality</span>
-                            <span className={styles.costValue}>
-                              {creditBalance.costs?.ultra ?? 4} credits
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* ── Add more credits ── */}
-                      <div className={styles.fieldGroup}>
-                        <label className={styles.fieldLabel}>Add more credits</label>
-                        <p className={styles.fieldLabelDesc}>
-                          Purchase credit packs for additional image generations. Credits expire
-                          after 90 days.
+                        <button className={styles.refreshBtn} onClick={loadCredits}>
+                          Refresh usage data
+                        </button>
+                      </>
+                    ) : (
+                      <div className={styles.usageEmpty}>
+                        <p>
+                          {creditsError ||
+                            'Unable to load usage data. Check your connection and try again.'}
                         </p>
-                        <div className={styles.packCards}>
-                          {Object.entries(creditBalance.packs || {}).map(([key, pack]) => {
-                            const price = IMAGE_PACKS[key]?.price || pack.price;
-                            return (
-                              <div key={key} className={styles.packCard}>
-                                <div className={styles.packCardBody}>
-                                  <span className={styles.packCardCredits}>{pack.credits}</span>
-                                  <span className={styles.packCardLabel}>{pack.label}</span>
-                                  {price && <span className={styles.packCardPrice}>{price}</span>}
-                                </div>
-                                <button
-                                  className={styles.packCardBtn}
-                                  onClick={() => handlePackSelect(key)}
-                                  disabled={packLoading}
-                                >
-                                  Add credits
-                                </button>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-
-                      <button className={styles.refreshBtn} onClick={loadCredits}>
-                        Refresh usage data
-                      </button>
-                    </>
-                  ) : (
-                    <div className={styles.usageEmpty}>
-                      <p>
-                        {creditsError ||
-                          'Unable to load usage data. Check your connection and try again.'}
-                      </p>
-                      <button className={styles.refreshBtn} onClick={loadCredits}>
-                        Retry
-                      </button>
-                    </div>
-                  )}
-                </section>
-              )}
-
-              {/* ═══ NOTIFICATIONS ═══ */}
-              {activeSection === 'notifications' && (
-                <section className={styles.section}>
-                  <div className={styles.sectionHeader}>
-                    <h2 className={styles.sectionTitle}>Notifications</h2>
-                    <p className={styles.sectionDesc}>Choose what you want to be notified about.</p>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <div className={styles.toggleRow}>
-                      <div className={styles.toggleInfo}>
-                        <span className={styles.toggleLabel}>Usage limit warnings</span>
-                        <span className={styles.toggleDesc}>
-                          Get alerted when you&apos;re approaching your credit or usage limits.
-                        </span>
-                      </div>
-                      <ToggleSwitch
-                        value={settings.notifyUsageLimits}
-                        onChange={(v) => updateSetting('notifyUsageLimits', v)}
-                      />
-                    </div>
-
-                    {settings.notifyUsageLimits && (
-                      <div className={styles.thresholdPanel}>
-                        <span className={styles.thresholdTitle}>Warn me when I have</span>
-                        <span className={styles.thresholdDesc}>
-                          Pick one or more thresholds — we&apos;ll nudge you as each one gets
-                          crossed so there are no surprises.
-                        </span>
-                        <div className={styles.thresholdChipRow}>
-                          {USAGE_THRESHOLD_OPTIONS.map((pct) => {
-                            const current = Array.isArray(settings.usageLimitThresholds)
-                              ? settings.usageLimitThresholds
-                              : [];
-                            const active = current.includes(pct);
-                            return (
-                              <button
-                                key={pct}
-                                type="button"
-                                className={`${styles.thresholdChip} ${
-                                  active ? styles.thresholdChipActive : ''
-                                }`}
-                                aria-pressed={active}
-                                onClick={() => {
-                                  const next = active
-                                    ? current.filter((v) => v !== pct)
-                                    : [...current, pct].sort((a, b) => b - a);
-                                  updateSetting('usageLimitThresholds', next);
-                                }}
-                              >
-                                {pct}% left
-                              </button>
-                            );
-                          })}
-                        </div>
+                        <button className={styles.refreshBtn} onClick={loadCredits}>
+                          Retry
+                        </button>
                       </div>
                     )}
-                  </div>
-                </section>
-              )}
+                  </section>
+                )}
 
-              {/* ═══ DATA & PRIVACY ═══ */}
-              {activeSection === 'data' && (
-                <section className={styles.section}>
-                  <div className={styles.sectionHeader}>
-                    <h2 className={styles.sectionTitle}>Data & privacy</h2>
-                    <p className={styles.sectionDesc}>Control how your data is stored and used.</p>
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <div className={styles.toggleRow}>
-                      <div className={styles.toggleInfo}>
-                        <span className={styles.toggleLabel}>Location metadata</span>
-                        <span className={styles.toggleDesc}>
-                          Allow Araviel to use coarse location data (city/region) to improve
-                          responses.
-                        </span>
-                      </div>
-                      <ToggleSwitch
-                        value={settings.locationMetadata}
-                        onChange={(v) => updateSetting('locationMetadata', v)}
-                      />
+                {/* ═══ NOTIFICATIONS ═══ */}
+                {activeSection === 'notifications' && (
+                  <section className={styles.section}>
+                    <div className={styles.sectionHeader}>
+                      <h2 className={styles.sectionTitle}>Notifications</h2>
+                      <p className={styles.sectionDesc}>
+                        Choose what you want to be notified about.
+                      </p>
                     </div>
-                  </div>
 
-                  <div className={styles.fieldGroup}>
-                    <label className={styles.fieldLabel}>Shared chats</label>
-                    <p className={styles.fieldLabelDesc}>
-                      Links to conversations you&rsquo;ve shared publicly. Manage every active link
-                      from the Shared tab in Conversations.
-                    </p>
-                    <SharedChatsStub active={activeSection === 'data'} />
-                  </div>
+                    <div className={styles.fieldGroup}>
+                      <div className={styles.toggleRow}>
+                        <div className={styles.toggleInfo}>
+                          <span className={styles.toggleLabel}>Usage limit warnings</span>
+                          <span className={styles.toggleDesc}>
+                            Get alerted when you&apos;re approaching your credit or usage limits.
+                          </span>
+                        </div>
+                        <ToggleSwitch
+                          value={settings.notifyUsageLimits}
+                          onChange={(v) => updateSetting('notifyUsageLimits', v)}
+                        />
+                      </div>
 
-                  <div className={styles.dangerZone}>
-                    <h3 className={styles.dangerTitle}>Danger zone</h3>
-                    <div className={styles.dangerCard}>
-                      <div className={styles.dangerInfo}>
-                        <span className={styles.dangerLabel}>Delete all conversations</span>
-                        <span className={styles.dangerDesc}>
-                          Move every conversation to Recently deleted. You have 15 days to restore
-                          them before they&rsquo;re permanently removed.
-                        </span>
-                      </div>
-                      <button
-                        className={styles.dangerBtn}
-                        onClick={() => setShowDeleteAllConfirm(true)}
-                        disabled={deletingAll}
-                      >
-                        {deletingAll ? 'Deleting…' : 'Delete all'}
-                      </button>
+                      {settings.notifyUsageLimits && (
+                        <div className={styles.thresholdPanel}>
+                          <span className={styles.thresholdTitle}>Warn me when I have</span>
+                          <span className={styles.thresholdDesc}>
+                            Pick one or more thresholds — we&apos;ll nudge you as each one gets
+                            crossed so there are no surprises.
+                          </span>
+                          <div className={styles.thresholdChipRow}>
+                            {USAGE_THRESHOLD_OPTIONS.map((pct) => {
+                              const current = Array.isArray(settings.usageLimitThresholds)
+                                ? settings.usageLimitThresholds
+                                : [];
+                              const active = current.includes(pct);
+                              return (
+                                <button
+                                  key={pct}
+                                  type="button"
+                                  className={`${styles.thresholdChip} ${
+                                    active ? styles.thresholdChipActive : ''
+                                  }`}
+                                  aria-pressed={active}
+                                  onClick={() => {
+                                    const next = active
+                                      ? current.filter((v) => v !== pct)
+                                      : [...current, pct].sort((a, b) => b - a);
+                                    updateSetting('usageLimitThresholds', next);
+                                  }}
+                                >
+                                  {pct}% left
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
                     </div>
-                    <div className={styles.dangerCard}>
-                      <div className={styles.dangerInfo}>
-                        <span className={styles.dangerLabel}>Delete account</span>
-                        <span className={styles.dangerDesc}>
-                          Permanently delete your account and all associated data.
-                        </span>
-                      </div>
-                      <button className={styles.dangerBtn}>Delete account</button>
+                  </section>
+                )}
+
+                {/* ═══ DATA & PRIVACY ═══ */}
+                {activeSection === 'data' && (
+                  <section className={styles.section}>
+                    <div className={styles.sectionHeader}>
+                      <h2 className={styles.sectionTitle}>Data & privacy</h2>
+                      <p className={styles.sectionDesc}>
+                        Control how your data is stored and used.
+                      </p>
                     </div>
-                  </div>
-                </section>
-              )}
+
+                    <div className={styles.fieldGroup}>
+                      <div className={styles.toggleRow}>
+                        <div className={styles.toggleInfo}>
+                          <span className={styles.toggleLabel}>Location metadata</span>
+                          <span className={styles.toggleDesc}>
+                            Allow Araviel to use coarse location data (city/region) to improve
+                            responses.
+                          </span>
+                        </div>
+                        <ToggleSwitch
+                          value={settings.locationMetadata}
+                          onChange={(v) => updateSetting('locationMetadata', v)}
+                        />
+                      </div>
+                    </div>
+
+                    <div className={styles.fieldGroup}>
+                      <label className={styles.fieldLabel}>Shared chats</label>
+                      <p className={styles.fieldLabelDesc}>
+                        Links to conversations you&rsquo;ve shared publicly. Manage every active
+                        link from the Shared tab in Conversations.
+                      </p>
+                      <SharedChatsStub active={activeSection === 'data'} />
+                    </div>
+
+                    <div className={styles.dangerZone}>
+                      <h3 className={styles.dangerTitle}>Danger zone</h3>
+                      <div className={styles.dangerCard}>
+                        <div className={styles.dangerInfo}>
+                          <span className={styles.dangerLabel}>Delete all conversations</span>
+                          <span className={styles.dangerDesc}>
+                            Move every conversation to Recently deleted. You have 15 days to restore
+                            them before they&rsquo;re permanently removed.
+                          </span>
+                        </div>
+                        <button
+                          className={styles.dangerBtn}
+                          onClick={() => setShowDeleteAllConfirm(true)}
+                          disabled={deletingAll}
+                        >
+                          {deletingAll ? 'Deleting…' : 'Delete all'}
+                        </button>
+                      </div>
+                      <div className={styles.dangerCard}>
+                        <div className={styles.dangerInfo}>
+                          <span className={styles.dangerLabel}>Delete account</span>
+                          <span className={styles.dangerDesc}>
+                            Permanently delete your account and all associated data.
+                          </span>
+                        </div>
+                        <button className={styles.dangerBtn}>Delete account</button>
+                      </div>
+                    </div>
+                  </section>
+                )}
+              </div>
             </div>
-          </div>
+          </RequireAuth>
         </div>
       </div>
 

--- a/src/components/SubscriptionView/SubscriptionView.jsx
+++ b/src/components/SubscriptionView/SubscriptionView.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { selectIsAuthenticated } from '../../store/slices/authSlice';
 import useScrollRestoration from '../../hooks/useScrollRestoration';
-import GuestGate from '../GuestGate/GuestGate';
+import RequireAuth from '../RequireAuth';
 import SubscriptionSummary from './SubscriptionSummary';
 import styles from './SubscriptionView.module.css';
 
@@ -19,54 +19,50 @@ export default function SubscriptionView() {
   const pageRef = useRef(null);
   useScrollRestoration(pageRef);
 
-  if (!isAuthenticated) {
-    return (
-      <div ref={pageRef} className={styles.container}>
-        <div className={styles.inner}>
-          <GuestGate
-            title="View your subscription"
-            description="Sign in to manage your plan, track usage, and view billing details."
-            actionLabel="Sign in to continue"
-          />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div ref={pageRef} className={styles.container}>
       <div className={styles.inner}>
-        <div className={styles.header}>
-          <button
-            className={styles.backBtn}
-            onClick={() => navigate('/')}
-            aria-label="Back to chat"
-          >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <polyline points="15 18 9 12 15 6" />
-            </svg>
-            Back
-          </button>
-        </div>
+        {isAuthenticated && (
+          <>
+            <div className={styles.header}>
+              <button
+                className={styles.backBtn}
+                onClick={() => navigate('/')}
+                aria-label="Back to chat"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="15 18 9 12 15 6" />
+                </svg>
+                Back
+              </button>
+            </div>
 
-        <div className={styles.hero}>
-          <h1 className={styles.heroTitle}>My Subscription</h1>
-          <p className={styles.heroSubtitle}>
-            Manage your plan, monitor credit usage, and access billing.
-          </p>
-        </div>
+            <div className={styles.hero}>
+              <h1 className={styles.heroTitle}>My Subscription</h1>
+              <p className={styles.heroSubtitle}>
+                Manage your plan, monitor credit usage, and access billing.
+              </p>
+            </div>
+          </>
+        )}
 
-        <SubscriptionSummary />
+        <RequireAuth
+          title="View your subscription"
+          description="Sign in to manage your plan, track usage, and view billing details."
+          actionLabel="Sign in to continue"
+        >
+          <SubscriptionSummary />
+        </RequireAuth>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Four views — Conversations, Projects, Settings, Subscription — each duplicated the same `if (!isAuthenticated) return <chrome + GuestGate>` pattern. Each guest branch re-rendered the same page chrome (page wrapper, header, title) and called `GuestGate` with a custom title/description/icon.

Add a small `<RequireAuth>` component that owns the auth check + GuestGate render. Each view now renders its chrome **once**, gates view-only header actions behind `{isAuthenticated && ...}`, and wraps the data content in `<RequireAuth>`.

## What it looks like in a view

```jsx
// Before
if (!isAuthenticated) {
  return (
    <div className={styles.page}>
      <div className={styles.inner}>
        <div className={styles.header}>
          <h1>Conversations</h1>
        </div>
        <GuestGate icon={...} title="..." description="..." actionLabel="..." />
      </div>
    </div>
  );
}
return (
  <div className={styles.page}>
    <div className={styles.inner}>
      <div className={styles.header}>
        <h1>Conversations</h1>
        <div className={styles.headerActions}>...</div>
      </div>
      <SectionSwitcher /><Search /><Tabs /><List />
    </div>
  </div>
);

// After
return (
  <div className={styles.page}>
    <div className={styles.inner}>
      <div className={styles.header}>
        <h1>Conversations</h1>
        {isAuthenticated && <div className={styles.headerActions}>...</div>}
      </div>
      <RequireAuth icon={...} title="..." description="..." actionLabel="...">
        <SectionSwitcher /><Search /><Tabs /><List />
      </RequireAuth>
    </div>
  </div>
);
```

## The wrapper

```jsx
// src/components/RequireAuth/RequireAuth.jsx
export default function RequireAuth({ children, icon, title, description, actionLabel }) {
  const isAuthenticated = useSelector(selectIsAuthenticated);
  if (isAuthenticated) return children;
  return (
    <GuestGate icon={icon} title={title} description={description} actionLabel={actionLabel} />
  );
}
```

30 lines including JSDoc. No new patterns, no router-level changes.

## Behavior preserved

- Guests see the same chrome + GuestGate as before
- Authed users see the same view content
- `SettingsView`'s loading early return is preserved but now gated on `isAuthenticated && loading` so guests don't briefly flash a spinner before the GuestGate appears
- `ProjectsView`'s workspace branch (`if (selectedProject)`) is untouched — only the list-mode branch was refactored
- All data-loading effects already gated on `isAuthenticated` internally — no risk of guest API calls
- No CSS classes added, removed, or renamed

## Files

- **+** `src/components/RequireAuth/RequireAuth.jsx` (24 lines)
- **+** `src/components/RequireAuth/index.js` (1 line)
- `src/components/ConversationsView/ConversationsView.jsx`
- `src/components/ProjectsView/ProjectsView.jsx`
- `src/components/SettingsView/SettingsView.jsx`
- `src/components/SubscriptionView/SubscriptionView.jsx`

Net delta after the linter's reformatting: ~3 net lines added, but the actual hand-authored change removes ~40 lines of duplicated chrome across the four views.

## Test plan

- [ ] Each route in a fresh session shows the GuestGate with the same copy as before
- [ ] Each route after signing in shows the full authed view with the same chrome
- [ ] `/settings` as a guest renders the GuestGate without spinner-flashing
- [ ] `/projects/:id` workspace mode still works for authed users (no regression to the detail view)
- [ ] Header actions (Import, New conversation, New project, Save changes) only show when signed in
- [ ] Build, lint, tests — 603 pass, 1 pre-existing unrelated authSlice failure

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ha5ZuxPmpaGzzHH52fq6B)_