### PR TITLE
fix(code-panel): trim trailing whitespace so the gutter and pre agree

### DIFF
--- a/src/components/MessageList/MessageList.jsx
+++ b/src/components/MessageList/MessageList.jsx
@@ -828,7 +828,11 @@ function extractPanelBlocks(text) {
   let m;
   while ((m = codeBlockRegex.exec(text)) !== null) {
     const lang = m[1] || '';
-    const code = m[2];
+    // Strip trailing whitespace so the line-number gutter and the rendered
+    // <pre> agree on row count — otherwise the regex's captured trailing \n
+    // before the closing fence (and any blank lines the model padded with)
+    // become phantom empty rows you can scroll past in the side panel.
+    const code = m[2].replace(/\s+$/, '');
 
     if (isArtifactCandidate(lang, code)) {
       blocks.push({


### PR DESCRIPTION
## Summary
- The code side panel let you scroll past the last line into empty space because the fenced-code regex in `extractPanelBlocks` captures the trailing `\n` before the closing ``` (plus any blank lines the model padded the block with).
- `block.code.split('\n').length` therefore over-counts by one or more vs. the rows the `<pre>` actually renders. The gutter emits one `<span>` per split entry, the codeArea is a flex row that stretches the shorter child to match the taller one, and the leftover height at the bottom became scrollable empty space (also leaking into the "N lines" footer).
- Stripping trailing whitespace at the extraction point keeps the footer line count, gutter spans, and `<pre>` rows in sync — internal blank lines in the snippet are preserved.

## Test plan
- [ ] Open a long fenced HTML/code block in the chat, click into the side panel, scroll to the last line — confirm scroll stops at the final visible row, no empty space below.
- [ ] Verify the footer "N lines" matches the highest line number in the gutter.
- [ ] Verify intentional blank lines inside a code block are still rendered (only trailing whitespace is trimmed).
- [ ] Verify HTML artifact blocks still preview correctly in the visual view.

https://claude.ai/code/session_014km6gDac5pfEN54WqTVJGk

---
_Generated by [Claude Code](https://claude.ai/code/session_014km6gDac5pfEN54WqTVJGk)_